### PR TITLE
[WD-35057]: copy update for /gcp/fips

### DIFF
--- a/templates/gcp/fips.html
+++ b/templates/gcp/fips.html
@@ -47,7 +47,7 @@
   <section class="p-section">
     <div class="u-fixed-width p-section--shallow">
       <hr />
-      <h2>Launch Ubuntu Pro FIPS for Google Cloud</h2>
+      <h2>What’s included in Ubuntu Pro FIPS?</h2>
     </div>
     <div class="row">
       <div class="col-start-large-4 col-9 col-medium-6">
@@ -93,7 +93,7 @@
               <div class="list-matrix-container">
                 <p class="p-heading--5">HIPAA, PCI, ISO compliance</p>
                 <p>
-                  Healthcare, financial services, insurance and other organizations that operate in heavily-regulated industries ensure compliance with HIPAA, PCI and ISO.
+                  Healthcare, financial services, insurance, and other organizations that operate in heavily-regulated industries ensure compliance with HIPAA, PCI, and ISO.
                 </p>
               </div>
             </div>
@@ -139,9 +139,9 @@
             <hr class="u-hide--large u-hide--medium p-rule--muted" />
             <div class="list-matrix">
               <div class="list-matrix-container">
-                <p class="p-heading--5">10-year lifetime</p>
+                <p class="p-heading--5">Up to 15-year lifetime</p>
                 <p>
-                  Canonical backs Ubuntu Pro FIPS for 10 years, ensuring security updates are available throughout, with a guaranteed upgrade path.
+                  Canonical backs Ubuntu Pro FIPS for up to 15 years, ensuring security updates are available throughout, with a guaranteed upgrade path.
                 </p>
               </div>
             </div>
@@ -180,7 +180,7 @@
             <h3 class="p-matrix__title">Ubuntu Pro FIPS 22.04 LTS</h3>
             <div class="p-matrix__desc">
               <p>
-                Ubuntu Pro FIPS 22.04 LTS includes a GCP-optimized FIPS-certified 5.15 kernel and other FIPS-certified modules pre-enabled out of the box. It also provides extended security maintenance through April 2032.
+                Ubuntu Pro FIPS 22.04 LTS includes a Google Cloud-optimized FIPS-certified 5.15 kernel and other FIPS-certified modules pre-enabled out of the box. It also provides extended security maintenance through April 2032.
               </p>
               <a class="p-button"
                  href="https://console.cloud.google.com/compute/instancesAdd?imageId=4467206581577450407&imageProjectId=ubuntu-os-pro-cloud">Launch now</a>
@@ -192,7 +192,7 @@
             <h3 class="p-matrix__title">Ubuntu Pro FIPS 20.04 LTS</h3>
             <div class="p-matrix__desc">
               <p>
-                Ubuntu 20.04 LTS includes FIPS-certified 5.4  kernel and other FIPS- certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2030.
+                Ubuntu 20.04 LTS includes a Google Cloud-optimized, FIPS-certified 5.4  kernel and other FIPS-certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2030.
               </p>
               <a class="p-button" href="https://console.cloud.google.com/compute/">Launch now</a>
             </div>
@@ -234,7 +234,7 @@
         </div>
         <h3 class="p-heading--5">Ubuntu Pro FIPS Google Cloud compliance made easy</h3>
         <p class="p-section--shallow">
-          With Google Cloud, US government agencies and their partners have been able to combine unparalleled flexibility, breakthrough innovation, world class security and Google Cloud compliance. However when it comes to running a secure and compliant enterprise Linux on Google Cloud, IT departments are often left with expensive options that sacrifice innovation for compliance.
+          With Google Cloud, US government agencies and their partners have been able to combine unparalleled flexibility, breakthrough innovation, world class security, and Google Cloud compliance. However, when it comes to running a secure and compliant enterprise Linux on Google Cloud, IT departments are often left with expensive options that sacrifice innovation for compliance.
         </p>
         <hr class="is-muted" />
         <p>
@@ -265,7 +265,7 @@
         <tbody>
           <tr>
             <td class="u-align--left" data-heading="Ubuntu LTS">22.04</td>
-            <td data-heading="FIPS certified component">GCP Kernel</td>
+            <td data-heading="FIPS certified component">Google Cloud Kernel</td>
             <td data-heading="Description">Kernel optimized for use in Google Cloud</td>
             <td class="u-align--right" data-heading="Version">5.15</td>
             <td class="u-align--right" data-heading="CMVP Certificate">(pending)</td>
@@ -535,13 +535,6 @@
             </li>
           </ul>
         </div>
-        <div class="col-3">
-          <p class="u-no-margin--bottom">
-            More about Ubuntu Pro FIPS:
-            <br />
-            <a href="https://assets.ubuntu.com/v1/8ad870d4-Ubuntu-Pro-FIPS-for-Google-Cloud-compliance-DS-14-12.22.pdf">Read the datasheet</a>
-          </p>
-        </div>
       </div>
     </div>
   </div>
@@ -567,7 +560,7 @@
         </div>
       </div>
       <p>
-        Ubuntu Pro FIPS images are based on Ubuntu Pro premium images, with security coverage included for the entire collection of software packages shipped with Ubuntu, tracking high and critical CVEs. This makes it ideal for companies that have embraced open source for their new products and need to ensure security for production and mission-critical workloads.
+        Ubuntu Pro FIPS images are based on Ubuntu Pro premium images, with up to 15 years of security coverage included for the entire collection of software packages shipped with Ubuntu, tracking high and critical CVEs. This makes it ideal for companies that have embraced open source for their new products and need to ensure security for production and mission-critical workloads.
       </p>
       <hr class="is-muted" />
       <p>


### PR DESCRIPTION
## Done

- Updated https://ubuntu.com/gcp/fips with this [copy doc](https://docs.google.com/document/d/17Rr6Fdrr7xSPi1g2h7GMTztQUGYqz2hdbNUqK0uQihw/edit?tab=t.0#heading=h.9pfrw3dugcd5)
## QA

- Open the [DEMO](https://ubuntu-com-16144.demos.haus/gcp/fips)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-35057