### PR TITLE
fix(/security/standards/pci-dss): blogs are not rendering

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1422,6 +1422,9 @@ def render_security_pci_dds_blogs():
     )
 
 
+app.add_url_rule(
+    "/security/standards/pci-dss", view_func=render_security_pci_dds_blogs
+)
 app.add_url_rule("/security/pci-dss", view_func=render_security_pci_dds_blogs)
 
 


### PR DESCRIPTION
## Done

- there are two pages `/security/standards/pci-dss` and `/security/pci-dss` that require the same blog context. This PR add a url rule for the former

## QA

- Open the [DEMO](https://ubuntu-com-16050.demos.haus/security/standards/pci-dss)
- Scroll down the blogs/resources section and check they both render correctly
- Also check https://ubuntu-com-16050.demos.haus/security/pci-dss

## Issue / Card

Fixes [WD-33466](https://warthogs.atlassian.net/browse/WD-33466)




[WD-33466]: https://warthogs.atlassian.net/browse/WD-33466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ