### PR TITLE
[WD-34481] Copy updates to security/esm page

### DIFF
--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -10,6 +10,7 @@
   https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit
 {% endblock meta_copydoc %}
 
+{% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}


### PR DESCRIPTION
## Done

- Copy updates to the security esm page

## QA

- Open the [DEMO](https://ubuntu-com-16077.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that all suggestions in the [copydoc ](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit?tab=t.0#heading=h.rhdsdlvl1app) have been implemented.

## Issue / Card

Fixes [WD-34481](https://warthogs.atlassian.net/browse/WD-34481)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-34481]: https://warthogs.atlassian.net/browse/WD-34481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
