### PR TITLE
WD-31980 Add Chiselled Ubuntu to the Dev tools Products navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -462,6 +462,9 @@ products:
             - title: Snap Store
               description: App store for Linux
               url: https://snapcraft.io
+            - title: Chiseled Ubuntu
+              description: Ultra-small containerization
+              url: /containers/chiseled
             - title: Juju
               description: Orchestrator engine for operators
               url: https://juju.is/


### PR DESCRIPTION
## Done

- Add Chiselled Ubuntu to the Dev tools Product navigation

## QA

- Open the demo
- Open the Products navigation menu
- Click on Developer tools
- See that Chiselled Ubuntu is present
- Click it and check it works

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31980