### PR TITLE
Fix incorrect openstack links

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -37,7 +37,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a class="p-button--positive" href="/openstack">Discover Canonical OpenStack</a>
+      <a class="p-button--positive" href="https://canonical.com/openstack">Discover Canonical OpenStack</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-hero-video-container u-embedded-media">
@@ -401,7 +401,7 @@
       <hr class="p-rule" />
       <ol class="p-list">
         <li id="footnote-1" class="p-list__item">
-          <sup>1</sup> Source: <a href="https://www.stackalytics.com/">stackalytics.com</a>.
+          <sup>1</sup> Source: <a href="https://www.stackalytics.io">stackalytics.io</a>.
           <a class="u-off-screen"
              href="#footnote-1-link"
              aria-label="Back to content">↩</a>


### PR DESCRIPTION
## Done

Fixes incorrect links in the "What is openstack" page as requested in [copydoc](https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to the [what is openstack page](https://ubuntu-com-15920.demos.haus/openstack/what-is-openstack)
- Verify that the "discover canonical openstack" link goes to https://canonical.com/openstack
- Verify that the stackalytics source points to https://www.stackalytics.io

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-32437

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
