### PR TITLE
Certified: add dedicated download URL for Renesas RZ/G project

### DIFF
--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -28,6 +28,9 @@ def get_download_url(model_details):
     if "qualcomm" in make and "dragonwing" in configuration_name:
         return "https://ubuntu.com/download/qualcomm-iot#evaluation-kit"
 
+    if "renesas" in make and "rz/g" in configuration_name:
+        return "https://ubuntu.com/download/renesas-iot"
+
     if "core" in platform_category:
         if make == "xilinx":
             return "https://ubuntu.com/download/amd"


### PR DESCRIPTION


## Done

Similar to what has been done in the past for Qualcomm (#15853) and NVIDIA (#14876) projects, an additional check is made for Renesas RZ/G projects to point to the [dedicated project page on ubuntu.com.](https://ubuntu.com/download/renesas-iot)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/C3-1342
