### PR TITLE
WD-33544: Change /security/cves footer text.

### DIFF
--- a/templates/security/cves/_cve-footer.html
+++ b/templates/security/cves/_cve-footer.html
@@ -28,11 +28,7 @@
           <h3 class="p-heading--5">Ubuntu Pro</h3>
         </div>
         <div class="col-6">
-          <p>
-            10-year security coverage for Ubuntu
-            <br aria-hidden="true" />
-            and 23,000 open-source applications and toolchains.
-          </p>
+          <p>Up to 15 years of security coverage for Ubuntu and your full stack of open-source applications and toolchains.</p>
           <a class="p-button" href="/pro">Get Ubuntu Pro</a>
           <a href="/pro/free-trial">30-day free trial</a>
         </div>


### PR DESCRIPTION
## Done
Change `/security/cves` footer text.

## QA

- Open the [DEMO](https://ubuntu-com-16034.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cves
- Check the copy on the footer matches the requested change on the [ticket](https://warthogs.atlassian.net/browse/WD-33544) 


