### PR TITLE
Replaced p-status-labels with the read-only p-chip label

### DIFF
--- a/static/sass/_pattern_distributor.scss
+++ b/static/sass/_pattern_distributor.scss
@@ -87,31 +87,9 @@
     }
   }
 
-  .p-status-label--positive {
-    @include vf-p-status-label;
-    @extend %small-text;
-
-    background-color: hsl(129deg 90% 39% / 10%);
-    border: 1px solid $color-positive;
-    border-radius: 1rem;
-    color: $color-dark;
-    font-weight: $font-weight-bold;
-    margin: 0 $sph--small $input-margin-bottom 0;
-    padding: calc(#{$spv--x-small} - 1px) $sph--small;
-    position: relative;
-    top: -0.4rem;
-  }
-
   .versions-features {
     > li.p-list__item {
       padding: 0.5rem 0;
-    }
-
-    .p-status-label--positive {
-      border: none;
-      font-style: oblique;
-      margin-left: 0.5rem;
-      top: 0;
     }
   }
 

--- a/static/sass/_pattern_subscribe.scss
+++ b/static/sass/_pattern_subscribe.scss
@@ -76,31 +76,9 @@
     }
   }
 
-  .p-status-label--positive {
-    @include vf-p-status-label;
-    @extend %small-text;
-
-    background-color: hsl(129deg 90% 39% / 10%);
-    border: 1px solid $color-positive;
-    border-radius: 1rem;
-    color: $color-dark;
-    font-weight: $font-weight-bold;
-    margin: 0 $sph--small $input-margin-bottom 0;
-    padding: calc(#{$spv--x-small} - 1px) $sph--small;
-    position: relative;
-    top: -0.4rem;
-  }
-
   .versions-features {
     > li.p-list__item {
       padding: 0.5rem 0;
-    }
-
-    .p-status-label--positive {
-      border: none;
-      font-style: oblique;
-      margin-left: 0.5rem;
-      top: 0;
     }
   }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -914,16 +914,6 @@ img.has-shadow {
   box-shadow: 0 0 1rem #e5e5e5;
 }
 
-// Style for status labels (similar to chips but non-clickable)
-.p-status-label--rounded {
-  background-color: #ddf2e0;
-  border-radius: map-get($line-heights, h4);
-  margin-bottom: map-get($sp-after, h4) - map-get($nudges, h4);
-  padding-bottom: map-get($nudges, h4);
-  padding-left: $sph--x-large;
-  padding-right: $sph--x-large;
-}
-
 // Temp fix for anchor underlines
 // Being addressed upstream in https://github.com/canonical/vanilla-framework/issues/4600
 a:hover {

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -57,14 +57,14 @@
                   <td aria-label="Status">
                     {% if invoice.invoice %}
                       {% if invoice.invoice.status == "paid" %}
-                        <div class="p-status-label--positive">Paid</div>
+                        <div class="p-chip--positive">Paid</div>
                       {% elif invoice.invoice.status == "open" %}
                         <div class="p-label">Pending</div>
                       {% else %}
-                        <div class="p-status-label--negative">Failed</div>
+                        <div class="p-chip--negative">Failed</div>
                       {% endif %}
                     {% elif invoice.status == "done" %}
-                      <div class="p-status-label">Not available</div>
+                        <div class="p-chip">Not available</div>
                     {% else %}
                       <div class="p-label">Pending</div>
                     {% endif %}


### PR DESCRIPTION
## Done
- deleted deprecated p-status label uses
- implemented the new p-chip labels

## QA
- Open the branch's code in a text editor
- No references to p-status-label
- No references to custom classes related to p-status-labels

## Issue / Card
https://warthogs.atlassian.net/browse/WD-33961
