### PR TITLE
fix(linux-patch-management-with-pro): update long term support from 12 to 15 years

### DIFF
--- a/templates/pro/linux-patch-management-with-pro/index.html
+++ b/templates/pro/linux-patch-management-with-pro/index.html
@@ -212,7 +212,7 @@
         </div>
         <div class="col">
           <p>
-            Ubuntu Pro secures your entire open source stack with enterprise-grade CVE patching, compliance tooling, and 12 years of long term support - 10 of Expanded Security Maintenance (ESM) and 5 additional years of “Legacy” add-on.
+            Ubuntu Pro secures your entire open source stack with enterprise-grade CVE patching, compliance tooling, and 15 years of long term support - 10 of Expanded Security Maintenance (ESM) and 5 additional years of “Legacy” add-on.
           </p>
           <div class="p-cta-block">
             <a href="/blog/how-can-you-personalize-your-ubuntu-pro-subscription">Discover the tools available with Ubuntu Pro and how to tailor your subscription &rsaquo; </a>


### PR DESCRIPTION
## Done

- in linux-patch-management-with-pro > index.html: replace `12` by `15`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to Ubuntu pro > CVE coverage > scroll down to `Expanding the scope of open source support` section.
- Make sure it reads: `Ubuntu Pro secures your entire open source stack with enterprise-grade CVE patching, compliance tooling, and 15 years of long term support - 10 of Expanded Security Maintenance (ESM) and 5 additional years of “Legacy” add-on.`

## Screenshots

<img width="1850" height="1108" alt="image" src="https://github.com/user-attachments/assets/ce76e3dc-4f0b-4789-902b-47daec5e212f" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
