### PR TITLE
chore(WD-32668): Remove animation for nojs fallback takeover

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -34,7 +34,7 @@
     </noscript>
 
     <section id="test-takeover" class="p-section--hero" hidden>
-      <div class="row p-takeover-animation" id="test-takeover-animaition">
+      <div class="row p-takeover-animation" id="test-takeover-animation">
         <div class="row--50-50 p-section--shallow">
           <div class="col">
             <h1 class="u-no-margin--bottom" id="test-takeover-title">A CTO's guide to real-time Linux</h1>
@@ -66,7 +66,7 @@
 
     <!-- Default Takeover: Download the latest Ubuntu -->
     <section data-lang="all" id="takeover" class="p-section--hero">
-      <div class="row p-takeover-animation" id="takeover-animaition">
+      <div class="row p-takeover-animation" id="takeover-animation">
         <div class="col-6">
           <div class="p-section--shallow">
             <h1 id="takeover-title" class="u-no-margin--bottom">Ubuntu 24.04 LTS Noble Numbat is available for download</h1>
@@ -1439,9 +1439,9 @@
       var baseTakeover = document.getElementById('takeover');
       let takeoverAnimation;
       if (getCookie()?.[2] === 'variant') {
-        takeoverAnimation = document.getElementById("test-takeover-animaition");
+        takeoverAnimation = document.getElementById("test-takeover-animation");
       } else {
-        takeoverAnimation = document.getElementById("takeover-animaition");
+        takeoverAnimation = document.getElementById("takeover-animation");
       }
 
       if (window.localStorage && baseTakeover) {


### PR DESCRIPTION
## Done

- Added noscript for style override to remove animation  for fallback takeover when JS is disabled
- Drive-by: Fixed spelling mistakes

## QA

- Check out the [demo](https://ubuntu-com-15945.demos.haus/)
- Open devtools, disable Javascript and refresh the page
- Verify no animation is present on the takeover and that it loads instantly

## Issue / Card

Fixes [WD-32668](https://warthogs.atlassian.net/browse/WD-32668)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-32668]: https://warthogs.atlassian.net/browse/WD-32668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ