### PR TITLE
update: security/fips ubuntu pro messaging [WD-33543]

### DIFF
--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -79,7 +79,7 @@
 
     {%- if slot == 'list_item_description_2' -%}
       <p>
-        Keeping up to date with the latest security patches is vital, especially in high-security environments. With the Ubuntu Pro subscription, you get up to 15 years of security maintenance for your Ubuntu systems. You can also automate patching at scale with Landscape, a fleet management tool included in Ubuntu Pro. 
+        Keeping up to date with the latest security patches is vital, especially in high-security environments. With the Ubuntu Pro subscription, you get up to 15 years of security maintenance for your Ubuntu systems. You can also automate patching at scale with Landscape, a fleet management tool included in Ubuntu Pro.
       </p>
     {%- endif -%}
 
@@ -484,7 +484,7 @@
         <hr class="p-rule--muted">
 
         <p class="p-section--shallow">
-          Ubuntu Pro provides an easy pathway to FIPS compliance. It delivers vulnerability patching for the entire Ubuntu Archive (Main and Universe repositories), along with automated, unattended, and restartless updates, and the best tools to secure and manage your Ubuntu infrastructure, developed by the publisher of Ubuntu. 
+          Ubuntu Pro provides an easy pathway to FIPS compliance. It delivers vulnerability patching for the entire Ubuntu Archive (Main and Universe repositories), along with automated, unattended, and restartless updates, and the best tools to secure and manage your Ubuntu infrastructure, developed by the publisher of Ubuntu.
         </p>
 
         <a href="/security/contact-us"


### PR DESCRIPTION
## Done

- Made the [copy doc](https://docs.google.com/document/d/1moTJCAtFXKD7ZXrxB-EB7GPVyZRTSIdkP-0BhPZl69M/edit?tab=t.0#heading=h.6sz7bcicb7ur) changes

## QA

- Open the [DEMO](https://ubuntu-com-16028.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

