### PR TITLE
feat: update link to chisel docs on the containers page

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -346,7 +346,7 @@
         <div class="p-cta-block">
           <a href="https://documentation.ubuntu.com/rockcraft/en/latest/"
              class="p-button">Learn more about Rockcraft</a>
-          <a href="https://documentation.ubuntu.com/rockcraft/en/latest/explanation/chisel/"
+          <a href="https://documentation.ubuntu.com/chisel/en/latest/"
              class="p-button">Learn more about Chisel</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Update the link to the Chisel docs.

## QA

- Go to [/containers](https://ubuntu-com-15882.demos.haus/containers).
- Scroll down to "Canonical’s container toolkit"
- Check that the "Learn more about Chisel" link takes you to https://documentation.ubuntu.com/chisel/en/latest/

## Issue / Card

https://warthogs.atlassian.net/browse/WD-31978

[Copy doc](https://docs.google.com/document/d/1OtyfNeA--EJgpgvDzqcbJ8jqa6d9H5H9xyxHNxcKXvc/edit?tab=t.0)