### PR TITLE
copy: add sdn extensive options and remove portainer image

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -401,16 +401,6 @@
                 }}
               </div>
               <div class="p-logo-section__item">
-                {{ image(url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
-                                alt="Portainer.io",
-                                width="144",
-                                height="96",
-                                hi_def=True,
-                                loading="lazy",
-                                attrs={"class": "p-logo-section__logo"}) | safe
-                }}
-              </div>
-              <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/19c3c265-spectrocloud-logo.png",
                                 alt="Spectro Cloud",
                                 width="87",
@@ -548,7 +538,7 @@
                     <a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>, <a href="https://maas.io/">Bare Metal</a>
                   </li>
                   <li class="p-list__item is-ticked js-discoverer-item">Storage and SDN basic options</li>
-                  <li class="p-list__item is-ticked u-hide discoverer-pro-item">Storage and SDN extensive options</li>
+                  <li class="p-list__item is-ticked u-hide js-discoverer-pro-item">Storage and SDN extensive options</li>
                   <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
                   <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
                   <li class="p-list__item is-ticked">Security essentials</li>


### PR DESCRIPTION
## Done

- Copy update changes on `/kubernetes` page based on these copydocs requests: 
    - [Request 1](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit?disco=AAABwV7MFck)
    - [Request 2](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit?disco=AAABwV7MFcg)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the copy update changes have been made

## Issue / Card
[WD-32380](https://warthogs.atlassian.net/browse/WD-32380)

## Screenshots

<img width="416" height="759" alt="image" src="https://github.com/user-attachments/assets/4f9ab214-8827-4380-80a5-8937e106662d" />
<img width="1495" height="1068" alt="image" src="https://github.com/user-attachments/assets/16d9b35f-c3f6-4ed9-9964-125987b09e77" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-32380]: https://warthogs.atlassian.net/browse/WD-32380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ