### PR TITLE
BAU: Fix typo in ProContent search packages label

### DIFF
--- a/static/js/src/advantage/linux-patch-management/components/ProContent.tsx
+++ b/static/js/src/advantage/linux-patch-management/components/ProContent.tsx
@@ -94,7 +94,7 @@ const ProContent = ({
       <div className="p-section--shallow">
         <Row>
           <Col size={2}>
-            <p className="u-align--right">Seach packages</p>
+            <p className="u-align--right">Search packages</p>
           </Col>
           <Col size={4}>
             <SearchAndFilter


### PR DESCRIPTION
## Done

- Fixed typo "Seach packages" → "Search packages" in `static/js/src/advantage/linux-patch-management/components/ProContent.tsx`

## QA

- Open the [DEMO](https://ubuntu-com-16224.demos.haus/advantage/linux-patch-management)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-35728](https://warthogs.atlassian.net/browse/WD-35728) https://warthogs.atlassian.net/browse/WD-35728

[WD-35728]: https://warthogs.atlassian.net/browse/WD-35728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
