### PR TITLE
fix: marketo test fails for empty form fields

### DIFF
--- a/templates/advantage/subscribe/form-data.json
+++ b/templates/advantage/subscribe/form-data.json
@@ -259,7 +259,7 @@
               "label": "NIS2"
             },
             {
-              "type":"checkbox",
+              "type": "checkbox",
               "id": "cyber-essentials",
               "value": "Cyber Essentials",
               "label": "Cyber Essentials"

--- a/templates/contact-us/form/form-data.json
+++ b/templates/contact-us/form/form-data.json
@@ -283,7 +283,7 @@
               "label": "NIS2"
             },
             {
-              "type":"checkbox",
+              "type": "checkbox",
               "id": "cyber-essentials",
               "value": "Cyber Essentials",
               "label": "Cyber Essentials"

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -42,7 +42,13 @@ class TestFormGenerator(MarketoFormTestCase):
 
             # form-data.json may have multiple forms
             for form_data in forms.values():
-                form_id = form_data.get("formData").get("formId")
+                form_data_obj = form_data.get("formData", {})
+                form_id = form_data_obj.get("formId")
+
+                self.assertIsNotNone(
+                    form_id,
+                    f"formId not found in form data for {form_path}",
+                )
 
                 # Check that marketo form exists
                 marketo_fields = self._get_marketo_fields(form_id)


### PR DESCRIPTION
## Done

- Add checks for empty form ID on marketo integration tests
- Drive-by: linting on `form-data.json`

## QA

- See that `test-python` check passes

## Issue / Card

Fixes [WD-33158](https://warthogs.atlassian.net/browse/WD-33158)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-33158]: https://warthogs.atlassian.net/browse/WD-33158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ