### PR TITLE
fix: error handling for blog article retrieval and improve retry error logging

### DIFF
--- a/tests/test_sentry_filtering.py
+++ b/tests/test_sentry_filtering.py
@@ -306,7 +306,6 @@ class TestSentryFiltering(unittest.TestCase):
             "requests.exceptions.ConnectionError should also be sampled",
         )
 
-
     @patch("webapp.app.random.random")
     def test_sample_blog_api_retry_error_drops_95_percent(self, mock_random):
         """
@@ -384,10 +383,7 @@ class TestSentryFiltering(unittest.TestCase):
 
         mock_error = MaxRetryError(
             pool=None,
-            url=(
-                "/wp-json/wp/v2/posts?slug=test"
-                "&tags_exclude=3184"
-            ),
+            url=("/wp-json/wp/v2/posts?slug=test" "&tags_exclude=3184"),
             reason=(
                 "ResponseError('too many 503 error responses')"
                 " admin.insights.ubuntu.com"
@@ -402,7 +398,6 @@ class TestSentryFiltering(unittest.TestCase):
             result,
             "MaxRetryError from blog API should also be sampled",
         )
-
 
     def test_blog_api_connection_timeout_not_filtered(self):
         """

--- a/tests/test_sentry_filtering.py
+++ b/tests/test_sentry_filtering.py
@@ -307,5 +307,126 @@ class TestSentryFiltering(unittest.TestCase):
         )
 
 
+    @patch("webapp.app.random.random")
+    def test_sample_blog_api_retry_error_drops_95_percent(self, mock_random):
+        """
+        Test that RetryError from blog API
+        (admin.insights.ubuntu.com) is sampled at 5% (95% dropped).
+        """
+        mock_random.return_value = 0.96
+
+        mock_error = RetryError()
+        mock_error.args = (
+            "HTTPSConnectionPool(host='admin.insights.ubuntu.com', port=443):"
+            " Max retries exceeded with url: /wp-json/wp/v2/posts?slug=test"
+            " (Caused by ResponseError('too many 503 error responses'))",
+        )
+
+        hint = {"exc_info": (None, mock_error, None)}
+        event = {"level": "error"}
+        result = sentry_before_send(event, hint)
+
+        self.assertIsNone(
+            result, "95% of blog API RetryErrors should be dropped"
+        )
+
+    @patch("webapp.app.random.random")
+    def test_sample_blog_api_retry_error_keeps_5_percent(self, mock_random):
+        """
+        Test that RetryError from blog API keeps 5% of errors.
+        """
+        mock_random.return_value = 0.04
+
+        mock_error = RetryError()
+        mock_error.args = (
+            "HTTPSConnectionPool(host='admin.insights.ubuntu.com', port=443):"
+            " Max retries exceeded with url: /wp-json/wp/v2/posts?slug=test"
+            " (Caused by ResponseError('too many 503 error responses'))",
+        )
+
+        hint = {"exc_info": (None, mock_error, None)}
+        event = {"level": "error"}
+        result = sentry_before_send(event, hint)
+
+        self.assertEqual(
+            result, event, "5% of blog API RetryErrors should be kept"
+        )
+
+    @patch("webapp.app.random.random")
+    def test_blog_api_connection_error_also_sampled(self, mock_random):
+        """
+        Test that ConnectionError from blog API is also sampled.
+        """
+        mock_random.return_value = 0.96
+
+        mock_error = RequestsConnectionError()
+        mock_error.args = (
+            "HTTPSConnectionPool(host='admin.insights.ubuntu.com', port=443):"
+            " Max retries exceeded with url: /wp-json/wp/v2/posts?slug=test"
+            " (Caused by ResponseError('too many 503 error responses'))",
+        )
+
+        hint = {"exc_info": (None, mock_error, None)}
+        event = {"level": "error"}
+        result = sentry_before_send(event, hint)
+
+        self.assertIsNone(
+            result,
+            "ConnectionError from blog API should also be sampled",
+        )
+
+    @patch("webapp.app.random.random")
+    def test_blog_api_max_retry_error_also_sampled(self, mock_random):
+        """
+        Test that MaxRetryError from blog API is also sampled.
+        """
+        mock_random.return_value = 0.96
+
+        mock_error = MaxRetryError(
+            pool=None,
+            url=(
+                "/wp-json/wp/v2/posts?slug=test"
+                "&tags_exclude=3184"
+            ),
+            reason=(
+                "ResponseError('too many 503 error responses')"
+                " admin.insights.ubuntu.com"
+            ),
+        )
+
+        hint = {"exc_info": (None, mock_error, None)}
+        event = {"level": "error"}
+        result = sentry_before_send(event, hint)
+
+        self.assertIsNone(
+            result,
+            "MaxRetryError from blog API should also be sampled",
+        )
+
+
+    def test_blog_api_connection_timeout_not_filtered(self):
+        """
+        Test that blog API errors without 500/502/503/504 status codes
+        (e.g. connection timeouts) are NOT filtered.
+        """
+        mock_error = RequestsConnectionError()
+        mock_error.args = (
+            "HTTPSConnectionPool(host='admin.insights.ubuntu.com', port=443):"
+            " Max retries exceeded with url: /wp-json/wp/v2/posts?slug=test"
+            " (Caused by ConnectTimeoutError('connection timed out'))",
+        )
+
+        hint = {"exc_info": (None, mock_error, None)}
+        event = {"level": "error"}
+        result = sentry_before_send(event, hint)
+
+        self.assertEqual(
+            result,
+            event,
+            "Blog API errors without 5xx status codes "
+            "should not be filtered",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -317,9 +317,7 @@ def sentry_before_send(event, hint):
                 f"{code} error" in error_msg
                 for code in ["500", "502", "503", "504"]
             ):
-                if (
-                    random.random() > 0.05
-                ):  # Drop 95% of blog API retry errors
+                if random.random() > 0.05:  # Drop 95% of blog API retry errors
                     return None
 
     return event

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -283,7 +283,8 @@ def sentry_before_send(event, hint):
     """
     Filter Sentry events.
     Excludes all 4xx errors.
-    Samples MaxRetryError from security API calls to reduce quota usage.
+    Samples retry errors from security and
+    blog/WordPress API calls to reduce quota usage.
     """
     if "exc_info" in hint:
         _, exc_value, _ = hint["exc_info"]
@@ -313,7 +314,7 @@ def sentry_before_send(event, hint):
                     return None
 
             # Sample blog/WordPress API retry errors
-            if "admin.insights.ubuntu.com" in error_msg and any(
+            if "/wp-json/wp/v2" in error_msg and any(
                 f"{code} error" in error_msg
                 for code in ["500", "502", "503", "504"]
             ):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -313,7 +313,10 @@ def sentry_before_send(event, hint):
                     return None
 
             # Sample blog/WordPress API retry errors
-            if "admin.insights.ubuntu.com" in error_msg:
+            if "admin.insights.ubuntu.com" in error_msg and any(
+                f"{code} error" in error_msg
+                for code in ["500", "502", "503", "504"]
+            ):
                 if (
                     random.random() > 0.05
                 ):  # Drop 95% of blog API retry errors

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -297,7 +297,7 @@ def sentry_before_send(event, hint):
             # return None to discard the event
             return None
 
-        # Sample MaxRetryError from security API calls
+        # Sample MaxRetryError from security and blog API calls
         if isinstance(
             exc_value, (MaxRetryError, RetryError, RequestsConnectionError)
         ):
@@ -310,6 +310,13 @@ def sentry_before_send(event, hint):
                 if (
                     random.random() > 0.05
                 ):  # Drop 95% of security API retry errors
+                    return None
+
+            # Sample blog/WordPress API retry errors
+            if "admin.insights.ubuntu.com" in error_msg:
+                if (
+                    random.random() > 0.05
+                ):  # Drop 95% of blog API retry errors
                     return None
 
     return event

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -748,7 +748,16 @@ class BlogView(flask.views.View):
 class BlogRedirects(BlogView):
     def dispatch_request(self, slug):
         slug = quote(slug, safe="/:?&")
-        context = self.blog_views.get_article(slug)
+
+        try:
+            context = self.blog_views.get_article(slug)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.HTTPError,
+        ):
+            sentry_sdk.capture_exception()
+            flask.abort(502)
 
         if "article" not in context:
             return flask.abort(404)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -756,9 +756,7 @@ class BlogRedirects(BlogView):
             Timeout,
             HTTPError,
         ):
-            return flask.make_response(
-                flask.render_template("500.html"), 502
-            )
+            return flask.make_response(flask.render_template("500.html"), 502)
 
         if "article" not in context:
             return flask.abort(404)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -31,7 +31,7 @@ from canonicalwebteam.search.views import NoAPIKeyError
 from canonicalwebteam.directory_parser import generate_sitemap
 from geolite2 import geolite2
 from requests import Session
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError, Timeout
 from ubuntu_release_info.data import Data
 from werkzeug.exceptions import BadRequest
 from canonicalwebteam.flask_base.env import get_flask_env
@@ -752,12 +752,13 @@ class BlogRedirects(BlogView):
         try:
             context = self.blog_views.get_article(slug)
         except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
-            requests.exceptions.HTTPError,
+            ConnectionError,
+            Timeout,
+            HTTPError,
         ):
-            sentry_sdk.capture_exception()
-            flask.abort(502)
+            return flask.make_response(
+                flask.render_template("500.html"), 502
+            )
 
         if "article" not in context:
             return flask.abort(404)


### PR DESCRIPTION
 BlogRedirects.dispatch_request has no error handling around the WordPress API call
   (admin.insights.ubuntu.com). When the API returns repeated 503s, the             
  ConnectionError propagates unhandled — resulting in noisy unhandled exceptions in Sentry. 

## Done
 - webapp/views.py: Wrap the get_article() call in BlogRedirects with a try/except
  for ConnectionError, Timeout, and HTTPError. 
  - webapp/app.py: Extend sentry_before_send to sample out 95% of blog/WordPress API
   retry errors matching /wp-json/wp/v2 with 500/502/503/504 status codes.
  - tests/test_sentry_filtering.py: Add 5 tests covering the new blog API sampling
  branch — drops, keeps, ConnectionError/MaxRetryError variants, and a negative case
   for non-5xx errors.

## QA

- Open the [DEMO](https://ubuntu-com-16118.demos.haus/blog)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

