### PR TITLE
feat: add edge-fan suru for engage pages

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -65,4 +65,16 @@
     );
     color: $color-x-light;
   }
+
+  @include p-engage-banner("edge-fan") {
+    background-color: #262628;
+    color: $color-x-light;
+
+    @media screen and (min-width: $breakpoint-large) {
+      background-image: url("https://assets.ubuntu.com/v1/90c93cd6-suru_edge_fan_bottom_dark_engage_hero.jpg");
+      background-position: right bottom;
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Adds a new suru for enage pages, `edge-fan`, using this [background](https://assets.ubuntu.com/v1/90c93cd6-suru_edge_fan_bottom_dark_engage_hero.jpg)

## QA

- Open the [DEMO](https://ubuntu-com-16133.demos.haus/engage/test-whitepaper)
- See it is using [this suru](https://assets.ubuntu.com/v1/90c93cd6-suru_edge_fan_bottom_dark_engage_hero.jpg)
- Check on different screen size, it should hide on medium/small screens

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-35093
