### PR TITLE
fix: Ubuntu Mono font not found 404

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -74,7 +74,7 @@
       <link rel="preload"
             as="font"
             type="font/woff2"
-            href="https://assets.ubuntu.com/v1/0df3f53f-UbuntuMono%5Bwght%5D-latin-v0.896a.woff2"
+            href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
             crossorigin />
       
       {%- block head_extra %}{% endblock %}


### PR DESCRIPTION
## Done

- Fixed link for font which is returning 404 [here](https://github.com/canonical/ubuntu.com/actions/runs/20891502995/job/60023260776#step:4:15)

## QA

- Verify the updated asset exists and loads fine
- Visit [demo](https://ubuntu-com-15940.demos.haus/) and verify it looks like ubuntu.com

## Issue
Fixes [WD-32083](https://warthogs.atlassian.net/browse/WD-32803)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-32083]: https://warthogs.atlassian.net/browse/WD-32083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ