### PR TITLE
[Ignore] Sentry sampling test

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -105,7 +105,11 @@ def init_handlers(app):
                 response_data = error.response.json()
                 message = response_data.get("message", message)
             except (ValueError, AttributeError):
-                pass
+                app.logger.warning(
+                    "Failed to parse SecurityAPIError response JSON; "
+                    "using default error message.",
+                    exc_info=True,
+                )
 
         return (
             flask.render_template(


### PR DESCRIPTION
…ndling

Add ~1% sampling for RetryError/ConnectionError in sentry_before_send to prevent Sentry flooding during upstream outages. Refactor SecurityAPIError to include status_code and handle 503 errors gracefully in the error handler, providing a user-friendly message when the security data service is unavailable.

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
