### PR TITLE
chore: bump cookie-policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@axe-core/playwright": "^4.8.5",
-    "@canonical/cookie-policy": "^3.7.4",
+    "@canonical/cookie-policy": "^3.8.3",
     "@canonical/global-nav": "3.8.0",
     "@canonical/latest-news": "2.1.1",
     "@canonical/react-components": "^0.60.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.7.4":
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.7.5.tgz#29dfbc1f6d42dbdcdf6125330083a2ccde7d93d0"
-  integrity sha512-Fi0a8vk9q7L4Em4TiMTYDYnGGnHBfpOwOv7WGWbA/apT6whl33V6HFTTcN+LcY5UnoSNBTZmQn4YBwqLOVdZyQ==
+"@canonical/cookie-policy@^3.8.3":
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.3.tgz#f8edf020c1737c263e332b97ff79c0eb8a98eadc"
+  integrity sha512-tY+0t3prlmZqrOnYFVhbH4tKf4ylCBILcWRupJdoNvH/DJCsROtfAEDEPgZlH6F+YGimdbfa4zraqsKx4Vt+Rw==
 
 "@canonical/global-nav@3.8.0":
   version "3.8.0"


### PR DESCRIPTION
## Done

- Bump cookie policy to make sure that cookie banner stays persistent when no cookies are selected

## QA

- Go to [demo](https://ubuntu-com-15883.demos.haus/)
- Don't select any cookies, redirect to another page and see that the banner persists

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
