### PR TITLE
chore: Change image on what are containers page

### DIFF
--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -175,7 +175,7 @@
     <div class="u-fixed-width">
       <div class="p-media-container p-strip is-shallow u-darker-background col-3 u-align--center u-vertically-center">
         {{ image(url="https://assets.ubuntu.com/v1/9c56d569-diagram_machine_virtualization_vs_containers.svg",
-                alt="Diagram comparing containers and virtual machines architecture",
+                alt="",
                 width="2433",
                 height="1461",
                 hi_def=True,


### PR DESCRIPTION
## Done
Replaces an image on the /containers/what-are-containers page

## QA
- Go to https://ubuntu-com-15887.demos.haus/containers/what-are-containers
- Check that the text in the image underneath the "Containers vs. virtual machines" heading reads as "Machine Virtualization" rather than "Machine Virtualisation" (Compare to [production](https://ubuntu.com/containers/what-are-containers))