### PR TITLE
WD-34599 download/nvidia-jetson

### DIFF
--- a/templates/download/nvidia-jetson/index.html
+++ b/templates/download/nvidia-jetson/index.html
@@ -110,6 +110,42 @@
         <hr class="p-rule" />
         <div class="row">
           <div class="col-3">
+            <h2 class="p-text--small-caps">Release Maturity Levels Explained</h2>
+          </div>
+          <div class="col-6">
+            <div>
+              <ul class="p-list--divided u-no-margin--bottom">
+                <li class="p-list__item has-bullet">
+                  <strong>Early Access</strong>: A preliminary Ubuntu image<span aria-describedby="footnote-1">*</span> for early adopters and developers.
+                  <em>Use to validate hardware enablement and start development early.</em>
+                </li>
+                <li class="p-list__item has-bullet">
+                  <strong>Beta</strong>: A stable Ubuntu image<span aria-describedby="footnote-1">*</span> with the majority of features integrated and validated.
+                  <em>Use to build prototypes and test applications. Not for production deployment.</em>
+                </li>
+                <li class="p-list__item has-bullet">
+                  <strong>Certified</strong>: A production-grade Ubuntu image<span aria-describedby="footnote-1">*</span>. This is a feature-complete, quality-assured release. Long-term support from Canonical available with Ubuntu Pro.
+                  <em>Use for production deployments.</em>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <p id="footnote-1">
+                *check the release notes for supported features and known issues.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3">
             <h2 class="p-text--small-caps">Are you working on a commercial project?</h2>
           </div>
           <div class="col-6">

--- a/templates/download/nvidia-jetson/tab-4-jetson-agx-thor.html
+++ b/templates/download/nvidia-jetson/tab-4-jetson-agx-thor.html
@@ -25,7 +25,7 @@
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server 24.04</h3>
     </div>
     <div class="col-6">
-      <p class="u-no-padding--top">This is Ubuntu Server 24.04 certified.</p>
+      <p class="u-no-padding--top">This is the Ubuntu Server 24.04 certified release on Jetson AGX Thor Platform.</p>
       <hr class="p-rule--muted" />
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
@@ -52,7 +52,7 @@
         Get started with Ubuntu 24.04 for <a href="https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor/">Jetson AGX Thor</a>
       </p>
       <p>
-        <a href="https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/classic/release-note-noble-thor-ga/">Ubuntu 24.04 for NVIDIA Jetson Thor Early Access Release Notes</a>
+        <a href="https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/classic/release-note-noble-thor-ga/">Ubuntu 24.04 for NVIDIA Jetson Thor Release Notes</a>
         <br />
         <a href="https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/how-to/flash/">Program an Ubuntu on NVIDIA Jetson Thor AGX</a>
       </p>


### PR DESCRIPTION
## Done

- Updated jetson-agx-thor tab
- Created "Release Maturity Levels Explained" section
    - Purposely did not use basic section pattern to keep consistency as the rest of the page is using old grid

## QA

- Open the [DEMO](https://ubuntu-com-16098.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

[WD-34599](https://warthogs.atlassian.net/browse/WD-34599)


[WD-34599]: https://warthogs.atlassian.net/browse/WD-34599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
