### PR TITLE
chore: bump discourse to 7.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse==7.1.1
+canonicalwebteam.discourse==7.2.0
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 python-dateutil==2.8.2


### PR DESCRIPTION
## Done

- Bump to discourse [7.2.0](https://github.com/canonical/canonicalwebteam.discourse/pull/221). This adds handling for sentry_sdk

## QA

- Open the [DEMO](https://ubuntu-com-16114.demos.haus/engage)
- See that it loads

