### PR TITLE
feat: automatically fill out the pr description with demo link and jira link

### DIFF
--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -41,8 +41,8 @@ jobs:
             exit 0
           fi
           
-          # Add demo link after "Check out this feature branch"
-          sed "s|Check out this feature branch|Check out this feature branch or visit the [demo link]($demo_link)|g" original_body.txt > temp_body.txt
+          # Replace __DEMO_URL__ placeholder with actual demo link
+          sed "s|__DEMO_URL__|$demo_link|g" original_body.txt > temp_body.txt
           
           if [ -n "$jira_link" ]; then
             sed "s|Fixes #|Fixes $jira_link|g" temp_body.txt > updated_body.txt


### PR DESCRIPTION
## Done

- On PR creation adds 'or visit the demo link' to the QA steps
- If there is a valid Jira ticket number (e.g. 'wd-12345') in the branch name, link the jira ticket
- Here is a [PR](https://github.com/canonical/ubuntu.com/pull/16007) I made from this branch. I did not touch the description

## QA

- Create your own PR off this branch, include a valid jira ticket number in the branch name
- Check the demo link is correctly formed and placed logically
- Check the jira ticket link is correctly formed and placed logically
- Create your own PR off this branch, without a jira ticket number
- See only the demo link is added



