### PR TITLE
chore(WD-32976): updated illustrations on /containers/docs

### DIFF
--- a/templates/containers/docs.html
+++ b/templates/containers/docs.html
@@ -123,10 +123,10 @@ Canonical containers, also known as “rocks”, are a new generation of secure,
 <div class="p-section">
   <div class="grid-row--25-75-on-large">
     <hr class="p-rule" />
-    <div class="grid-col-2">
+    <div class="grid-col">
       <h2>Use a rock</h2>
     </div>
-    <div class="grid-col-6 grid-col-start-large-3">
+    <div class="grid-col">
       <div class="p-section--shallow">
         <img 
           src="https://assets.ubuntu.com/v1/24d60b8b-use_a_rock.gif" 


### PR DESCRIPTION
## Done

- made the "use a rock" gif more visible
- uploaded and used new images for the build steps
- 
## QA

- Check out this feature branch
- Run the site using the command `task`
- View the site locally in your web browser at: http://0.0.0.0:8001/containers/docs
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-32976

## Screenshots

### Enlarged "Use a rock gif"

<img width="1514" height="675" alt="image" src="https://github.com/user-attachments/assets/19762cf0-1df9-4a6e-8f4e-3fbdb9f68b92" />

### New images for the steps

<img width="1551" height="891" alt="image" src="https://github.com/user-attachments/assets/11920474-f4c0-4fbe-bfbc-00fca25e3a94" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
