### PR TITLE
fix(pagination): prevent duplication of active page in navigation

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -115,7 +115,7 @@
                 {% set ns.outer_title = page.navlink_text %}
               {% endif %}
               {{- loop(page.children|reverse) }}
-              {% if page.is_active and not ns.found_active %}
+              {% if page.is_active and not ns.found_active and page.path in request.path %}
                 {% set ns.found_active = true %}
                 {% set ns.use_next = true %}
               {% elif ns.use_next and not page.hidden and page.navlink_text %}
@@ -137,7 +137,7 @@
             {% set ns.found_active = false %}
 
             {%- for page in nav_items recursive %}
-              {% if page.is_active and not ns.found_active %}
+              {% if page.is_active and not ns.found_active and page.path in request.path %}
                 {% set ns.found_active = true %}
                 {% set ns.use_next = true %}
               {% elif ns.use_next and not page.hidden and page.navlink_text %}


### PR DESCRIPTION
Documentation pagination displayed duplicate "Previous" and "Next" buttons when multiple navigation entries pointed to the same Discourse topic URL. 

## Done
Added a found_active flag to track the first active page encountered during tree traversal. 
The pagination logic now only processes the first active page, ignoring subsequent active pages to prevent duplicate links.


## QA

- Check out the demo link [/disa-stig/installation](https://ubuntu-com-15973.demos.haus/security/certifications/docs/2204/disa-stig/installation)
  - Compare that with production https://ubuntu.com/security/certifications/docs/2204/disa-stig/installation
- Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #
https://github.com/canonical/ubuntu.com/issues/12913

## Screenshots
<img width="2148" height="452" alt="image" src="https://github.com/user-attachments/assets/f577e8ad-3a50-43af-85af-3c97d7449f99" />

### AFTER
<img width="2308" height="458" alt="image" src="https://github.com/user-attachments/assets/7f5d29d0-0131-409d-bdbf-17fd5b4e3ad9" />

### After


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
