### PR TITLE
feat(WD-33542): Copytext update for livepatch page

### DIFF
--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -337,6 +337,7 @@ meta_copydoc %}
       {%- endif -%}
 
       {%- if slot == 'description' -%}
+        
         <div class="p-section--shallow u-hide--medium u-hide--small">
           <div class="p-image-container is-highlighted">
             {{ image(url="https://assets.ubuntu.com/v1/df38fad4-ubuntu-pro.png",
@@ -348,8 +349,9 @@ meta_copydoc %}
                         attrs={"class": "p-image-container__image"}) | safe
             }}
           </div>
-          <p>Ubuntu Pro is Canonical’s comprehensive subscription for open source security, support, and compliance. Ubuntu Pro gives you access to a trusted open source repository, compliance profiles for the most stringent security standards, and up to 15 years of vulnerability fixes for your OS, infrastructure, and applications – as well as tools like Livepatch and Landscape that make security maintenance and compliance at scale easier and faster.</p>
         </div>
+        <p>Ubuntu Pro is Canonical’s comprehensive subscription for open source security, support, and compliance. Ubuntu Pro gives you access to a trusted open source repository, compliance profiles for the most stringent security standards, and up to 15 years of vulnerability fixes for your OS, infrastructure, and applications – as well as tools like Livepatch and Landscape that make security maintenance and compliance at scale easier and faster.</p>
+
       {%- endif -%}
 
       {%- if slot == 'list_item_title_1' -%}


### PR DESCRIPTION
## Done

- Content updated to match this [copydoc](https://docs.google.com/document/d/1g_Ip5MzlBRpbM2wULpSnsR5XaHJVWgLPLdq8_7fCHrs/edit?tab=t.0).

## QA

- Open the [DEMO](https://ubuntu-com-16036.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/livepatch
- Make sure content matches copydoc.

## Issue / Card

Fixes [WD-33542](https://warthogs.atlassian.net/browse/WD-33542) [WD-33542](https://warthogs.atlassian.net/browse/WD-33542)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-33542]: https://warthogs.atlassian.net/browse/WD-33542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
