### PR TITLE
WD-32257 - Copy update for /summit

### DIFF
--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -44,7 +44,7 @@
           <iframe width="560" 
                   height="315" 
                   class="u-embedded-media__element"
-                  src="https://www.youtube.com/embed/gKMz7FVPJjo?si=2PPT29IJJ6KV59Ja" 
+                  src="https://www.youtube.com/embed/gKMz7FVPJjo?si=2PPT29IJJ6KV59Ja&autoplay=1&mute=1&loop=1" 
                   title="Ubuntu Summit 25.10 Highlights" 
                   frameborder="0" 
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 


### PR DESCRIPTION
## Done

- Copy update: https://docs.google.com/document/d/1lj-xPVQjWqo2J_eZ-3ldKhJHj6RQ0Cwmk_Mr4QA4UTY

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/summit
    - Be sure to test on mobile, tablet and desktop screen sizes

Alternatively go to [Demos](https://ubuntu-com-15907.demos.haus/summit).

## Issue / Card

Fixes [WD-32257](https://warthogs.atlassian.net/browse/WD-32257)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-32257]: https://warthogs.atlassian.net/browse/WD-32257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ