### PR TITLE
fix: Navigation visual bugs

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -47,13 +47,16 @@ $navigation-height: 3rem;
     }
   }
 
-  .p-navigation__item--dropdown-toggle#canonical-login {
-    position: relative;
-  }
+  // Fix account dropdown position on larger screens
+  @media (min-width: $breakpoint-navigation-threshold) {
+    .p-navigation__item--dropdown-toggle#canonical-login {
+      position: relative;
+    }
 
-  .p-navigation__dropdown#canonical-login-content-mobile {
-    position: absolute;
-    right: 0;
+    .p-navigation__dropdown#canonical-login-content-mobile {
+      position: absolute;
+      right: 0;
+    }
   }
 
   .p-navigation--sliding {


### PR DESCRIPTION
## Done

- Fix 'Account' dropdown going out of viewport
- Flyby: Fix first item overlapping the top navigation bar (mobile)

## QA

- Check out this branch locally
- Login, open the 'Account' dropdown
- See it doesn't go off screen (it's only on some screen sizes)
- Go to mobile view, hover the first dropdown item (products)
- See it no longer overlaps the navigation

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31830

## Screenshots

**Before**:
<img width="1417" height="469" alt="image" src="https://github.com/user-attachments/assets/a9fe8fa9-f48e-472f-8c09-42571d40db88" />
**After**:
<img width="1417" height="469" alt="image" src="https://github.com/user-attachments/assets/fe5f9a49-8620-4082-ba47-fe27597375f7" />

**Before**:
<img width="1417" height="469" alt="image" src="https://github.com/user-attachments/assets/869e9901-bfeb-4592-abe6-8ee417dea0f3" />
**After**:
<img width="1417" height="469" alt="image" src="https://github.com/user-attachments/assets/1055bd20-9cc3-4f5f-9808-bad1400670cd" />


