### PR TITLE
Copy update: /aws/pro

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -3,7 +3,7 @@
 {% block title %}Ubuntu Pro for AWS{% endblock %}
 
 {% block meta_description %}
-  Ubuntu Pro for AWS, the Ubuntu image optimised for production and professional use on public cloud. Including broad security coverage, live kernel patching, certified components with hardening profiles, and backed by a 10-years maintenance commitment by Canonical. Get it on the AWS marketplace.
+  Ubuntu Pro for AWS, the Ubuntu image optimized for production and professional use on public cloud. Including live kernel patching, certified components with hardening profiles, and backed by up to 15 years of security maintenance.
 {% endblock %}
 
 {% block meta_copydoc %}
@@ -162,7 +162,7 @@
             <div class="list-matrix">
               <div class="list-matrix-container">
                 <p class="p-heading--5">FIPS &amp; CC-EAL2 certified</p>
-                <p>Certified components to enable operating environments under compliance regimes like FedRAMP, HIPAA, PCI and ISO.</p>
+                <p>Certified components to enable operating environments under compliance regimes like FedRAMP, HIPAA, PCI, and ISO.</p>
               </div>
             </div>
           </div>
@@ -183,7 +183,7 @@
               <div class="list-matrix-container">
                 <p class="p-heading--5">Open source security</p>
                 <p>
-                  Ubuntu Pro adds security coverage for the most important open source applications like Apache Kafka, NGINX, MongoDB, Redis and PostgreSQL.
+                  Ubuntu Pro adds security coverage for the most important open source applications like Apache Kafka, NGINX, MongoDB, Redis, and PostgreSQL.
                 </p>
               </div>
             </div>
@@ -198,9 +198,9 @@
           <div class="col-3 col-medium-2">
             <div class="list-matrix">
               <div class="list-matrix-container">
-                <p class="p-heading--5">Predictable and optimised</p>
+                <p class="p-heading--5">Predictable and optimized</p>
                 <p>
-                  Ubuntu Pro is based on Ubuntu and leverages both the breadth of open source included and the AWS optimisations built in.
+                  Ubuntu Pro is based on Ubuntu and leverages both the breadth of open source included and the AWS optimizations built in.
                 </p>
               </div>
             </div>
@@ -222,7 +222,7 @@
               <div class="list-matrix-container">
                 <p class="p-heading--5">Priced for the cloud</p>
                 <p>
-                  Ubuntu Pro pricing tracks the underlying EC2 cost, starting at 20% for the smallest t3.nano instances, and ramping down to less than 1%.
+                  Ubuntu Pro's pricing scales with the instance size, as it is based on the instance's vCPUs and metered by the second. Perfect for automation, scaling and all deployment sizes. Customers can also get discounts through AWS Savings Plans.
                 </p>
               </div>
             </div>
@@ -239,7 +239,7 @@
               <div class="list-matrix-container">
                 <p class="p-heading--5">The right Ubuntu for you</p>
                 <p>
-                  Canonical brings the most popular Ubuntu Server distributions to choose from - 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS.
+                  Choose from the latest Ubuntu Server LTS release, minimal Ubuntu, CIS-hardened Ubuntu, or one of many fully-supported earlier LTS versions.
                 </p>
               </div>
             </div>
@@ -248,9 +248,9 @@
             <hr class="u-hide--large u-hide--medium p-rule--muted" />
             <div class="list-matrix">
               <div class="list-matrix-container">
-                <p class="p-heading--5">10-year lifetime</p>
+                <p class="p-heading--5">Up to 15-year lifetime</p>
                 <p>
-                  Canonical backs Ubuntu Pro for 10 years, ensuring security updates are available throughout, with a guaranteed upgrade path.
+                  Canonical backs Ubuntu Pro for up to 15 years, ensuring security updates are available throughout, with a guaranteed upgrade path.
                 </p>
               </div>
             </div>
@@ -260,7 +260,7 @@
             <div class="list-matrix">
               <div class="list-matrix-container">
                 <p class="p-heading--5">Optional 24/7 support</p>
-                <p>Additional enterprise-grade support available through private offer for Pro.</p>
+                <p>Additional enterprise-grade support available through private offer.</p>
               </div>
             </div>
           </div>
@@ -294,12 +294,12 @@
             <tr>
               <td>ESM-Infra</td>
               <td>All LTS</td>
-              <td>18.04, 20.04, 22.04</td>
+              <td>All LTS</td>
             </tr>
             <tr>
               <td>ESM-Apps</td>
               <td>All LTS</td>
-              <td>18.04, 20.04, 22.04</td>
+              <td>All LTS</td>
             </tr>
             <tr>
               <td>Livepatch</td>
@@ -308,23 +308,23 @@
             </tr>
             <tr>
               <td>USG</td>
-              <td>16.04, 18.04, 20.04, 22.04</td>
-              <td>22.04 (CIS)</td>
+              <td>All LTS</td>
+              <td>22.04, 24.04</td>
             </tr>
             <tr>
               <td>FIPS</td>
-              <td>16.04, 18.04 and 20.04</td>
-              <td>Coming soon</td>
-            </tr>
-            <tr>
-              <td>FIPS-Updates</td>
-              <td>16.04, 18.04 and 20.04</td>
-              <td>Coming soon</td>
+              <td>16.04, 18.04, 20.04 and 22.04</td>
+              <td>22.04</td>
             </tr>
             <tr>
               <td>FIPS-Preview</td>
-              <td>22.04</td>
-              <td>22.04</td>
+              <td>24.04</td>
+              <td>24.04</td>
+            </tr>
+            <tr>
+              <td>Realtime-kernel</td>
+              <td>22.04, 24.04</td>
+              <td>22.04, 24.04</td>
             </tr>
           </tbody>
         </table>
@@ -353,7 +353,7 @@
           </div>
         </div>
         <p>
-          The FIPS certified Ubuntu Pro image is now available on AWS. Ubuntu Pro FIPS is the critical foundation for state agencies administering federal programs and private sector companies with government contracts. Ubuntu Pro FIPS is built upon the power of Ubuntu Pro's enhanced stability, AWS compliance and security features and is maintained to provide your organisation with the strongest FIPS foundation now and in the future.
+          The FIPS certified Ubuntu Pro image is now available on AWS. Ubuntu Pro FIPS is the critical foundation for state agencies administering federal programs and private sector companies with government contracts. Ubuntu Pro FIPS is built upon the power of Ubuntu Pro's enhanced stability, AWS compliance, and security features and is maintained to provide your organization with the strongest FIPS foundation now and in the future.
         </p>
         <hr class="is-muted" />
         <p>
@@ -373,11 +373,12 @@
     <div class="row--50-50">
       <div class="col">
         <p>
-          Ubuntu Pro includes security coverage for the entire collection of software packages shipped with Ubuntu, tracking high and critical CVEs. Ideal for companies that have embraced open source for their new products.
+          Ubuntu Pro includes security coverage for the entire collection of software packages shipped with Ubuntu, tracking high and critical CVEs. This comprehensive security, support, and compliance subscription is ideal for companies that have embraced open source for their new products.
         </p>
         <p>
-          Developers choose Ubuntu because it includes a set of open source packages known as 'universe'. These include NGINX, MongoDB, Redis, Kafka&hellip; with Ubuntu Pro, CIOs and security officers can be confident they can roll these packages out to production.
+          Developers choose Ubuntu because it includes a set of open source packages known as 'universe'. These include NGINX, MongoDB, Redis, Kafka, and many, many more. With Ubuntu Pro, CIOs and security officers can be confident they can roll these packages out to production.
         </p>
+        <a href="/pro/why-pro">Learn why organizations choose Ubuntu Pro&nbsp;&rsaquo;</a>
       </div>
       <div class="col">
         <div class="p-section--shallow">
@@ -410,7 +411,7 @@
       <div class="col-6 col-medium-4 p-section--shallow">
         <blockquote style="border-left: none;">
           <p class="p-heading--4">
-            <i>The new Ubuntu Pro images will deliver a further optimised experience to our customers, providing additional security and performance to their Ubuntu instances, Ubuntu Pro can be purchased, deployed and launched on AWS in a seamless and effortless manner, removing the need for additional provisioning or procurement processes.</i>
+            <i>The new Ubuntu Pro images will deliver a further optimized experience to our customers, providing additional security and performance to their Ubuntu instances, Ubuntu Pro can be purchased, deployed and launched on AWS in a seamless and effortless manner, removing the need for additional provisioning or procurement processes.</i>
           </p>
         </blockquote>
       </div>
@@ -438,7 +439,7 @@
           </thead>
           <tbody>
             <tr>
-              <td>AWS optimised kernel and userspace</td>
+              <td>AWS optimized kernel and userspace</td>
               <td class="u-align--center">
                 <i class="p-icon--success"></i>
               </td>
@@ -481,7 +482,7 @@
             <tr>
               <td>Maintenance commitment</td>
               <td class="u-align--center">5&nbsp;years</td>
-              <td class="u-align--center">10&nbsp;years</td>
+              <td class="u-align--center">Up to 15&nbsp;years (with Legacy add-on)</td>
             </tr>
           </tbody>
         </table>
@@ -538,7 +539,7 @@
           </tbody>
         </table>
         <p>
-          *For complete pricing, <a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw">see Ubuntu Pro 22.04 LTS on the AWS Marketplace&nbsp;&rsaquo;</a>
+          <a href="https://calculator.aws/#/">Visit the AWS price calculator&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done
Updated the Ubuntu Pro for AWS page in line with the [copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit?tab=t.0).

## QA
- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/pro
- Ensure the page is line with the copy doc.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-34718