### PR TITLE
Redirect newly migrated tutorials

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1150,6 +1150,16 @@ tutorials/electron-kiosk/?: https://canonical.com/mir/docs/make-a-secure-ubuntu-
 tutorials/get-started-with-edgex-as-snaps?: /internet-of-things
 tutorials/how-to-install-adguard-home-raspberry-pi/?: /appliance/adguard/raspberry-pi
 tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc/?: /appliance/nextcloud/intel-nuc
+tutorials/try-ubuntu-before-you-install/?: https://documentation.ubuntu.com/desktop/en/latest/tutorial/try-ubuntu-desktop/
+tutorials/install-ubuntu-desktop/?: https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/
+tutorials/upgrading-ubuntu-desktop/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/
+tutorials/create-a-usb-stick-on-ubuntu/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/
+tutorials/create-a-usb-stick-on-windows/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/
+tutorials/create-a-usb-stick-on-macos/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/
+tutorials/how-to-use-smart-card-authentication-in-ubuntu-desktop/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/log-in-using-a-smart-card/
+tutorials/enable-smart-cards-in-snapped-browsers/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/enable-smart-cards-in-snapped-browsers/
+tutorials/access-remote-desktop/?: https://documentation.ubuntu.com/desktop/en/latest/how-to/access-a-remote-desktop/
+tutorials/command-line-for-beginners/?: https://documentation.ubuntu.com/desktop/en/latest/tutorial/the-linux-command-line-for-beginners/
 
 # Image builder
 build: /core/build


### PR DESCRIPTION
This PR adds redirects from several old, unmaintained tutorials to their updated equivalents in the new Ubuntu Desktop documentation.