### PR TITLE
feat: add sitemaps for dedicated snap store and enterprise store

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -22,7 +22,7 @@
     <loc>https://ubuntu.com/security/certifications/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-      <loc>https://ubuntu.com/blog/sitemap.xml</loc>
+    <loc>https://ubuntu.com/blog/sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://ubuntu.com/security/notices/sitemap.xml</loc>
@@ -34,12 +34,12 @@
     <loc>https://ubuntu.com/security/cves/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-   <loc>https://ubuntu.com/security/livepatch/docs/sitemap.xml</loc>
+    <loc>https://ubuntu.com/security/livepatch/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-   <loc>https://ubuntu.com/internet-of-things/appstore/docs/doc-sitemap.xml</loc>
+    <loc>https://ubuntu.com/internet-of-things/appstore/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-   <loc>https://ubuntu.com/enterprise-store/docs/doc-sitemap.xml</loc>
+    <loc>https://ubuntu.com/enterprise-store/docs/doc-sitemap.xml</loc>
   </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Adds sitemaps for https://ubuntu.com/internet-of-things/appstore/docs/ and https://ubuntu.com/enterprise-store/docs/ which are now served on the main Ubuntu URL through the [RTD proxy](https://docs.google.com/document/d/1LKQ6HL_4OgWXDLmyeCf3aNj9AcK22xKYht3fEzlx-Q4/). 

## QA

Should have no effect on QA