### PR TITLE
Rollup Feb 2026 release notes to overall release notes page

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
@@ -24,7 +24,7 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane
-* Reduced rules needed by `ClusterRole/system:cos` to improve security posture
+* Reduced rules needed by  `ClusterRole/system:cos` to improve security posture
 
 # 1.32+ck4
 

--- a/templates/kubernetes/charmed-k8s/docs/1.33/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.33/release-notes.md
@@ -25,7 +25,7 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane
-* Reduced rules needed by `ClusterRole/system:cos` to improve security posture
+* Reduced rules needed by  `ClusterRole/system:cos` to improve security posture
 
 # 1.33+ck3
 

--- a/templates/kubernetes/charmed-k8s/docs/1.34/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.34/release-notes.md
@@ -25,7 +25,7 @@ toc: False
 ## Notable Fixes
 
 ### Kubernetes Control Plane
-* Reduced rules needed by `ClusterRole/system:cos` to improve security posture
+* Reduced rules needed by  `ClusterRole/system:cos` to improve security posture
 
 
 # 1.34

--- a/templates/kubernetes/charmed-k8s/docs/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/release-notes.md
@@ -13,6 +13,15 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.34+ck1
+
+### Feb 12, 2026 - `charmed-kubernetes --channel 1.34/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane
+* Reduced rules needed by `ClusterRole/system:cos` to improve security posture
+
 # 1.34
 
 ### September 24, 2025 - `charmed-kubernetes --channel 1.34/stable`
@@ -44,7 +53,7 @@ The release bundle can also be [downloaded here](https://raw.githubusercontent.c
 
 ### openstack-integrator
 
-* [LP#2110221](https://launchpad.net/bugs/2111261) Config change and creds
+* [LP#2110221](https://launchpad.net/bugs/2110221) Config change and creds
   changes validates LB Requests
 * Allow Juju admin to specify o7k endpoint proxy values by charm or model
 
@@ -88,6 +97,15 @@ For details of other deprecation notices and API changes for Kubernetes 1.34, pl
 relevant sections of the [upstream release notes][upstream-changelog-1.34].
 
 [upstream-changelog-1.34]: https://github.com/kubernetes/kubernetes/blob/release-1.34/CHANGELOG/CHANGELOG-1.34.md#deprecation
+
+# 1.33+ck4
+
+### Feb 12, 2026 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane
+* Reduced rules needed by `ClusterRole/system:cos` to improve security posture
 
 # 1.33+ck3
 
@@ -212,6 +230,15 @@ For details of other deprecation notices and API changes for Kubernetes 1.33, pl
 relevant sections of the [upstream release notes][upstream-changelog-1.33].
 
 [upstream-changelog-1.33]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#deprecation
+
+# 1.32+ck5
+
+### Feb 12, 2026 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane
+* Reduced rules needed by `ClusterRole/system:cos` to improve security posture
 
 # 1.32+ck4
 
@@ -2363,6 +2390,6 @@ Please see [this page][historic] for release notes of earlier versions.
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/release-notes.md" >edit this page</a>
     or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new">file a bug here</a>.</p>
-    <p>See the guide to <a href="/kubernetes/charmed-k8s/docs/how-to-contribute"> contributing </a> or discuss these docs in our <a href="https://kubernetes.slack.com/archives/CG1V2CAMB"> public Slack  channel</a>.</p>
+    <p>See the guide to <a href="/kubernetes/charmed-k8s/docs/how-to-contribute"> contributing </a> or discuss these docs in our <a href="https://kubernetes.slack.com/archives/CG1V2CAMB"> public Slack channel</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updating release notes for Charmed Kubernetes bugfix releases for 1.32, 1.33, and 1.34
- Updating release notes for Charmed Kubernetes bugfix releases on the rollup site

