### PR TITLE
fix: conditionally render fieldset id to prevent empty attribute

### DIFF
--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -20,8 +20,7 @@
       <div class="{% if loop.index != fieldsets|length %}p-section{% endif %}">
         <hr class="p-rule is-fixed-width" />
         <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox' or fieldset.inputType == 'checkbox-visibility' %} js-remove-checkbox-names{% if fieldset.isRequired %} js-required-checkbox{% endif %}{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% endif %}{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
-                  {% if fieldset.id %}id="{{ fieldset.id }}-field"{% endif %}
-                  aria-labelledby="{{ fieldset.id }}">
+                  {% if fieldset.id %}id="{{ fieldset.id }}-field" aria-labelledby="{{ fieldset.id }}-legend"{% endif %}>
           <!-- This legend is for screen readers only, to fix a11y warning -->
           <legend class="u-hide">{{ fieldset.title }}</legend>
           <div class="row--50-50 {% if not fieldset.noCommentsFromLead %}js-formfield{% endif %}">


### PR DESCRIPTION
## Done

- Avoid rendering an empty id attribute when fieldset.id is falsy, which
can cause invalid HTML and accessibility issues.

As can be seen in this [failing action](https://github.com/canonical/ubuntu.com/actions/runs/22297035125/job/64495743421)

## QA
- Open the [DEMO](https://ubuntu-com-16055.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

