### PR TITLE
Update releases.yaml

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -9,7 +9,7 @@ latest:
   eol: "July 2026"
   past_eol_date: false
   release_notes_url: "https://discourse.ubuntu.com/t/questing-quokka-release-notes/59220"
-  iso_download_size: "5.8GB"
+  iso_download_size: "5.3GB"
   arm_iso_download_size: "3.6GB"
   server_iso_size: "1.9GB"
   raspi_desktop_iso_size: "2.9GB"


### PR DESCRIPTION
changed size from 5.8 to 5.3 GB (actual download size).
Hoping this will fix the appearance on https://ubuntu.com/download/desktop, (issue #15930) otherwise please close this request

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #15930

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
