### PR TITLE
chore: bump blog version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==2.6.1
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==6.8.2
+canonicalwebteam.blog==6.8.3
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0


### PR DESCRIPTION
## Done

- Bump blog module version

## QA

- Visit [demo](https://ubuntu-com-15944.demos.haus/blog/tag/performance)
- Click at first article "Maximizing CPU efficiency and energy savings with IntelⓇ QuickAssist Technology on Ubuntu 24.04"
- Make sure it opens up
- Open some other blog articles and verify they work as expected too

## Issue / Card

Fixes [WD-32593](https://warthogs.atlassian.net/browse/WD-32593)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-32593]: https://warthogs.atlassian.net/browse/WD-32593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ