### PR TITLE
fix: update section class on /desktop/developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -491,7 +491,7 @@
     </div>
   </section>
 
-  <section class="p-strip--white u-no-padding--top">
+  <section class="p-section">
     <div class="u-fixed-width p-section--shallow">
       {{ image(url="https://assets.ubuntu.com/v1/db0c14a8-Ubuntu%20Pro.svg",
             alt="",


### PR DESCRIPTION
## Done
Removed the white background of a section on the page. The whole page should have the paper background

## QA

- Open the [DEMO](https://ubuntu-com-16094.demos.haus/desktop/developers/)
- Check that no section have a white background
  - compare with prod https://ubuntu.com/desktop/developers
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-34449?focusedCommentId=1029475

## Screenshots
Before
<img width="2702" height="1840" alt="image" src="https://github.com/user-attachments/assets/832de912-c5c1-45d0-a091-7b4a05d574b7" />

After
<img width="2696" height="1890" alt="image" src="https://github.com/user-attachments/assets/0fe7c5f9-fc9f-483e-9622-30de2704b84c" />


[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

