### PR TITLE
chore(WD-35047): Update copytext for aws support page

### DIFF
--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -45,10 +45,12 @@
           "aspect_ratio": "",
           "is_highlighted": false,
           "is_cover": true,
-          "attrs": {
-            "src": "https://assets.ubuntu.com/v1/7d50bc74-ubuntu_pro-aws.svg",
-            "alt": "Ubuntu Pro and AWS logo"
-          }
+          "attrs": image(url="https://assets.ubuntu.com/v1/7d50bc74-ubuntu_pro-aws.svg",
+                    alt="Ubuntu Pro and AWS logo",
+                    width="230",
+                    height="104",
+                    hi_def=True,
+                    loading="auto", output_mode="attrs")
         }
       },
     ]


### PR DESCRIPTION
## Done

- Updated based on [this copydoc](https://docs.google.com/document/d/1j_gH-pU1ldCGSoJ8EwXPtSFqhdS1zEY8mXUAqSDxK2U/edit?tab=t.0).

## QA

- Open the [DEMO](https://ubuntu-com-16134.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/support
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure changes are consistent with copydoc.

## Issue / Card

Fixes [WD-35047](https://warthogs.atlassian.net/browse/WD-35047) [WD-35047](https://warthogs.atlassian.net/browse/WD-35047)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-35047]: https://warthogs.atlassian.net/browse/WD-35047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
