### PR TITLE
fix: meta title incorrectly rendering on individual vulnerabilities pages

### DIFF
--- a/templates/security/vulnerabilities/vulnerability-detailed.html
+++ b/templates/security/vulnerabilities/vulnerability-detailed.html
@@ -1,6 +1,6 @@
 {% extends "security/base_security.html" %}
 
-{% block title %}Vulnerability Knowledge Base | document.title{% endblock %}
+{% block title %}Vulnerability Knowledge Base | {{ document.title }}{% endblock %}
 
 {% block meta_description %}{{ document.sections[0].title }}{% endblock %}
 


### PR DESCRIPTION
## Done

- meta title incorrectly rendering on individual vulnerabilities pages

## QA

- Open the [DEMO](https://ubuntu-com-16122.demos.haus//security/vulnerabilities/vmscape)
- Check the meta title contains the name of the vulnerability and not 'document.title'

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34795

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

