### PR TITLE
WD-34696: Only send UTMs to Marketo for non-essential cookie consent

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1103,32 +1103,16 @@ def marketo_submit():
     original_form_id = form_fields.get("formid", 4198)
     enrichment_fields["original_form_id"] = original_form_id
 
-    if "formid" not in form_fields:
-        flask.flash(
-            "There was a problem submitting your form.",
-            "contact-form-fail",
-        )
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("enrichment_fields", enrichment_fields)
-            sentry_sdk.capture_message("Marketo form ID missing")
-        return flask.redirect(f"{referrer}#contact-form-fail")
-
-    payload = {
-        "formId": form_fields.pop("formid"),
-        "input": [
-            {
-                "leadFormFields": form_fields,
-                "visitorData": visitor_data,
-                "cookie": flask.request.args.get("mkt", None),
-            }
-        ],
-    }
-
     # Only attach UTM values when the user has consented to
     # non-essential cookies (functionality, performance, or all)
     cookie_consent = flask.request.cookies.get("_cookies_accepted", "unset")
     non_essential_consent = cookie_consent in {
         "functionality", "performance", "all"}
+
+    utm_keys = {
+        "utm_source", "utm_medium", "utm_campaign",
+        "utm_content", "utm_term", "utmcontent",
+    }
 
     encoded_utms = flask.request.cookies.get("utms") or flask.request.form.get(
         "utms"
@@ -1158,6 +1142,50 @@ def marketo_submit():
                     acquisition_url, utm_dict, approved_utms
                 )
                 enrichment_fields["acquisition_url"] = enriched_acquisition_url
+
+    if not non_essential_consent:
+        # Strip utm_* keys from form_fields (e.g. hidden inputs)
+        for key in utm_keys:
+            form_fields.pop(key, None)
+
+        # Strip utm_* keys from enrichment_fields
+        for key in utm_keys:
+            enrichment_fields.pop(key, None)
+
+        # Strip utm_* query params from acquisition_url
+        for target in (form_fields, enrichment_fields):
+            acq_url = target.get("acquisition_url")
+            if acq_url:
+                parsed = urlparse(acq_url)
+                params = parse_qs(parsed.query, keep_blank_values=True)
+                cleaned = {
+                    k: v for k, v in params.items()
+                    if not k.startswith("utm_")
+                }
+                target["acquisition_url"] = urlunparse(
+                    parsed._replace(query=urlencode(cleaned, doseq=True))
+                )
+
+    if "formid" not in form_fields:
+        flask.flash(
+            "There was a problem submitting your form.",
+            "contact-form-fail",
+        )
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("enrichment_fields", enrichment_fields)
+            sentry_sdk.capture_message("Marketo form ID missing")
+        return flask.redirect(f"{referrer}#contact-form-fail")
+
+    payload = {
+        "formId": form_fields.pop("formid"),
+        "input": [
+            {
+                "leadFormFields": form_fields,
+                "visitorData": visitor_data,
+                "cookie": flask.request.args.get("mkt", None),
+            }
+        ],
+    }
 
     enriched_payload = {
         "formId": "4198",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1198,18 +1198,6 @@ def marketo_submit():
         "input": [{"leadFormFields": enrichment_fields}],
     }
 
-    # TODO: Remove after QA - returns payloads without hitting Marketo
-    if flask.request.args.get("dry_run") == "true":
-        return flask.jsonify(
-            {
-                "dry_run": True,
-                "cookie_consent": cookie_consent,
-                "non_essential_consent": non_essential_consent,
-                "payload": payload,
-                "enriched_payload": enriched_payload,
-            }
-        )
-
     try:
         # Send form data
         r = marketo_api.submit_form(payload)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1124,38 +1124,55 @@ def marketo_submit():
         ],
     }
 
+    # Only attach UTM values when the user has consented to
+    # non-essential cookies (functionality, performance, or all)
+    cookie_consent = flask.request.cookies.get("_cookies_accepted", "unset")
+    non_essential_consent = cookie_consent in {
+        "functionality", "performance", "all"}
+
     encoded_utms = flask.request.cookies.get("utms") or flask.request.form.get(
         "utms"
     )
     if encoded_utms:
         form_fields.pop("utms", None)
-        utms = unquote(encoded_utms)
-        utm_dict = dict(i.split(":", 1) for i in utms.split("&"))
-        approved_utms = [
-            "utm_source",
-            "utm_medium",
-            "utm_campaign",
-            "utm_content",
-            "utm_term",
-        ]
-        for k, v in utm_dict.items():
-            if k in approved_utms:
-                if k == "utm_content":
-                    k = "utmcontent"
-                enrichment_fields[k] = v
+        if non_essential_consent:
+            utms = unquote(encoded_utms)
+            utm_dict = dict(i.split(":", 1) for i in utms.split("&"))
+            approved_utms = [
+                "utm_source",
+                "utm_medium",
+                "utm_campaign",
+                "utm_content",
+                "utm_term",
+            ]
+            for k, v in utm_dict.items():
+                if k in approved_utms:
+                    if k == "utm_content":
+                        k = "utmcontent"
+                    enrichment_fields[k] = v
 
-        # Append utm values in acquisition url
-        acquisition_url = enrichment_fields.get("acquisition_url")
-        if acquisition_url:
-            enriched_acquisition_url = enrich_acquisition_url(
-                acquisition_url, utm_dict, approved_utms
-            )
-            enrichment_fields["acquisition_url"] = enriched_acquisition_url
+            # Append utm values in acquisition url
+            acquisition_url = enrichment_fields.get("acquisition_url")
+            if acquisition_url:
+                enriched_acquisition_url = enrich_acquisition_url(
+                    acquisition_url, utm_dict, approved_utms
+                )
+                enrichment_fields["acquisition_url"] = enriched_acquisition_url
 
     enriched_payload = {
         "formId": "4198",
         "input": [{"leadFormFields": enrichment_fields}],
     }
+
+    # TODO: Remove after QA - returns payloads without hitting Marketo
+    if flask.request.args.get("dry_run") == "true":
+        return flask.jsonify({
+            "dry_run": True,
+            "cookie_consent": cookie_consent,
+            "non_essential_consent": non_essential_consent,
+            "payload": payload,
+            "enriched_payload": enriched_payload,
+        })
 
     try:
         # Send form data

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1107,11 +1107,18 @@ def marketo_submit():
     # non-essential cookies (functionality, performance, or all)
     cookie_consent = flask.request.cookies.get("_cookies_accepted", "unset")
     non_essential_consent = cookie_consent in {
-        "functionality", "performance", "all"}
+        "functionality",
+        "performance",
+        "all",
+    }
 
     utm_keys = {
-        "utm_source", "utm_medium", "utm_campaign",
-        "utm_content", "utm_term", "utmcontent",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_content",
+        "utm_term",
+        "utmcontent",
     }
 
     encoded_utms = flask.request.cookies.get("utms") or flask.request.form.get(
@@ -1159,8 +1166,7 @@ def marketo_submit():
                 parsed = urlparse(acq_url)
                 params = parse_qs(parsed.query, keep_blank_values=True)
                 cleaned = {
-                    k: v for k, v in params.items()
-                    if not k.startswith("utm_")
+                    k: v for k, v in params.items() if not k.startswith("utm_")
                 }
                 target["acquisition_url"] = urlunparse(
                     parsed._replace(query=urlencode(cleaned, doseq=True))
@@ -1194,13 +1200,15 @@ def marketo_submit():
 
     # TODO: Remove after QA - returns payloads without hitting Marketo
     if flask.request.args.get("dry_run") == "true":
-        return flask.jsonify({
-            "dry_run": True,
-            "cookie_consent": cookie_consent,
-            "non_essential_consent": non_essential_consent,
-            "payload": payload,
-            "enriched_payload": enriched_payload,
-        })
+        return flask.jsonify(
+            {
+                "dry_run": True,
+                "cookie_consent": cookie_consent,
+                "non_essential_consent": non_essential_consent,
+                "payload": payload,
+                "enriched_payload": enriched_payload,
+            }
+        )
 
     try:
         # Send form data


### PR DESCRIPTION
## Done

- UTM parameters are now only attached to the Marketo enrichment payload when the user has consented to non-essential cookies (`functionality`, `performance`, or `all`)
- When consent is `essential` or `unset` (or cookie is missing), UTMs are stripped from the payload before it reaches Marketo
- Includes a temporary `?dry_run=true` query param on `/marketo/submit` for QA — returns the payloads as JSON without calling the Marketo API. **Remove before merge.**

## QA
This can be tested entirely on the [DEMO](https://ubuntu-com-16216.demos.haus/) using `curl`. The `?dry_run=true` param returns the Marketo payloads as JSON without making any API calls.

### Test 1: `essential` consent — UTMs should NOT be sent

```bash
curl -s -X POST "https://ubuntu-com-16216.demos.haus/marketo/submit?dry_run=true" -b "_cookies_accepted=essential; utms=utm_source%3Agoogle%26utm_medium%3Acpc" -d "formid=4198&email=test@test.com" | python3 -m json.tool
```

**Expected:** `non_essential_consent: false`, and `enriched_payload.input[0].leadFormFields` should have **no** `utm_source` or `utm_medium` keys.

### Test 2: `performance` consent — UTMs SHOULD be sent

```bash
curl -s -X POST "https://ubuntu-com-16216.demos.haus/marketo/submit?dry_run=true" -b "_cookies_accepted=performance; utms=utm_source%3Agoogle%26utm_medium%3Acpc" -d "formid=4198&email=test@test.com" | python3 -m json.tool
```

**Expected:** `non_essential_consent: true`, and `enriched_payload.input[0].leadFormFields` should contain `utm_source: "google"` and `utm_medium: "cpc"`.

### Test 3: `functionality` consent — UTMs SHOULD be sent

```bash
curl -s -X POST "https://ubuntu-com-16216.demos.haus/marketo/submit?dry_run=true" -b "_cookies_accepted=functionality; utms=utm_source%3Agoogle%26utm_medium%3Acpc" -d "formid=4198&email=test@test.com" | python3 -m json.tool
```

**Expected:** `non_essential_consent: true`, UTM fields present in enriched payload.

### Test 4: `all` consent — UTMs SHOULD be sent

```bash
curl -s -X POST "https://ubuntu-com-16216.demos.haus/marketo/submit?dry_run=true" \
  -b "_cookies_accepted=all; utms=utm_source%3Agoogle%26utm_medium%3Acpc" \
  -d "formid=4198&email=test@test.com" | python3 -m json.tool
```

**Expected:** `non_essential_consent: true`, UTM fields present in enriched payload.

### Test 5: No `_cookies_accepted` cookie — UTMs should NOT be sent

```bash
curl -s -X POST "https://ubuntu-com-16216.demos.haus/marketo/submit?dry_run=true" \
  -b "utms=utm_source%3Agoogle%26utm_medium%3Acpc" \
  -d "formid=4198&email=test@test.com" | python3 -m json.tool
```

**Expected:** `cookie_consent: "unset"`, `non_essential_consent: false`, no UTM fields in enriched payload.

### Summary table

| `_cookies_accepted` | UTMs in enriched payload? |
|---|---|
| `essential` | No |
| `unset` / missing | No |
| `functionality` | Yes |
| `performance` | Yes |
| `all` | Yes |

## Before merge

- [x] Remove the `dry_run` block from `webapp/views.py`

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34696

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
