### PR TITLE
WD-34597 - Move CTA in /support to separate line

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -37,6 +37,8 @@
           <a href="/support/contact-us?product=support-overview"
              class="p-button--positive">Get in touch</a>
           <a href="/pro/subscribe">Buy support with Ubuntu Pro&nbsp;&rsaquo;</a>
+        </p>
+        <p>
           If you are already a support customer, <a href="https://support-portal.canonical.com/">get help from the Support Portal&nbsp;&rsaquo;</a>
         </p>
       </div>


### PR DESCRIPTION
## Done

- Moved CTA to new line as requested in the Jira ticket.

## QA

- Open the [DEMO](https://ubuntu-com-16096.demos.haus/support)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the text `If you are already a support customer...` appears on a line under the "Get in touch" button.

## Issue / Card

Fixes [WD-34597](https://warthogs.atlassian.net/browse/WD-34597)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-34597]: https://warthogs.atlassian.net/browse/WD-34597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
