### PR TITLE
chore: Add new tab to partner-built page

### DIFF
--- a/templates/download/risc-v/milk-v-titan.html
+++ b/templates/download/risc-v/milk-v-titan.html
@@ -1,0 +1,32 @@
+<div tabindex="0" role="tabpanel" id="milk-v-titan-tab" aria-labelledby="milk-v-titan"
+  aria-hidden="true">
+  <div class="grid-row p-section--shallow">
+    <div class="grid-col-2 grid-col-medium-1">
+      <h3 class="u-hide--small p-heading--2">Milk-V Titan</h3>
+    </div>
+    <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
+      <div class="p-image-container is-highlighted">
+        {{ image(url="https://assets.ubuntu.com/v1/8748959d-milk_v_titan.png",
+          alt="",
+          width="1727",
+          height="1263",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    </div>
+  </div>
+  <div class="grid-row">
+    <hr class="p-rule--muted" />
+    <div class="grid-col-2 grid-col-medium-1">
+      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h4>
+    </div>
+    <div class="grid-col-4 grid-col-medium-2">
+      <p>Please follow Milk-V’s instructions when installing the Milk-V Titan image.</p>
+      <div class="p-cta-block">
+        <a href="https://github.com/milkv-titan" class="p-button">Download Milk-V Titan image</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/download/risc-v/partner-built.html
+++ b/templates/download/risc-v/partner-built.html
@@ -86,6 +86,13 @@
           </li>
           <li>
             <button class="p-tabs__item"
+                    id="milk-v-titan"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="milk-v-titan-tab">Milk-V Titan</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
                     id="sifive-hifive-premier-p550"
                     role="tab"
                     aria-selected="false"
@@ -97,6 +104,7 @@
             <option value="deepcomputing-fml13v01-tab">DeepComputing FML13V01</option>
             <option value="eswin-ebc7700-sbc-tab">ESWIN EBC7700 SBC</option>
             <option value="eswin-ebc7702-mini-dtx-mainboard-tab">ESWIN EBC7702 Mini-DTX Mainboard</option>
+            <option value="milk-v-titan-tab">Milk-V Titan</option>
             <option value="sifive-hifive-premier-p550-tab">SiFive HiFive Premier P550</option>
           </select>
         </form>
@@ -105,6 +113,7 @@
         {% include "download/risc-v/deepcomputing-fml13v01-partner.html" %}
         {% include "download/risc-v/eswin-ebc7700-sbc.html" %}
         {% include "download/risc-v/eswin-ebc7702-mini-dtx-mainboard.html" %}
+        {% include "download/risc-v/milk-v-titan.html" %}
         {% include "download/risc-v/sifive-hifive-premier-p550.html" %}
       </div>
     </div>


### PR DESCRIPTION
## Done

Added Milk-V Titan tab to /download/risc-v/partner-built

## QA

- Go to https://ubuntu-com-15918.demos.haus/download/risc-v/partner-built
- Scroll down to the "Choose a board" section
- Check that there is a tab for Milk-V Titan and that it matches [the copy doc](https://docs.google.com/document/d/11AUwjePeOGvT6H8xM4QYixzmUTRpG_uKPa_pSzR5ucs/edit?tab=t.8soe4ta3y51a)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-32374
