### PR TITLE
chore: Apply redirects for stale UA tutorials

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1144,6 +1144,8 @@ download/desktop/questions/?: /download/desktop/thank-you
 tutorials/tutorial/(?P<path>.*)/?: /tutorials/{path}
 t/(?P<path>.*)/?: /tutorials/{path}
 tutorial/(?P<path>.*)/?: /tutorials/{path}
+tutorials/audit-ua-client-esm-configurations-at-scale-with-landscape/?: https://documentation.ubuntu.com/pro-client/en/latest/tutorials/security-with-pro/
+tutorials/using-the-ua-client-to-enable-the-cis-benchmarking-tool/?: https://documentation.ubuntu.com/pro-client/en/latest/howtoguides/enable_cis/
 tutorials/microstack-get-started?: https://canonical-openstack.readthedocs-hosted.com/en/latest/tutorial/
 tutorials/install-openstack-with-conjure-up?: https://canonical-openstack.readthedocs-hosted.com/en/latest/tutorial/
 tutorials/electron-kiosk/?: https://canonical.com/mir/docs/make-a-secure-ubuntu-web-kiosk


### PR DESCRIPTION
## Done

- Applied redirects as per ticket

## QA

- Visit https://ubuntu-com-16106.demos.haus/tutorials/audit-ua-client-esm-configurations-at-scale-with-landscape and see that you are redirected to https://documentation.ubuntu.com/pro-client/en/latest/tutorials/security-with-pro/
- Visit https://ubuntu-com-16106.demos.haus/tutorials/using-the-ua-client-to-enable-the-cis-benchmarking-tool and see that you are redirected to https://documentation.ubuntu.com/pro-client/en/latest/howtoguides/enable_cis/

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34641 ,  https://github.com/canonical/ubuntu.com/issues/13041
