### PR TITLE
chore: redirect openstack cheat sheet

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1272,4 +1272,4 @@ tutorials/install-istio-on-charmed-distribution-of-kubernetes/?: "https://ubuntu
 tutorials/how-to-build-a-ceph-backed-kubernetes-cluster/?: "https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/charm/howto/ceph-csi/"
 tutorials/accelerated-ml-experiments-on-microk8s-with-inaccel-fpga-operator-and-kubeflow-katib/?: "https://charmed-kubeflow.io/docs/accelerated-ml-experiments-on-microk8s-with-inaccel-fpga-operator-and-kubeflow-katib"
 
-/openstack/openstack-cheat-sheet/?: /engage/openstack-commands-cheat-sheet
+openstack/openstack-cheat-sheet/?: /engage/openstack-commands-cheat-sheet


### PR DESCRIPTION
## Done

- redirected /openstack/openstack-cheat-sheet to /engage/openstack-commands-cheat-sheet

## QA

- visit [<demo>/openstack/openstack-cheat-sheet](https://ubuntu-com-16040.demos.haus/openstack/openstack-cheat-sheet)
- check that you've been redirected to /engage/openstack-commands-cheat-sheet

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33509

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

