### PR TITLE
Add server sitemap to sitemap index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -42,4 +42,7 @@
   <sitemap>
     <loc>https://ubuntu.com/enterprise-store/docs/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/server/docs/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

- Add sitemap for https://ubuntu.com/server/docs/ which is now served on the main Ubuntu URL through the [RTD proxy](https://docs.google.com/document/d/1LKQ6HL_4OgWXDLmyeCf3aNj9AcK22xKYht3fEzlx-Q4/).
- Follows the example of PR #16073 which did the same for the Enterprise Store docs

## QA

Should have no effect on QA
