### PR TITLE
chore: Remove dead link on /cloud

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -79,7 +79,7 @@
           <div class="col-6 col-medium-3">
             <ul class="p-list--divided">
               <li class="p-list__item is-ticked">
-                If run efficiently and well-utilised, private clouds are often <a href="https://go.451research.com/Emerging-pricing-model-for-private-cloud">more cost-effective</a> for equivalent resources than public clouds.
+                If run efficiently and well-utilised, private clouds are often more cost-effective for equivalent resources than public clouds.
               </li>
               <li class="p-list__item is-ticked">
                 An organisation with a private cloud does not share its hosting resources with other organisations meaning in general, private clouds provide better performance.
@@ -163,7 +163,7 @@
           <div class="col-6 col-medium-3">
             <ul class="p-list--divided">
               <li class="p-list__item is-crossed">
-                <a href="https://go.451research.com/Emerging-pricing-model-for-private-cloud">Can be more expensive</a> than an efficiently-managed and well-utilised private cloud.
+                Can be more expensive than an efficiently-managed and well-utilised private cloud.
               </li>
               <li class="p-list__item is-crossed">
                 In addition to the compute costs, there can be unexpected ancillary costs like egress (taking your data out of the cloud)


### PR DESCRIPTION
## Done

- Removed failing link
  - Note: there's no copy doc for this template yet, approval to remove instead of replace the link for now given by pdm [here](https://warthogs.atlassian.net/browse/WD-34509?focusedCommentId=1034908)

## QA

- See that the offending link has been removed [here](https://ubuntu-com-16117.demos.haus/cloud#:~:text=If%20run%20efficiently%20and%20well%2Dutilised%2C%20private%20clouds%20are%20often%20more%20cost%2Deffective%20for%20equivalent%20resources%20than%20public%20clouds.) and [here](https://ubuntu-com-16117.demos.haus/cloud#:~:text=Can%20be%20more%20expensive%20than%20an%20efficiently%2Dmanaged%20and%20well%2Dutilised%20private%20cloud.)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34509
