### PR TITLE
Create new redirect to mini.iso for AMI

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1284,3 +1284,4 @@ openstack/openstack-cheat-sheet/?: /engage/openstack-commands-cheat-sheet
 # Redirects for mini-iso
 noble/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/ubuntu-mini-iso-24.04.4-mini-iso-amd64.iso"
 resolute/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/resolute/release/ubuntu-mini-iso-26.04-mini-iso-amd64.iso"
+AMI/MiniISO: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/ubuntu-mini-iso-24.04.4-mini-iso-amd64.iso"


### PR DESCRIPTION
Providing a simple url redirect for AMI to point to our latest LTS At this moment this will point to 24.04.4

## Done

- Added a single line redirect from ubuntu.com/AMI/MiniISO to the latest 24.04.4 mini.iso

## QA

None

## Issue / Card

None

## Screenshots

None

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
