### PR TITLE
Add comments field to whitepaper form for specific form IDs

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -87,21 +87,22 @@
         {% set form_id = metadata["form_id"] %}
         {# Form IDs for no preselected country value #}
         {% set no_preselect_country_form_ids = ["7722"] %}
+        {# Form IDs that show the optional "How can Canonical help you?" field #}
+        {% set comments_form_ids = ["4709", "4925"] %}
         <div class="col-5" id="the-form">
           {% if metadata["language"] != '' %}
             {% set form = "engage/shared/_" + metadata["language"] + "_engage_form.html" %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids, showCommentsField=form_id in comments_form_ids %}
                 {% include form %}
               {% endwith %}
             {% else %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", noPreselectCountry=form_id in no_preselect_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", noPreselectCountry=form_id in no_preselect_country_form_ids, showCommentsField=form_id in comments_form_ids %}
                 {% include form %}
               {% endwith %}
             {% endif %}
 
           {% else %}
-            {% set comments_form_ids = ["4709", "4925"] %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
               {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids, showCommentsField=form_id in comments_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -101,12 +101,13 @@
             {% endif %}
 
           {% else %}
+            {% set comments_form_ids = ["4709", "4925"] %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids, showCommentsField=form_id in comments_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}
               {% endwith %}
             {% else %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", noPreselectCountry=form_id in no_preselect_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", noPreselectCountry=form_id in no_preselect_country_form_ids, showCommentsField=form_id in comments_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}
               {% endwith %}
             {% endif %}

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -29,6 +29,13 @@
       </li>
 
       {% include "shared/forms/_country.html" %}
+
+      {% if showCommentsField is defined and showCommentsField %}
+       <li>
+        <label for="Comments_from_lead__c">How can Canonical help you?</label>
+        <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+      </li>
+      {% endif %}
       <li>
         <label class="p-checkbox">
           <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />


### PR DESCRIPTION
Add optional "How can Canonical help you?" field to engage forms 4709 and 4925

## Done
- Adds a non-mandatory "How can Canonical help you?" textarea to engage whitepaper forms 4709 (MicroK8s confinement) and 4925 (OpenStack made easy) to test whether it improves conversion rates
- Field value syncs to Comments_from_lead__c in Marketo (same field used in contact forms)
- Cleans up base.html by extracting repeated metadata["form_id"] and form ID list into variables

## QA

- Open the [DEMO](https://ubuntu-com-16219.demos.haus/)
- Visit [/engage/openstack-ebook-beginners](https://ubuntu-com-16219.demos.haus/engage/openstack-ebook-beginners) form 4925 — confirm the "How can Canonical help you?" textarea appears before the checkbox, is not required, and submits successfully with the value mapped to Comments_from_lead__c
- Visit [/engage/secure-kubernetes-at-the-edge](https://ubuntu-com-16219.demos.haus/engage/secure-kubernetes-at-the-edge) form 4709 — same checks as above
- Visit any other engage page (different form ID)  [/engage/open-source-virtualization-alternatives](https://ubuntu-com-16219.demos.haus/engage/open-source-virtualization-alternatives) — confirm the textarea does not appear
- Visit a non-English engage page [/engage/von-vmware-zu-openstack](https://ubuntu-com-16219.demos.haus/engage/von-vmware-zu-openstack) — confirm no regressions in form rendering
- Submit a form on [/engage/openstack-ebook-beginners](https://ubuntu-com-16219.demos.haus/engage/openstack-ebook-beginners) with the field empty — confirm submission still works (field is optional)
- Submit a form on [/engage/openstack-ebook-beginners](https://ubuntu-com-16219.demos.haus/engage/openstack-ebook-beginners) with text in the field — confirm the value reaches Marketo under Comments_from_lead__c

## Issue / Card

Fixes # [WD-35380](https://warthogs.atlassian.net/browse/WD-35380)

## Screenshots
<img width="1128" height="1580" alt="image" src="https://github.com/user-attachments/assets/9ad97c36-701a-43d6-bb52-f56c29eed7fb" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-35380]: https://warthogs.atlassian.net/browse/WD-35380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ