### PR TITLE
WD-33865 Security page copy updates

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -262,14 +262,9 @@
       <p>
         Ubuntu Pro has been designed to simplify your security compliance burden for frameworks such as NIST, <a href="/security/fedramp">FedRAMP</a>, <a href="/security/pci-dss">PCI-DSS</a>, ISO27001 by providing <a href="/security/fips">FIPS-validated cryptographic modules</a>, and automated system hardening for <a href="/security/cis">CIS</a> and <a href="/security/disa-stig">DISA STIG</a>.
       </p>
-      <ul class="p-list">
-        <li class="p-list__item">
-          <a href="/security/security-standards">Get help with your security standard&nbsp;&rsaquo;</a>
-        </li>
-        <li class="p-list__item">
-          <a href="/security/compliance-automation">Learn more about compliance automation&nbsp;&rsaquo;</a>
-        </li>
-      </ul>
+      <div class="p-cta-block">
+        <a href="/security/security-standards">Get help with your security standard&nbsp;&rsaquo;</a>
+      </div>
     {%- endif -%}
 
     {%- if slot == 'list_item_title_1' -%}


### PR DESCRIPTION
## Done

- Updates the security page copy
- [Copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit?tab=t.0)

## QA

- Open the [DEMO](https://ubuntu-com-16054.demos.haus/security)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Review the changes agains the copy doc

## Issue / Card

Fixes [WD-33865](https://warthogs.atlassian.net/browse/WD-33865)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-33865]: https://warthogs.atlassian.net/browse/WD-33865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ