### PR TITLE
Copy update: /security/security-standards

### DIFF
--- a/templates/security/standards/index.html
+++ b/templates/security/standards/index.html
@@ -35,7 +35,7 @@
             <a href="/security/contact-us"
                class="p-button--positive js-invoke-modal"
                aria-controls="security-standards-modal">Contact us</a>
-            <a href="/pro">Learn more about Pro&nbsp;&rsaquo;</a>
+            <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
@@ -504,14 +504,14 @@
             }}
           </div>
           <p>
-            Ubuntu Pro provides an easy pathway to compliance. It delivers CVE patching for Ubuntu OS and Applications covering 36,000 packages, along with automated, unattended, and restartless updates, and the best tools to secure and manage your Ubuntu infrastructure developed by the publisher of Ubuntu.
+            Ubuntu Pro provides an easy pathway to compliance. It delivers vulnerability patching for the entire Ubuntu Archive (Main and Universe repositories), along with automated, unattended, and restartless updates, and the best tools to secure and manage your Ubuntu infrastructure developed by the publisher of Ubuntu.
           </p>
           <hr class="p-rule--muted" />
           <p>
             <a class="p-button--positive js-invoke-modal"
                href="/security/contact-us"
                aria-controls="security-standards-modal">Contact us</a>
-            <a href="/pro">Learn more about Pro&nbsp;&rsaquo;</a>
+            <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done
Added compliance with Ubuntu Pro in line with the [copy doc](https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit?tab=t.0#heading=h.87izly7ww5du).

## QA
- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/security-standards
- Ensure the page is line with the copy doc.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-33540