### PR TITLE
Enhance form handling by adding conditional country prepopulation logic

### DIFF
--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -34,12 +34,12 @@ export async function prepareInputFields(phoneInput, countryInput) {
  */
 function preFormatCountry(countryCode, countryInput) {
   if (countryInput.dataset.skipCountryPrepopulate === "true") {
-    const matchingOption = countryInput.querySelector(
-      `option[value="${countryCode}"]`
-    );
+    const matchingOption = countryInput.querySelector(`option[value="${countryCode.toUpperCase()}"]`);
     if (matchingOption) {
-      const firstOption = countryInput.querySelector("option");
-      firstOption.after(matchingOption);
+      const selectOption = countryInput.querySelector('option[value=""]');
+      if (selectOption) {
+        selectOption.after(matchingOption);
+      }
     }
   } else {
     countryInput.value = countryCode;

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -34,7 +34,9 @@ export async function prepareInputFields(phoneInput, countryInput) {
  */
 function preFormatCountry(countryCode, countryInput) {
   if (countryInput.dataset.skipCountryPrepopulate === "true") {
-    const matchingOption = countryInput.querySelector(`option[value="${countryCode.toUpperCase()}"]`);
+    const matchingOption = countryInput.querySelector(
+      `option[value="${countryCode.toUpperCase()}"]`,
+    );
     if (matchingOption) {
       const selectOption = countryInput.querySelector('option[value=""]');
       if (selectOption) {

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -33,7 +33,7 @@ export async function prepareInputFields(phoneInput, countryInput) {
  * @param {HTMLElement} countryInput - The select element for the country.
  */
 function preFormatCountry(countryCode, countryInput) {
-  if (countryInput.dataset.skipCountryPrepopulate === "true") {
+  if (countryInput.dataset.noPreselectCountry === "true") {
     const matchingOption = countryInput.querySelector(
       `option[value="${countryCode.toUpperCase()}"]`,
     );

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -33,7 +33,17 @@ export async function prepareInputFields(phoneInput, countryInput) {
  * @param {HTMLElement} countryInput - The select element for the country.
  */
 function preFormatCountry(countryCode, countryInput) {
-  countryInput.value = countryCode;
+  if (countryInput.dataset.skipCountryPrepopulate === "true") {
+    const matchingOption = countryInput.querySelector(
+      `option[value="${countryCode}"]`
+    );
+    if (matchingOption) {
+      const firstOption = countryInput.querySelector("option");
+      firstOption.after(matchingOption);
+    }
+  } else {
+    countryInput.value = countryCode;
+  }
 }
 
 /**

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -85,29 +85,28 @@
       </div>
       {% if "form_id" in metadata and metadata["form_id"] != "" %}
         {% set form_id = metadata["form_id"] %}
-        {# Form IDs that show the optional "How can Canonical help you?" field #}
-        {% set comments_form_ids = ["4709", "4925"] %}
-        {% set no_prepopulate_country_form_ids = ["7722"] %}
+        {# Form IDs for no preselected country value #}
+        {% set no_preselect_country_form_ids = ["7722"] %}
         <div class="col-5" id="the-form">
           {% if metadata["language"] != '' %}
             {% set form = "engage/shared/_" + metadata["language"] + "_engage_form.html" %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids %}
                 {% include form %}
               {% endwith %}
             {% else %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", noPreselectCountry=form_id in no_preselect_country_form_ids %}
                 {% include form %}
               {% endwith %}
             {% endif %}
 
           {% else %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], noPreselectCountry=form_id in no_preselect_country_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}
               {% endwith %}
             {% else %}
-              {% with id=form_id, returnURL=metadata['path']+"/thank-you", showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", noPreselectCountry=form_id in no_preselect_country_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}
               {% endwith %}
             {% endif %}

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -84,26 +84,30 @@
         {{ metadata["body_html"] | safe }}
       </div>
       {% if "form_id" in metadata and metadata["form_id"] != "" %}
+        {% set form_id = metadata["form_id"] %}
+        {# Form IDs that show the optional "How can Canonical help you?" field #}
+        {% set comments_form_ids = ["4709", "4925"] %}
+        {% set no_prepopulate_country_form_ids = ["7722"] %}
         <div class="col-5" id="the-form">
           {% if metadata["language"] != '' %}
             {% set form = "engage/shared/_" + metadata["language"] + "_engage_form.html" %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-              {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'] %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
                 {% include form %}
               {% endwith %}
             {% else %}
-              {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you" %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
                 {% include form %}
               {% endwith %}
             {% endif %}
 
           {% else %}
             {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-              {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'] %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'], showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}
               {% endwith %}
             {% else %}
-              {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you" %}
+              {% with id=form_id, returnURL=metadata['path']+"/thank-you", showCommentsField=form_id in comments_form_ids, skipCountryPrepopulate=form_id in no_prepopulate_country_form_ids %}
                 {% include "engage/shared/_en_engage_form.html" %}
               {% endwith %}
             {% endif %}

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -28,7 +28,9 @@
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
 
-      {% include "shared/forms/_country.html" %}
+      {% with skipCountryPrepopulate=skipCountryPrepopulate %}
+        {% include "shared/forms/_country.html" %}
+      {% endwith %}
       <li>
         <label class="p-checkbox">
           <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -28,9 +28,7 @@
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
 
-      {% with skipCountryPrepopulate=skipCountryPrepopulate %}
-        {% include "shared/forms/_country.html" %}
-      {% endwith %}
+      {% include "shared/forms/_country.html" %}
       <li>
         <label class="p-checkbox">
           <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />

--- a/templates/shared/forms/_country.html
+++ b/templates/shared/forms/_country.html
@@ -2,7 +2,7 @@
   <li class="p-list_item">
     <label {% if required %}class="is-required"{% endif %} for="country">{{ country or 'Country' }}:</label>
   {% endif %}
-  <select {% if required %}required{% endif %} id="country" name="country" {% if skipCountryPrepopulate is defined and skipCountryPrepopulate %}data-skip-country-prepopulate="true"{% endif %}>
+  <select {% if required %}required{% endif %} id="country" name="country" {% if noPreselectCountry is defined and noPreselectCountry %}data-no-preselect-country="true"{% endif %}>
     <option value="">Select...</option>
     <option value="FR">France</option>
     <option value="DE">Germany</option>

--- a/templates/shared/forms/_country.html
+++ b/templates/shared/forms/_country.html
@@ -2,7 +2,7 @@
   <li class="p-list_item">
     <label {% if required %}class="is-required"{% endif %} for="country">{{ country or 'Country' }}:</label>
   {% endif %}
-  <select {% if required %}required{% endif %} id="country" name="country">
+  <select {% if required %}required{% endif %} id="country" name="country" {% if skipCountryPrepopulate is defined and skipCountryPrepopulate %}data-skip-country-prepopulate="true"{% endif %}>
     <option value="">Select...</option>
     <option value="FR">France</option>
     <option value="DE">Germany</option>


### PR DESCRIPTION
We need to change the way the country field is presented on the UI in a couple of forms to see if the number of misroutings will decrease.
Current way: country field is prepopulated based on the browser/IP setup
New way for 2 forms: Country field displays “Select a country”, and the prepopulated country is the first in the list of countries.
Second form is https://github.com/canonical/canonical.com/pull/2441

## Done
- For specific form IDs (starting with 7722), the country dropdown no longer auto-selects based on browser/IP detection — it shows "Select..." instead, with the detected country moved to the top of the list
- Adds a configurable no_prepopulate_country_form_ids list in base.html to control which forms get this behavior
- New form IDs can be added to the list without any other code changes

## QA

- Open the [DEMO](https://ubuntu-com-16222.demos.haus/)
- Visit https://ubuntu-com-16222.demos.haus/engage/sovereign-ai-2026 which is an engage page with form ID 7722 — country should show "Select..." with detected country as first option
- Visit 
  - same page on production https://ubuntu.com/engage/sovereign-ai-2026
  - any other engage page e.g. https://ubuntu-com-16222.demos.haus/engage/canonical-day-paris-2026 — country should auto-select as before
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-35381](https://warthogs.atlassian.net/browse/WD-35381)

## Screenshots

### Before
<img width="1172" height="866" alt="image" src="https://github.com/user-attachments/assets/83fb6762-3a7a-4f6f-8f92-9acb7b0cc877" />
<img width="1160" height="984" alt="image" src="https://github.com/user-attachments/assets/446b5391-7ca7-49c1-8f13-e770fc540899" />

### After
<img width="1180" height="780" alt="image" src="https://github.com/user-attachments/assets/921c7f36-5a85-4cf2-aa24-be8ded97c84c" />
<img width="1156" height="824" alt="image" src="https://github.com/user-attachments/assets/7d8bffae-1861-40f0-b656-000ff6124d44" />

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-35381]: https://warthogs.atlassian.net/browse/WD-35381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ