### PR TITLE
feat: add RZ/V2L tab and release levels to /download/renesas-iot

### DIFF
--- a/templates/download/renesas-iot/index.html
+++ b/templates/download/renesas-iot/index.html
@@ -13,6 +13,7 @@
 {% endblock meta_copydoc %}
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
 {% block body_class %}
   is-paper
@@ -81,6 +82,12 @@
                     role="tab"
                     aria-controls="renesas-rz-g2ul-tab">RZ/G2UL</button>
           </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="renesas-rz-v2l"
+                    role="tab"
+                    aria-controls="renesas-rz-v2l-tab">RZ/V2L</button>
+          </li>
         </ul>
         <!-- form dropdown for smaller screens -->
         <form class="u-hide--large u-hide--medium">
@@ -88,6 +95,7 @@
             <option value="renesas-rz-g2l-tab" selected="">RZ/G2L</option>
             <option value="renesas-rz-g2lc-tab" selected="">RZ/G2LC</option>
             <option value="renesas-rz-g2ul-tab" selected="">RZ/G2UL</option>
+            <option value="renesas-rz-v2l-tab" selected="">RZ/V2L</option>
           </select>
         </form>
       </div>
@@ -95,9 +103,39 @@
         {% include "download/renesas-iot/tab-1-renesas-rz-g2l.html" %}
         {% include "download/renesas-iot/tab-2-renesas-rz-g2lc.html" %}
         {% include "download/renesas-iot/tab-3-renesas-rz-g2ul.html" %}
+        {% include "download/renesas-iot/tab-4-renesas-rz-v2l.html" %}
       </div>
     </div>
   </section>
+
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>Release Maturity Levels Explained</h2>
+  {%- endif -%}
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Early Access</h3>
+  {%- endif -%}
+  {%- if slot == 'list_item_description_1' -%}
+    <p>A preliminary Ubuntu image* for early adopters and developers.
+    <em>Use to validate hardware enablement and start development early.</em></p>
+  {%- endif -%}
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Beta</h3>
+  {%- endif -%}
+  {%- if slot == 'list_item_description_2' -%}
+    <p>A stable Ubuntu image* with the majority of features integrated and validated.
+    <em>Use to build prototypes and test applications. Not for production deployment.</em></p>
+  {%- endif -%}
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Certified</h3>
+  {%- endif -%}
+  {%- if slot == 'list_item_description_3' -%}
+    <p>A production-grade Ubuntu image*. This is a feature-complete, quality-assured release. Long-term support from Canonical
+  available with Ubuntu Pro.
+    <em>Use for production deployments.</em></p>
+    <p>*check the release notes for supported features and known issues.</p>
+  {%- endif -%}
+{%- endcall -%}
 
   <section class="p-section--deep">
     <div class="row--50-50">

--- a/templates/download/renesas-iot/tab-4-renesas-rz-v2l.html
+++ b/templates/download/renesas-iot/tab-4-renesas-rz-v2l.html
@@ -1,0 +1,71 @@
+<div tabindex="3"
+     role="tabpanel"
+     id="renesas-rz-v2l-tab"
+     aria-labelledby="renesas-rz-v2l"
+     aria-hidden="true">
+  <div class="p-section--shallow">
+    <div class="row">
+      <div class="col-6">
+        <h2 class="u-hide--small">Renesas RZ/V2L</h2>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Server 24.04</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            This is the Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
+          </p>
+          <div>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x09/iot-renesas-rz-classic-server-2404-release-20260226.img.xz"
+               class="p-button--positive">Download Ubuntu 24.04</a>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x09/bootassets-rzv2l.tar.gz"
+               class="p-button">Download boot assets</a>
+          </div>
+          <div class="p-cta-block">Ubuntu 24.04 for RZ/V2L&nbsp;<a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G2L-RZ_V2L%20with%20classic%20Ubuntu%20images_x09.pdf">image installation instructions</a></div>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">AI Snap Tutorial</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            Build AI applications on Ubuntu for RZ/V2L
+          </p>
+          <div>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Running%20AI%20Application%20on%20RZ_V2L%20with%20Ubuntu%20images.pdf"
+               class="p-button--positive">Access AI Snap Tutorial</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="p-rule--muted" />
+  <div class="row">
+    <div class="col-3">
+      <h3 class="p-heading--5">Get started</h3>
+    </div>
+    <div class="col-6">
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 24.04 for&nbsp;<a href="https://www.renesas.com/en/products/rz-v2l">RZ/V2L</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu for RZ/V2L
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G2L-G2UL-G2LC-V2L%20Release%20Notes%20-%20x09.pdf">release notes</a>
+        </li>
+        <hr class="p-rule--muted" />
+      </ul>
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the <a href="https://www.renesas.com/en/design-resources/boards-kits/rz-v2l-evkit?part-status=Active">RZ/V2L-EVKIT</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- added RZ/V2L tab and release levels to /download/renesas-iot

## QA

- Open [/download/renesas-iot](https://ubuntu-com-16081.demos.haus/download/renesas-iot)
- Click on the RZ/V2L tab.
- Check that the content matches the [copy doc](https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?tab=t.0).
- Check that the new Release Maturity Levels Explained section matches the [design](https://www.figma.com/design/cVGimTPHky4h3BPXfrT6GB/ubuntu.com-download---Sites?node-id=2333-12048&t=2F0aajOFvAGSTumc-0).

## Issue / Card

https://warthogs.atlassian.net/browse/WD-34354

## Screenshots

<img width="712" height="640" alt="Screenshot 2026-03-05 at 3 39 26 pm" src="https://github.com/user-attachments/assets/d3a5d5b8-3a57-4fd0-9a75-20cc7a908f1d" />

