### PR TITLE
fix: microcloud link resulting in 404

### DIFF
--- a/templates/support/firefighting.html
+++ b/templates/support/firefighting.html
@@ -75,7 +75,7 @@
           </div>
         </div>
         <p>
-          Running a cloud on <a href="/openstack">OpenStack</a> or <a href="/microcloud">MicroCloud</a>, or operating applications such as Kafka, Kubeflow, Spark, or OpenSearch, is complex and demanding. Canonical’s <a href="/managed">fully managed services</a> take that responsibility off your hands &ndash; but in some environments, security or compliance rules mean our engineers can’t access your systems directly.
+          Running a cloud on <a href="/openstack">OpenStack</a> or <a href="https://canonical.com/microcloud">MicroCloud</a>, or operating applications such as Kafka, Kubeflow, Spark, or OpenSearch, is complex and demanding. Canonical’s <a href="/managed">fully managed services</a> take that responsibility off your hands &ndash; but in some environments, security or compliance rules mean our engineers can’t access your systems directly.
         </p>
         <p>
           Firefighting Support is the answer to these restrictions: it gives the support, protection, and confidence you need, while allowing you to operate your own environments with full control and privacy.


### PR DESCRIPTION
## Done

- Fixed a broken link

## QA

- Checkout [demo](https://ubuntu-com-16142.demos.haus/support/firefighting)
- Search and click on `MicroCloud` link
- Verify it opens as expected

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

