### PR TITLE
Changed reverse proxy entry for /usn-db/

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -609,7 +609,7 @@ production:
       proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
     }
     location ^~ /usn-db/ {
-      proxy_pass https://people.canonical.com/%7Eubuntu-security/usn/;
+      proxy_pass http://seceng-people.internal/%7Eubuntu-security/usn/;
     }
     location ^~ /usn-db-stg/ {
       proxy_pass http://seceng-people.internal/%7Eubuntu-security/usn/;


### PR DESCRIPTION
The setup tested via https://github.com/canonical/ubuntu.com/pull/16038 has been successful.

The current PR migrates the in-use /usn-db/ entry to the new host, in preparation for people.canonical.com decommissioning.