### PR TITLE
fix(WD-32906): Service terms link 404

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -732,14 +732,14 @@ legal/managed-services/service-description?: "https://canonical.com/legal/ubuntu
 legal/online-accounts/?: "https://canonical.com/legal/online-account-terms"
 legal/privacy-policy/?: "https://canonical.com/legal/data-privacy"
 legal/privacy-policy/third-parties/?: "https://canonical.com/legal/data-privacy"
-legal/service-terms(?P<page>.*)/?: "https://canonical.com/legal/ubuntu-advantage-service-terms{page}"
+legal/service-terms(?P<page>.*)/?: "https://canonical.com/legal/ubuntu-pro-service-terms{page}"
 legal/terms-and-policies/privacy-policy?: "https://canonical.com/legal/data-privacy"
 legal/ubuntu-advantage/?: "https://canonical.com/legal/ubuntu-pro"
 legal/ubuntu-advantage/service-description: "https://canonical.com/legal/ubuntu-pro-description"
 legal/ubuntu-advantage/service-description-ja/2017-06-27: "https://canonical.com/legal/ubuntu-pro-description/ja"
 legal/ubuntu-advantage/service-description-ja/2017-02-09: "https://canonical.com/legal/ubuntu-pro-description/ja"
 legal/ubuntu-advantage/ua-terms-ja/?: "https://canonical.com/legal/ubuntu-pro-service-terms/ja"
-legal/short-terms(?P<page>.*)/?: "https://canonical.com/legal/ubuntu-advantage-service-terms/{page}"
+legal/short-terms(?P<page>.*)/?: "https://canonical.com/legal/ubuntu-pro-service-terms{page}"
 legal/short-terms-ja/?: "https://canonical.com/legal/ubuntu-pro-description/ja"
 legal/ubuntu-advantage/service-description/?: /legal/ubuntu-pro-description
 legal/ubuntu-advantage-service-description: /legal/ubuntu-pro-description
@@ -1126,7 +1126,7 @@ blog/kubernetes-1-21-available-from-canonical..*: /blog/kubernetes-1-21-availabl
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 blog/howto-host-your-own-snap-store: /internet-of-things/appstore
-blog/charmed-aether-sd-core-beta-release-announcement: https://canonical.com/solutions/telco 
+blog/charmed-aether-sd-core-beta-release-announcement: https://canonical.com/solutions/telco
 
 # Move snappy topic to snapcraft
 blog/topics/snappy/?: /blog/topics/snapcraft

--- a/static/js/src/advantage/subscribe/checkout/components/ConfirmAndBuy/ConfirmAndBuy.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/ConfirmAndBuy/ConfirmAndBuy.tsx
@@ -146,7 +146,7 @@ const getLabels = (product: Product, action: Action) => {
         <>
           I agree to the{" "}
           <a
-            href="https://canonical.com/legal/ubuntu-advantage-service-terms"
+            href="https://canonical.com/legal/ubuntu-pro-service-terms"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -218,7 +218,7 @@ const getLabels = (product: Product, action: Action) => {
       <>
         I agree to the{" "}
         <a
-          href="https://canonical.com/legal/ubuntu-advantage-service-terms"
+          href="https://canonical.com/legal/ubuntu-pro-service-terms"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -260,7 +260,7 @@
             <form>
               <label class="p-checkbox">
                 <input class="p-checkbox__input" type="checkbox" aria-labelledby="renewal-terms" checked="" class="js-terms">
-                <span class="p-checkbox__label u-float-left" id="renewal-terms">I agree to the <a href="https://canonical.com/legal/ubuntu-advantage-service-terms" target="_blank" rel="noopener noreferrer">Ubuntu Advantage service terms</a></span>
+                <span class="p-checkbox__label u-float-left" id="renewal-terms">I agree to the <a href="https://canonical.com/legal/ubuntu-pro-service-terms" target="_blank" rel="noopener noreferrer">Ubuntu Advantage service terms</a></span>
               </label>
             </form>
           </div>


### PR DESCRIPTION
## Done

- Fixed service terms link resulting in 404

## QA

- Check out the [demo](https://ubuntu-com-15957.demos.haus/legal/service-terms)
- Verify it redirects to https://canonical.com/legal/ubuntu-pro-service-terms

## Issue / Card

Fixes [WD-32906](https://warthogs.atlassian.net/browse/WD-32906)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-32906]: https://warthogs.atlassian.net/browse/WD-32906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ