### PR TITLE
Added reverse-proxy entry for staging usn-db

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -611,6 +611,9 @@ production:
     location ^~ /usn-db/ {
       proxy_pass https://people.canonical.com/%7Eubuntu-security/usn/;
     }
+    location ^~ /usn-db-stg/ {
+      proxy_pass http://seceng-people.internal/%7Eubuntu-security/usn/;
+    }
 
 # Overrides for staging
 staging:


### PR DESCRIPTION
This is done in preparation for the decommissioning of people.canonical.com.