### PR TITLE
[WD-34436] - Copy update for download desktop page

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -509,7 +509,9 @@
         </div>
         <div class="col">
           <p>
-            Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organizations. Ubuntu Pro Desktop is free for personal use on up to five machines.
+            Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, 
+            and up to 15 years of security and maintenance and extended support for developers and organizations. 
+            Ubuntu Pro Desktop is free for personal use on up to five machines.
           </p>
           <hr class="p-rule--muted u-no-margin--bottom" />
           <ul class="p-list--divided u-no-margin--bottom">
@@ -523,7 +525,7 @@
               Estate <a href="https://landscape.canonical.com/landscape-features">monitoring and management</a>
             </li>
             <li class="p-list__item is-ticked">
-              <a href="/security/security-standards#fips">FIPS 140-2 certified modules</a> and <a href="/security/security-standards#cis">CIS hardening</a>
+              <a href="/security/security-standards#fips">FIPS 140-3 certified modules</a> and <a href="/security/security-standards#cis">CIS hardening</a>
             </li>
             <li class="p-list__item is-ticked">Optional weekday or 24/7 support tiers</li>
           </ul>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -72,7 +72,7 @@
           </div>
 
           <p class="p-text--small">
-            For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
+            For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
         </div>
         <!-- Start tab container -->
@@ -229,7 +229,7 @@
             </div>
           </div>
           <p class="p-text--small">
-            For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
+            For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
         </div>
         <!-- Start tab container -->
@@ -335,7 +335,7 @@
       </div>
       <div class="col">
         <p>
-          Many of the world's biggest PC manufacturers certify their laptops and desktops for Ubuntu, from ultra-portable laptops to high-end workstations. Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out-of-the-box. Our partners also offer select devices preloaded with optimised Ubuntu images.
+          Many of the world's biggest PC manufacturers certify their laptops and desktops for Ubuntu, from ultra-portable laptops to high-end workstations. Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out-of-the-box. Our partners also offer select devices preloaded with optimized Ubuntu images.
         </p>
         <p>
           <a href="/certified">Learn more about certified hardware&nbsp;&rsaquo;</a>

--- a/templates/download/shared/_more-from-canonical.html
+++ b/templates/download/shared/_more-from-canonical.html
@@ -47,7 +47,7 @@
           </h3>
         </div>
         <div class="col-6 col-medium-3">
-          <p>Use your Raspberry Pi as a desktop, server or IoT device with Ubuntu.</p>
+          <p>Use your Raspberry Pi as a desktop, server, or IoT device with Ubuntu.</p>
           <hr class="p-rule--muted" />
           <p>
             <a href="/download/raspberry-pi">Learn about Ubuntu for Raspberry Pi&nbsp;&rsaquo;</a>
@@ -73,7 +73,7 @@
           </h3>
         </div>
         <div class="col-6 col-medium-3">
-          <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+          <p>Spin up Ubuntu VMs on Windows, Mac, and Linux.</p>
           <hr class="p-rule--muted" />
           <p>
             <a href="https://multipass.run/">Learn about Multipass&nbsp;&rsaquo;</a>

--- a/templates/download/shared/_secure-enterprise-management.html
+++ b/templates/download/shared/_secure-enterprise-management.html
@@ -25,8 +25,8 @@
         <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
         <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
         <li class="p-list__item is-ticked">Estate <a href="/landscape/features">monitoring and management</a></li>
-        <li class="p-list__item is-ticked"><a href="/security/security-standards">FIPS 140-2 certified modules and CIS hardening</a></li>
-        <li class="p-list__item is-ticked">Minimise rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
+        <li class="p-list__item is-ticked"><a href="/security/security-standards">FIPS 140-3 certified modules and CIS hardening</a></li>
+        <li class="p-list__item is-ticked">Minimize rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
         <li class="p-list__item is-ticked">Optional weekday or 24/7 support tiers</li>
       </ul>
       <hr class="p-rule--muted" />


### PR DESCRIPTION
## Done

- Copy updates for the download desktop page

## QA

- Open the [DEMO](https://ubuntu-com-16076.demos.haus/download/desktop)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure that the copy updates suggested in the [copydoc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit?tab=t.0) have been applied.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34436

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

