### PR TITLE
Updating Pro Desktop support from 10 to 15 years on /desktop/developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -62,7 +62,7 @@
             Tools, such as <a href="https://juju.is/">Juju</a>, <a href="https://microk8s.io/">Microk8s</a>, and <a href="https://multipass.run/">Multipass</a> make developing, testing, and cross-building easy and affordable.
           </li>
           <li class="p-list__item is-ticked">
-            <strong>Long term support (LTS)</strong> releases are delivered every 2 years, with 5 years of standard support extended to 10 years with an Ubuntu Pro Desktop subscription.
+            <strong>Long term support (LTS)</strong> releases are delivered every 2 years, with 5 years of standard support extended up to 15 years with an Ubuntu Pro Desktop subscription.
           </li>
           <li class="p-list__item is-ticked">
             New Developer editions of Ubuntu Desktop are released every 6 months, with 9 months of support and access to the latest kernel, libraries, and new upstream OS features.


### PR DESCRIPTION
Updated the duration of Pro Desktop support.

## Done

- Text change of a few words. "to 10" -> "up to 15".

## QA

- Open the [DEMO](https://ubuntu-com-16115.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

