### PR TITLE
Serve pages using Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Once the server has started, you can visit <http://127.0.0.1:8001> in your brows
 
 For more information on how to work with ubuntu.com project please refer to [HACKING.md](HACKING.md).
 
+## Markdown response (`?format=md`)
+
+Any HTML page on the site can be served as Markdown by appending the `?format=md` query parameter. This is provided by the [`canonicalwebteam.markdown-response`](https://github.com/canonical/canonicalwebteam.markdown-response) package for LLM and crawler optimisation.
+
+- `https://ubuntu.com/desktop?format=md` returns the page content as `text/markdown`
+- Only `200 OK` HTML responses are converted; JSON endpoints, redirects, and error pages are unaffected
+
 # Deploy
 
 You can find the deployment config in the deploy folder.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ canonicalwebteam.image-template==1.9.0
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
+canonicalwebteam.markdown-response==0.2.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -1,4 +1,4 @@
-<section class="p-section">
+<section class="p-section" data-md-strip>
   <form {% if isModal %}class="js-modal-form"{% endif %}
         action="/marketo/submit"
         method="post"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -387,6 +387,60 @@ class TestRoutes(VCRTestCase):
             response.location,
         )
 
+    def test_format_md_returns_markdown_content_type(self):
+        """
+        When ?format=md is set on an HTML page,
+        the response should have text/markdown content type
+        """
+        response = self.client.get("/?format=md")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/markdown", response.content_type)
+
+    def test_format_md_body_is_not_html(self):
+        """
+        When ?format=md is set on an HTML page,
+        the response body should not contain typical HTML tags
+        """
+        response = self.client.get("/?format=md")
+        self.assertEqual(response.status_code, 200)
+        data = response.get_data(as_text=True)
+        self.assertNotIn("<!doctype html>", data.lower())
+        self.assertNotIn("<html", data.lower())
+
+    def test_normal_request_returns_html(self):
+        """
+        A normal request without ?format=md should return text/html
+        """
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/html", response.content_type)
+
+    def test_format_md_does_not_transform_json(self):
+        """
+        JSON endpoints should not be transformed by ?format=md
+        """
+        response = self.client.get("/mirrors.json?format=md")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("text/markdown", response.content_type)
+
+    def test_format_md_does_not_transform_redirects(self):
+        """
+        Redirect responses should not be transformed by ?format=md
+        """
+        response = self.client.get(
+            "/getubuntu/releasenotes?os=ubuntu&format=md"
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("text/markdown", response.content_type)
+
+    def test_format_md_does_not_transform_404(self):
+        """
+        404 responses should not be transformed by ?format=md
+        """
+        response = self.client.get("/not-found-url?format=md")
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn("text/markdown", response.content_type)
+
     def test_release_notes_redirect_resolute(self):
         """
         Check that release notes redirect endpoint returns 302 redirect to the

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -39,6 +39,7 @@ import canonicalwebteam.directory_parser as directory_parser
 from canonicalwebteam.search import build_search_view
 from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam.form_generator import FormGenerator
+from canonicalwebteam.markdown_response import MarkdownResponse
 
 from webapp.certified.views import certified_routes
 from webapp.handlers import init_handlers
@@ -236,6 +237,10 @@ app = FlaskBase(
     template_500="500.html",
     static_folder="../static",
 )
+
+# Markdown endpoint for LLM/crawler optimization
+# Serves any page as Markdown via ?format=md query parameter
+MarkdownResponse(app)
 
 # ChoiceLoader attempts loading templates from each path in successive order
 directory_parser_templates = (


### PR DESCRIPTION
## Done

- Adds a `?format=md` query parameter that serves any page as clean Markdown with YAML frontmatter, optimized for LLM and crawler consumption
- Strips navigation, footer, scripts, hidden elements, and Marketo contact forms from output — uses data-md-strip
attribute for template-level control of what gets excluded
- robots.txt already directs AI crawlers to ?format=md (shipped previously)

Package extracted to https://github.com/canonical/canonicalwebteam.markdown-response

## QA

- Open the [DEMO](https://ubuntu-com-16226.demos.haus)
- check https://ubuntu-com-16226.demos.haus/?format=md and verify it returns markdown
- check that it doesn't format for 404 pages
  - [/non-existing-page](https://ubuntu-com-16226.demos.haus/non-existing-page) 
  - and verify that [/non-existing-page?format=md](https://ubuntu-com-16226.demos.haus/non-existing-page?format=md) returns the error html page

## Issue / Card

Fixes #
[WD-35034](https://warthogs.atlassian.net/browse/WD-35034)

## Screenshots
<img width="3444" height="1242" alt="image" src="https://github.com/user-attachments/assets/7bfbfa95-4657-4e73-a2fd-79a62b4151b0" />


[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-35034]: https://warthogs.atlassian.net/browse/WD-35034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ