### PR TITLE
feat: check mirror download exists before redirecting

### DIFF
--- a/static/js/src/image-download.js
+++ b/static/js/src/image-download.js
@@ -38,9 +38,8 @@ function startDownload(mirrors, imagePath) {
     var mirrorLink = selectedMirror.link + imagePath;
 
     // Check the mirror exists before attempting to download
-    fetch(
-      `/mirror-check?mirror_url=${encodeURIComponent(mirrorLink)}`,
-    )
+    // Has to be done server-side due to client-side CORs checks
+    fetch(`/mirror-check?mirror_url=${encodeURIComponent(mirrorLink)}`)
       .then(function (response) {
         return response.json();
       })

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -181,6 +181,7 @@ from webapp.views import (
     json_asset_query,
     marketo_submit,
     mirrors_query,
+    mirror_check,
     navigation_nojs,
     releasenotes_redirect,
     show_template,
@@ -356,6 +357,7 @@ app.add_url_rule("/asset/<file_name>", view_func=json_asset_query)
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 app.add_url_rule("/account.json", view_func=account_query)
 app.add_url_rule("/mirrors.json", view_func=mirrors_query)
+app.add_url_rule("/mirror-check", view_func=mirror_check)
 app.add_url_rule("/marketo/submit", view_func=marketo_submit, methods=["POST"])
 app.add_url_rule("/thank-you", view_func=thank_you)
 app.add_url_rule("/pro/activate", view_func=get_activate_view)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -233,6 +233,31 @@ def mirrors_query():
     )
 
 
+def mirror_check():
+    """
+    An endpoint that checks if a file exists on a given mirror.
+    Returns:
+      - 200 with {"available": true} if the file exists
+      - 400 with {"available": false} if file was not found or url was invalid
+    """
+    mirror_url = flask.request.args.get("mirror_url", default=None)
+
+    if not mirror_url:
+        return flask.jsonify({"available": False}), 400
+
+    parsed = urlparse(mirror_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return flask.jsonify({"available": False}), 400
+
+    try:
+        response = session.head(mirror_url, timeout=5, allow_redirects=True)
+        available = response.status_code == 200
+    except Exception:
+        available = False
+
+    return flask.jsonify({"available": available})
+
+
 def build_tutorials_index(session, tutorials_docs):
     def tutorials_index():
         page = flask.request.args.get("page", default=1, type=int)


### PR DESCRIPTION
## Done

- Adds a check to download ubuntu functionality to ensure the mirror exists. This is because on release it can take some time for mirrors to pick up the latest version

## QA

- go to https://ubuntu.com/download/desktop, attempt to download the latest point release (it should fail, with 404)
- run this branch, visit http://0.0.0.0:8001/download/desktop, attempt to download the point release (it should succeed)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33774

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
