### PR TITLE
replaced asset with typo-free asset

### DIFF
--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -240,7 +240,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="p-image-container--cinematic is-cover is-highlighted">        
-          {{ image(url="https://assets.ubuntu.com/v1/0b4a9b1a-livepatching_at_a_glance_diagram_01_2x.png",
+          {{ image(url="https://assets.ubuntu.com/v1/ef6ad8e0-livepatch_new.png",
             alt="A flow diagram showing how Ubuntu Livepatch works. On the left, a high priority or critical vulnerability is discovered. An arrow points to a cluster of servers/workstations with the Livepatch client enabled through a Canonical-authenticated livepatch update. The diagram highlights how a kernel can be live patched without a reboot.",
             width="3696",
             height="1541",
@@ -251,7 +251,6 @@ meta_copydoc %}
       </div>
     </div>
   </section>
-
 
   <section class="p-section">
     <hr class="is-fixed-width p-rule" />


### PR DESCRIPTION
## Done

- Updated [/security/livepatch](https://ubuntu-com-16074.demos.haus/security/livepatch) to fix typo in asset

## QA

- Navigate to [/security/livepatch](https://ubuntu-com-16074.demos.haus/security/livepatch)
- Scroll down to the Kernel livepatching at a glance section
- Ensure that there's no typo: 'autheticated'  in the image.
- Ensure this asset is used: https://assets.ubuntu.com/manager/details?file_path=ef6ad8e0-livepatch_new.png

## Issue / Card
https://warthogs.atlassian.net/browse/WD-34445

## Screenshots
### Before
<img width="1221" height="750" alt="image" src="https://github.com/user-attachments/assets/09f554a0-47f5-4af7-979f-3dbd25b4d453" />

### After
<img width="1221" height="750" alt="image" src="https://github.com/user-attachments/assets/d192bb6a-4bc8-4b46-9052-6e496cf4b5d1" />



