### PR TITLE
feat(kernel): update link to SRU wiki

### DIFF
--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -110,7 +110,7 @@
         </div>
         <div class="col">
           <p>
-            The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a>, and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of Common Vulnerabilities and Exposures (CVEs) assigned to the Linux kernel and application of relevant patches for all critical and serious kernel defects and then rigorously testing newly updated kernels end-to-end each SRU cycle.
+            The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://documentation.ubuntu.com/project/SRU/stable-release-updates/">Ubuntu SRU process</a>, and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of Common Vulnerabilities and Exposures (CVEs) assigned to the Linux kernel and application of relevant patches for all critical and serious kernel defects and then rigorously testing newly updated kernels end-to-end each SRU cycle.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

Updated link to SRU wiki.

Note: BAU request specifically requests only the link is updated.

## QA

- Head to https://ubuntu-com-16225.demos.haus/kernel
- Ensure URL in 'Kernel Security' section navigates to https://documentation.ubuntu.com/project/SRU/stable-release-updates/

## Issue / Card

Fixes WD-35773
