### PR TITLE
[WD-32968] update Screenly logo on three pages

### DIFF
--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -258,10 +258,10 @@
       <div class="col-3 col-medium-2 col-small-2">
         <a href="/engage/secure-digital-signage-screenly" aria-label="Screenly">
           <div class="p-image-container is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/a21934fe-screenly.png",
+            {{ image(url="https://assets.ubuntu.com/v1/8b0ff4db-screenly_linked_logo.png",
                         alt="",
                         width="852",
-                        height="481",
+                        height="480",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-image-container__image"}) | safe
@@ -322,12 +322,12 @@
 
       {%- if slot == 'signpost_image' -%}
         <div class="p-image-wrapper--logo">
-          {{ image(url="https://assets.ubuntu.com/v1/3cd4128e-screenly.png",
+          {{ image(url="https://assets.ubuntu.com/v1/1c576c31-screenly_logo_section.png",
                     alt="",
-                    width="103",
-                    height="29",
+                    width="106",
+                    height="18",
                     hi_def=True,
-                    loading="lazy",) | safe
+                    loading="lazy") | safe
           }}
         </div>
       {%- endif -%}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -305,10 +305,10 @@
             </div>
             <div class="p-logo-section__item">
               <a href="/engage/secure-digital-signage-screenly">
-                {{ image(url="https://assets.ubuntu.com/v1/a85bb8d1-Screenly-logo.png",
+                {{ image(url="https://assets.ubuntu.com/v1/1c576c31-screenly_logo_updated.png",
                                 alt="Screenly",
-                                width="223",
-                                height="313",
+                                width="318",
+                                height="312",
                                 hi_def=True,
                                 loading="lazy",
                                 attrs={"class": "p-logo-section__logo"},) | safe

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -349,7 +349,7 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-media-container u-darker-background">
-                {{ image(url="https://assets.ubuntu.com/v1/18c95711-screenly-updated.png",
+                {{ image(url="https://assets.ubuntu.com/v1/9e48a302-screenly_updated.png",
                                 alt="",
                                 width="852",
                                 height="1278",


### PR DESCRIPTION
## Done

- Update Screenly logo on:
   - /iot: [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit?tab=t.0)
   - /iot/smart-displays: [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit?tab=t.0)
   - /iot/appstore: [copy doc](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit?tab=t.0)

## QA

- Open each of the following pages:
  - https://ubuntu-com-15983.demos.haus/iot
  - https://ubuntu-com-15983.demos.haus/iot/smart-displays
  - https://ubuntu-com-15983.demos.haus/iot/appstore
- Check that Screenly logo has been updated and that the layout around the new logo looks intact.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-32968

