### PR TITLE
WD-36026 Update 12 to 15 years of Pro on vulnerabilities page

### DIFF
--- a/templates/security/vulnerabilities/index.html
+++ b/templates/security/vulnerabilities/index.html
@@ -78,7 +78,7 @@
           <div class="col-6">
             <ul class="p-list--divided">
               <p>
-                Up to 12 years of security coverage for Ubuntu
+                Up to 15 years of security coverage for Ubuntu
                 and 36,000 open-source applications and toolchains.
               </p>
               <div class="p-cta-block">

--- a/templates/security/vulnerabilities/index.html
+++ b/templates/security/vulnerabilities/index.html
@@ -76,15 +76,13 @@
             <h3 class="p-heading--5">Ubuntu Pro</h3>
           </div>
           <div class="col-6">
-            <ul class="p-list--divided">
-              <p>
-                Up to 15 years of security coverage for Ubuntu
-                and 36,000 open-source applications and toolchains.
-              </p>
-              <div class="p-cta-block">
-                <a class="p-button" href="/pro">Get Ubuntu Pro</a>
-              </div>
-            </ul>
+            <p>
+              Up to 15 years of security coverage for Ubuntu
+              and 36,000 open-source applications and toolchains.
+            </p>
+            <div class="p-cta-block">
+              <a class="p-button" href="/pro">Get Ubuntu Pro</a>
+            </div>
           </div>
         </div>
         <hr class="p-rule--muted" />


### PR DESCRIPTION
## Done

- Updates Pro security updates from 12 to 15 years on vulnerabilities page.

Drive-by: removes unnecessary (invalid) `<ul>` element wrapping the paragraph.

## QA

- Open the [DEMO](https://ubuntu-com-16239.demos.haus/security/vulnerabilities)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the number of years was updated to 15

## Issue / Card

Fixes [WD-36026](https://warthogs.atlassian.net/browse/WD-36026)

## Screenshots

<img width="1080" height="217" alt="image" src="https://github.com/user-attachments/assets/a20879d7-c033-4305-b5a8-336f19d9d6a8" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-36026]: https://warthogs.atlassian.net/browse/WD-36026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ