### PR TITLE
update: security/disclosure-policy

### DIFF
--- a/templates/security/disclosure-policy.html
+++ b/templates/security/disclosure-policy.html
@@ -97,9 +97,9 @@
                 <p class="p-stepped-list__content">
                   You may also send email to <a href="mailto:security@ubuntu.com">security@ubuntu.com</a>. Email may optionally be encrypted to:
                 </p>
-                <pre>OpenPGP key 4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0:
+                <pre>OpenPGP key 75E1 451E 529B 51E1 9006 CD5E 91EC 85F1 DA9A 776D:
 https://keyserver.ubuntu.com/pks/lookup?
-op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0</pre>
+op=get&search=0x75e1451e529b51e19006cd5e91ec85f1da9a776d</pre>
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Done

- Made the changes in this copy update: https://warthogs.atlassian.net/browse/WD-33116 ("Updated the [security@ubuntu.com](mailto:security@ubuntu.com) PGP fingerprint referenced in the ‘How to report an issue to us’ section.")
- Copy doc: https://docs.google.com/document/d/1WdamniXOHemuPzl6vESYD9StPgh4-PepbqdVHYrzbuI/edit?tab=t.0

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
