### PR TITLE
fix: remove duplicated nav section

### DIFF
--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -25,12 +25,12 @@
 
     {%- if slot == 'signpost_image' -%}
       {{ image(url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
-        alt="",
-        width="200",
-        height="32",
-        hi_def=True,
-        loading="auto",
-        attrs={"style": "padding-top: 1rem"},) | safe
+            alt="",
+            width="200",
+            height="32",
+            hi_def=True,
+            loading="auto",
+            attrs={"style": "padding-top: 1rem"},) | safe
       }}{%- endif -%}
       {%- if slot == 'description' -%}
         <p>
@@ -47,7 +47,8 @@
       {%- endif -%}
       {%- if slot == 'cta' -%}
         <a href="/download/contact-us"
-           class="js-invoke-modal p-button--positive" aria-controls="contact-modal">Contact us</a>
+           class="js-invoke-modal p-button--positive"
+           aria-controls="contact-modal">Contact us</a>
       {%- endif -%}
     {%- endcall -%}
 
@@ -101,6 +102,13 @@
             </li>
             <li>
               <button class="p-tabs__item"
+                      id="milk-v-mars-cm"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="milk-v-mars-cm-tab">Milk-V Mars CM</button>
+            </li>
+            <li>
+              <button class="p-tabs__item"
                       id="pine64-star64"
                       role="tab"
                       aria-selected="false"
@@ -134,6 +142,13 @@
                       aria-selected="false"
                       aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button>
             </li>
+                      <li>
+            <button class="p-tabs__item"
+                    id="starfive-visionfive-2-lite"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="starfive-visionfive-2-lite-tab">StarFive VisionFive 2 Lite</button>
+          </li>
           </ul>
           <form class="u-hide--large u-hide--medium">
             <select name="boardSelect" id="boardSelect" data-maintain-hash="true">
@@ -142,11 +157,13 @@
               <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
               <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
               <option value="milk-v-mars-tab">Milk-V Mars</option>
+              <option value="milk-v-mars-cm-tab">Milk-V Mars CM</option>
               <option value="pine64-star64-tab">Pine64 Star64</option>
               <option value="qemu-tab">QEMU emulator</option>
               <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
               <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
               <option value="starfive-visionfive-2-tab">StarFive VisionFive 2</option>
+              <option value="starfive-visionfive-2-lite-tab">StarFive VisionFive 2 Lite</option>
             </select>
           </form>
         </div>
@@ -156,131 +173,14 @@
           {% include "download/risc-v/microchip-curiosity.html" %}
           {% include "download/risc-v/microchip-polarfire.html" %}
           {% include "download/risc-v/milk-v-mars.html" %}
+          {% include "download/risc-v/milk-v-mars-cm.html" %}
           {% include "download/risc-v/pine64-star64.html" %}
           {% include "download/risc-v/qemu-emulator.html" %}
           {% include "download/risc-v/sifive-unmatched.html" %}
           {% include "download/risc-v/sipeed-licheerv.html" %}
           {% include "download/risc-v/starfive-visionfive.html" %}
+          {% include "download/risc-v/starfive-visionfive-2-lite.html" %}
         </div>
-        <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
-            role="tablist"
-            data-maintain-hash="true"
-            aria-label="Risc-v boards">
-          <li>
-            <button class="p-tabs__item"
-                    id="allwinner-nezha"
-                    role="tab"
-                    aria-selected="true"
-                    aria-controls="allwinner-nezha-tab">AllWinner Nezha</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="deepcomputing-fml13v01"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="deepcomputing-fml13v01-tab">DeepComputing FML13V01</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="microchip-curiosity"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="microchip-polarfire-soc-fpga-icicle-kit"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">
-              Microchip Polarfire SoC FPGA Icicle
-            </button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="milk-v-mars"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="milk-v-mars-tab">Milk-V Mars</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="milk-v-mars-cm"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="milk-v-mars-cm-tab">Milk-V Mars CM</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="pine64-star64"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="pine64-star64-tab">Pine64 Star64</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="qemu"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="qemu-tab">QEMU emulator</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="quemu-sifive-image"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="sipeed-licheerv-dock"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="starfive-visionfive-2"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
-                    id="starfive-visionfive-2-lite"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="starfive-visionfive-2-lite-tab">StarFive VisionFive 2 Lite</button>
-          </li>
-        </ul>
-        <form class="u-hide--large u-hide--medium">
-          <select name="boardSelect" id="boardSelect" data-maintain-hash="true">
-            <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-            <option value="deepcomputing-fml13v01-tab">DeepComputing FML13V01</option>
-            <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
-            <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
-            <option value="milk-v-mars-tab">Milk-V Mars</option>
-            <option value="pine64-star64-tab">Pine64 Star64</option>
-            <option value="qemu-tab">QEMU emulator</option>
-            <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
-            <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
-            <option value="starfive-visionfive-2-tab">StarFive VisionFive 2</option>
-          </select>
-        </form>
-      </div>
-      <div class="col-9 col-medium-4">
-        {% include "download/risc-v/allwinner-nezha.html" %}
-        {% include "download/risc-v/deepcomputing-fml13v01.html" %}
-        {% include "download/risc-v/microchip-curiosity.html" %}
-        {% include "download/risc-v/microchip-polarfire.html" %}
-        {% include "download/risc-v/milk-v-mars.html" %}
-        {% include "download/risc-v/milk-v-mars-cm.html" %}
-        {% include "download/risc-v/pine64-star64.html" %}
-        {% include "download/risc-v/qemu-emulator.html" %}
-        {% include "download/risc-v/sifive-unmatched.html" %}
-        {% include "download/risc-v/sipeed-licheerv.html" %}
-        {% include "download/risc-v/starfive-visionfive.html" %}
-        {% include "download/risc-v/starfive-visionfive-2-lite.html" %}
       </div>
     </section>
 


### PR DESCRIPTION
## Done

- The nav on https://ubuntu.com/download/risc-v/canonical-built is currently duplicated on prod, this removes the duplicate. Introduced in this [pr](https://github.com/canonical/ubuntu.com/pull/15933)

flyby:
- add the new fields to the mobile dropdown

## QA

- Open the [DEMO](https://ubuntu-com-16027.demos.haus/download/risc-v/canonical-built)
- Check the nav isn't duplicated

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33812

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

