### PR TITLE
Set redirects for Mini ISO

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1278,3 +1278,6 @@ tutorials/beginning-apparmor-profile-development/?: "https://documentation.ubunt
 
 openstack/openstack-cheat-sheet/?: /engage/openstack-commands-cheat-sheet
 
+# Redirects for mini-iso
+noble/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/ubuntu-mini-iso-24.04.4-mini-iso-amd64.iso"
+resolute/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/resolute/release/ubuntu-mini-iso-26.04-mini-iso-amd64.iso"


### PR DESCRIPTION
Hi!

Just adding a few redirects for Mini ISO.

Noble - already exists.
Resolute - doesn't exist yet - as we've not released.

This is for our partners who wanted a reliable link to download the mini ISO.