### PR TITLE
chore(WD-34341): copy doc for /security/assurances

### DIFF
--- a/templates/security/assurances.html
+++ b/templates/security/assurances.html
@@ -245,6 +245,8 @@
       <hr class="p-rule--muted" />
       <div class="grid-col-4 grid-col-start-large-5 grid-col-medium-2 grid-col-small-2">
         <p>
+          <a href="/pro">Explore the benefits of Ubuntu Pro ›</a>
+          <br />
           <a href="/pro/free-trial">Try Ubuntu Pro for 30 days ›</a>
         </p>
       </div>
@@ -351,71 +353,84 @@
     </div>
   </section>
 
-  <section class="p-section--deep">
-    <div class="grid-row">
-      <hr class="p-rule" />
-      <div class="grid-col-2">
-        <h2>Resources</h2>
+  <section class="p-section u-fixed-width">
+    <hr class="p-rule">
+    <div class="p-section--shallow">
+      <div class="grid-row--50-50-on-large">
+        <div class="grid-col">
+          <h2>Resources</h2>
+        </div>
+
+        <div class="grid-col">
+          <p> Ubuntu Pro is Canonical’s comprehensive subscription for open source security, support, and compliance.
+            Get access to a trusted open source repository, compliance profiles for the most stringent security standards,
+            and up to 15 years of vulnerability fixes for your OS, infrastructure, and applications.
+          </p>
+        </div>
       </div>
-      <div class="grid-col-6 grid-col-medium-4">
-        <div class="grid-row">
-          <div class="grid-col-4 grid-col-medium-2 grid-col-start-large-3 grid-col-start-medium-3">
-            <p>
-              Ubuntu Pro is Canonical’s comprehensive subscription for open source security, support, and compliance. Get access to a trusted open source repository, compliance profiles for the most stringent security standards, and up to 15 years of vulnerability fixes for your OS, infrastructure, and applications.
-            </p>
-          </div>
+    </div>
+    <div class="p-section--shallow">
+      <div class="grid-row">
+        <div class="grid-col-2 grid-col-start-large-3">
+          <h3 class="p-heading--5">Ubuntu Pro features</h3>
         </div>
-        <div class="grid-row">
-          <div class="grid-col-2 grid-col-medium-2">
-            <h3 class="p-heading--5">Ubuntu Pro features</h3>
-          </div>
-          <div class="grid-col-4 grid-col-medium-2 grid-col-start-medium-3">
-            <p>
-              <a href="/security/esm">ESM</a>
-            </p>
-            <hr class="p-rule--muted" />
-            <p>
-              <a href="/security/livepatch">Livepatch</a>
-            </p>
-            <hr class="p-rule--muted" />
-            <p>
-              <a href="/security/security-standards">Standards Compliance</a>
-            </p>
-            <hr class="p-rule--muted" />
-            <p>
-              <a href="/landscape">Landscape</a>
-            </p>
-          </div>
+
+        <div class="grid-col-4">
+          <p>
+            <a href="/security/esm">ESM</a>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/security/livepatch">Livepatch</a>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/security/security-standards">Standards Compliance</a>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/landscape">Landscape</a>
+          </p>
         </div>
-        <hr class="p-rule--muted" />
-        <div class="grid-row">
-          <div class="grid-col-2 grid-col-medium-2">
-            <h3 class="p-heading--5">Technical documentation</h3>
-          </div>
-          <div class="grid-col-4 grid-col-medium-2 grid-col-start-medium-3">
-            <p>
-              <a href="https://documentation.ubuntu.com/server/how-to/security/">Ubuntu Server Security documentation</a>
-            </p>
-          </div>
+      </div>
+      <div class="grid-row">
+        <div class="grid-col-6 grid-col-start-large-3">
+          <hr class="is-muted">
         </div>
-        <hr class="p-rule--muted" />
-        <div class="grid-row">
-          <div class="grid-col-2 grid-col-medium-2">
-            <h3 class="p-heading--5">Security articles</h3>
-          </div>
-          <div class="grid-col-4 grid-col-medium-2 grid-col-start-medium-3">
-            <p>
-              <a href="/blog/a-comprehensive-guide-to-nis2-compliance-part-1-understanding-nis2-and-its-scope">A comprehensive guide to NIS2 Compliance: Part 1 – Understanding NIS2 and its scope</a>
-            </p>
-            <hr class="p-rule--muted" />
-            <p>
-              <a href="/blog/canonical-announces-ubuntu-security-research-alliance-program">Canonical announces Ubuntu Security Research Alliance Program</a>
-            </p>
-            <hr class="p-rule--muted" />
-            <p>
-              <a href="/blog/what-is-system-hardening-definition-and-best-practices">What is System Hardening? Essential Checklists from OS to Applications</a>
-            </p>
-          </div>
+      </div>
+      <div class="grid-row">
+        <div class="grid-col-2 grid-col-start-large-3">
+          <h3 class="p-heading--5">Technical documentation</h3>
+        </div>
+
+        <div class="grid-col-4">
+          <p>
+            <a href="https://documentation.ubuntu.com/server/how-to/security/">Ubuntu Server Security documentation</a>
+          </p>
+        </div>
+      </div>
+      <div class="grid-row">
+        <div class="grid-col-6 grid-col-start-large-3">
+          <hr class="is-muted">
+        </div>
+      </div>
+      <div class="grid-row">
+        <div class="grid-col-2 grid-col-start-large-3">
+          <h3 class="p-heading--5">Security articles</h3>
+        </div>
+
+        <div class="grid-col-4">
+          <p>
+            <a href="/blog/a-comprehensive-guide-to-nis2-compliance-part-1-understanding-nis2-and-its-scope">A comprehensive guide to NIS2 Compliance: Part 1 – Understanding NIS2 and its scope</a>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/blog/canonical-announces-ubuntu-security-research-alliance-program">Canonical announces Ubuntu Security Research Alliance Program</a>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/blog/what-is-system-hardening-definition-and-best-practices">What is System Hardening? Essential Checklists from OS to Applications</a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

 - Copy updates for /security/assurances  

## Issue / Card
[WD-34341](https://warthogs.atlassian.net/browse/WD-34341)
[copydoc](https://docs.google.com/document/d/1hQ-n0FrjzQGAOUzIAshzxwhu5PpBC2ClBJMNSMO90Zo/edit?usp=sharing )
[demo](https://ubuntu-com-16095.demos.haus/security/assurances)

## QA
- Check out the [demo](https://ubuntu-com-16095.demos.haus/security/assurances) and verify it contains all changes requested in [copydoc](https://docs.google.com/document/d/1hQ-n0FrjzQGAOUzIAshzxwhu5PpBC2ClBJMNSMO90Zo/edit?usp=sharing )
- Have a good day :)

#### Worth noting
 - I've added a missing comma for "...(OVAL, OSV, and VEX). ..." Additionally in the second place this snippet occurs (added my comment to the copydoc)
 - Please verify that the long text added to the "Resources" section matches our design requirements.

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-34341]: https://warthogs.atlassian.net/browse/WD-34341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
