### PR TITLE
feat: add thank-you pages for desktop and server arm64 downloads and wsl downloads 

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -122,3 +122,5 @@ checksums:
     "22": "4c4b3958626611aff85bfa5873c45ad22fdf7642be868b5722900fa88e6fca86 *ubuntu-core-22-armhf+raspi.img.xz"
   wsl:
     "24.04.4": "9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5 *ubuntu-24.04.4-wsl-amd64.wsl"
+  wsl-arm64:
+    "24.04.4": "6b244d89f412a68f51e58f396fab65bed3b5896a25c045a99bef9c78a07df507 *ubuntu-24.04.4-wsl-arm64.wsl"

--- a/releases.yaml
+++ b/releases.yaml
@@ -71,6 +71,8 @@ checksums:
     "22.04.5": "bfd1cee02bc4f35db939e69b934ba49a39a378797ce9aee20f6e3e3e728fefbf *ubuntu-22.04.5-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
+  desktop-arm64:
+    "25.10": "9d383dd57220dec520fdec3be05da258d27d435c02fe6e296c5d0a505741a787 *ubuntu-25.10-desktop-arm64.iso"
   live-server:
     "25.10": "dc54870e5261c0abad19f74b8146659d10e625971792bd42d7ecde820b60a1d0 *ubuntu-25.10-live-server-amd64.iso"
     "25.04": "8b44046211118639c673335a80359f4b3f0d9e52c33fe61c59072b1b61bdecc5 *ubuntu-25.04-live-server-amd64.iso"

--- a/releases.yaml
+++ b/releases.yaml
@@ -82,6 +82,9 @@ checksums:
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
+  live-server-arm64:
+    "25.10": "ecf579664c0be9e4a68ae7b617399ce943c2dee49eb1fcc6702a5671a4f88320 *ubuntu-25.10-live-server-arm64.iso"
+    "24.04.4": "9a6ce6d7e66c8abed24d24944570a495caca80b3b0007df02818e13829f27f32 *ubuntu-24.04.4-live-server-arm64.iso"
   desktop-arm64+raspi:
     "25.10": "d35bc2aa6ed256293c4eab4d6066274364ddc790d327bb1ec1bfac117ec89dd3 *ubuntu-25.10-preinstalled-desktop-arm64+raspi.img.xz"
     "25.04": "278b1748c783a69edb526e7e29d51b4e55f505a1dcddcc8be3977df5b8d87088 *ubuntu-25.04-preinstalled-desktop-arm64+raspi.img.xz"

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -216,7 +216,7 @@
             </div>
             <div class="col-3">
               <a class="p-button"
-                 href="https://cdimage.ubuntu.com/releases/{{ releases_yaml.latest.full_version }}/release/ubuntu-{{ releases_yaml.latest.full_version }}-desktop-arm64.iso"
+                 href="/download/desktop/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=arm64"
                  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases_yaml.latest.short_version }}', 'eventValue' : undefined });"
                  aria-label="Download Ubuntu {{ releases_yaml.latest.full_version }} arm64">Download</a>
               {% if releases_yaml.latest.arm_iso_download_size %}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -258,13 +258,13 @@
             </div>
             <div class="u-float-right u-hide--small">
               <div class="p-image-wrapper u-align-center u-vertically-center">
-                {{ image(url="https://assets.ubuntu.com/v1/b26d26e5-t-shirt.png",
-                                alt="T-shirt",
-                                width="78",
-                                height="78",
-                                hi_def=True,
-                                loading="lazy",
-                                attrs={"class": "js-equivalent-image u-hide--medium u-hide--small"}) | safe
+                {{ image(url="https://assets.ubuntu.com/v1/691d844b-t-shirt.png",
+                  alt="",
+                  width="78",
+                  height="78",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "js-equivalent-image u-hide--medium u-hide--small"}) | safe
                 }}
               </div>
             </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -56,8 +56,8 @@
   {% endif %}
 
   <section class="p-strip is-shallow u-no-padding--bottom">
-    <div class="row--50-50">
-      <div class="col">
+    <div class="grid-row--50-50">
+      <div class="grid-col">
         {% if version %}
           <h1>Thank you for downloading Ubuntu Desktop {{ version }}{{ " LTS" if lts }}</h1>
           <p>
@@ -81,7 +81,7 @@
           </p>
         {% endif %}
       </div>
-      <div class="col">
+      <div class="grid-col">
         {% with returnUrl="/download/desktop", ga_event_title="Ubuntu Desktop download" %}
           {% include 'shared/_download-newsletter.html' %}
         {% endwith %}
@@ -97,11 +97,11 @@
 
   <section class="p-section">
     <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50">
-      <div class="col">
+    <div class="grid-row--50-50">
+      <div class="grid-col">
         <h2>Help us to keep Ubuntu free to download, share and use by contributing to...</h2>
       </div>
-      <div class="col">
+      <div class="grid-col">
         <noscript>
           <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
         </noscript>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -42,6 +42,11 @@
     {% if architecture == 'amd64+mac' %}
       <meta http-equiv="refresh"
             content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso" />
+    {% elif architecture == 'arm64' %}
+      <noscript>
+        <meta http-equiv="refresh"
+              content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-arm64.iso" />
+      </noscript>
     {% else %}
       <noscript>
         <meta http-equiv="refresh"
@@ -58,269 +63,274 @@
           <p>
             Your download should start automatically. If it doesn't,
             {% if architecture == 'amd64+mac' %}
-              <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download
-                now</a>.
-              {% else %}
-                <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download
-                  now</a>.
-                {% endif %}
-                <br />
-                {% with version=version, system="desktop", architecture=architecture %}
-                  {% include "download/shared/_verify-checksums.html" %}
-                {% endwith %}
-
-              </p>
+              <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
+            {% elif architecture == 'arm64' %}
+              <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-arm64.iso">download now</a>.
             {% else %}
-              <h1>You have not selected an image to download</h1>
-              <p>
-                Please <a href="/download/desktop">select an image</a> to download.
-              </p>
+              <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
             {% endif %}
-          </div>
-          <div class="col">
-            {% with returnUrl="/download/desktop", ga_event_title="Ubuntu Desktop download" %}
-              {% include 'shared/_download-newsletter.html' %}
+            <br />
+            {% with version=version, system="desktop" if architecture != "arm64" else "desktop-arm64", architecture=architecture %}
+              {% include "download/shared/_verify-checksums.html" %}
             {% endwith %}
-          </div>
-        </div>
-      </section>
-
-      {% include "download/shared/_downloads-resources.html" %}
-
-      {% include "download/shared/_secure-enterprise-management.html" %}
-
-      {% include "download/shared/_more-from-canonical.html" %}
-
-      <section class="p-section">
-        <hr class="p-rule is-fixed-width" />
-        <div class="row--50-50">
-          <div class="col">
-            <h2>Help us to keep Ubuntu free to download, share and use by contributing to...</h2>
-          </div>
-          <div class="col">
-            <noscript>
-              <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
-            </noscript>
-            <form class="contribute__options"
-                  action="https://www.paypal.com/cgi-bin/webscr"
-                  id="contributions-form"
-                  method="post"
-                  target="_top">
-
-              <div class="p-section--shallow">
-                <div id="community-projects">
-                  <p class="p-heading--5 u-no-margin--bottom">Community projects</p>
-                  <p>I support LoCo teams, UbuCons and other events, upstream projects and all the good work the community does.</p>
-                  <div class="p-slider__wrapper">
-                    <label for="amount-community" class="u-off-screen">Contribution to community projects in US dollars</label>
-                    <input class="p-slider"
-                           min="0"
-                           max="125"
-                           value="3"
-                           step="1"
-                           id="amount-community"
-                           type="range" />
-                    <label for="amount-community-input" class="u-off-screen">
-                      Contribution amount to community projects in US dollars
-                    </label>
-                    <input class="p-slider__input"
-                           style="min-width: 4rem"
-                           min="0"
-                           max="125"
-                           id="amount-community-input"
-                           name="amount_4"
-                           value="3"
-                           tabindex="4"
-                           type="number" />
-                    <input type="hidden" name="item_name_4" value="Community projects" />
-                  </div>
-                </div>
-
-                <div id="ubuntu-desktop">
-                  <p class="p-heading--5 u-no-margin--bottom">Ubuntu Desktop</p>
-                  <p>Make the desktop even more amazing.</p>
-                  <div class="p-slider__wrapper">
-                    <label for="amount-desktop" class="u-off-screen">Contribution to desktop projects in US dollars</label>
-                    <input class="p-slider"
-                           min="0"
-                           max="125"
-                           value="3"
-                           step="1"
-                           id="amount-desktop"
-                           type="range" />
-                    <label for="amount-desktop-input" class="u-off-screen">Contribution to desktop projects in US dollars</label>
-                    <input class="p-slider__input"
-                           style="min-width: 4rem"
-                           min="0"
-                           max="125"
-                           id="amount-desktop-input"
-                           name="amount_1"
-                           value="3"
-                           tabindex="1"
-                           type="number" />
-                    <input type="hidden" name="item_name_1" value="Ubuntu Desktop" />
-                  </div>
-                </div>
-
-                <div id="tip-to-canonical">
-                  <p class="p-heading--5 u-no-margin--bottom">Tip to Canonical</p>
-                  <p>Hats off for making Ubuntu possible. Keep it up.</p>
-                  <div class="p-slider__wrapper">
-                    <label for="amount-canonical" class="u-off-screen">Contribution to canonical projects in US dollars</label>
-                    <input class="p-slider"
-                           min="0"
-                           max="125"
-                           value="3"
-                           step="1"
-                           id="amount-canonical"
-                           type="range" />
-                    <label for="amount-canonical-input" class="u-off-screen">Contribution to canonical projects in US dollars</label>
-                    <input class="p-slider__input"
-                           style="min-width: 4rem"
-                           min="0"
-                           max="125"
-                           id="amount-canonical-input"
-                           name="amount_5"
-                           value="3"
-                           tabindex="5"
-                           type="number" />
-                    <input type="hidden" name="item_name_5" value="Tip to Canonical" />
-                  </div>
-                </div>
-
-                <div id="ubuntu-for-things">
-                  <p class="p-heading--5 u-no-margin--bottom">Ubuntu for IoT</p>
-                  <p>I want a secure, upgradeable Internet of Things, powered by Ubuntu.</p>
-                  <div class="p-slider__wrapper">
-                    <label for="amount-things" class="u-off-screen">Contribution to IOT projects in US dollars</label>
-                    <input class="p-slider"
-                           min="0"
-                           max="125"
-                           value="3"
-                           step="1"
-                           id="amount-things"
-                           type="range" />
-                    <label for="amount-things-input" class="u-off-screen">Contribution to IOT projects in US dollars</label>
-                    <input class="p-slider__input"
-                           style="min-width: 4rem"
-                           min="0"
-                           max="125"
-                           id="amount-things-input"
-                           name="amount_3"
-                           value="3"
-                           tabindex="3"
-                           type="number" />
-                    <input type="hidden" name="item_name_3" value="Ubuntu for things" />
-                  </div>
-                </div>
-
-                <div id="ubuntu-for-cloud">
-                  <p class="p-heading--5 u-no-margin--bottom">Ubuntu Server & Cloud</p>
-                  <p>I want Ubuntu Server running my servers, cloud and as a guest everywhere.</p>
-                  <div class="p-slider__wrapper">
-                    <label for="amount-cloud" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
-                    <input class="p-slider"
-                           min="0"
-                           max="125"
-                           value="3"
-                           step="1"
-                           id="amount-cloud"
-                           type="range" />
-                    <label for="amount-cloud-input" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
-                    <input class="p-slider__input"
-                           style="min-width: 4rem"
-                           min="0"
-                           max="125"
-                           id="amount-cloud-input"
-                           name="amount_2"
-                           value="3"
-                           tabindex="2"
-                           type="number" />
-                    <input type="hidden" name="item_name_2" value="Ubuntu for cloud computing" />
-                  </div>
-                </div>
-              </div>
-
-              <hr class="p-rule" />
-
-              <div class="u-clearfix">
-                <div class="u-float-left">
-                  <p class="u-no-margin--bottom">
-                    Your contribution:&nbsp;<span>&#36;<span class="js-total-amount">16</span></span>
-                  </p>
-                  <p>
-                    The same price as <span class="js-equivalent-description">Peace, Love and Linux t-shirt</span>
-                  </p>
-                </div>
-                <div class="u-float-right u-hide--small">
-                  <div class="p-image-wrapper u-align-center u-vertically-center">
-                    {{ image(url="https://assets.ubuntu.com/v1/b26d26e5-t-shirt.png",
-                                        alt="T-shirt",
-                                        width="78",
-                                        height="78",
-                                        hi_def=True,
-                                        loading="lazy",
-                                        attrs={"class": "js-equivalent-image u-hide--medium u-hide--small"}) | safe
-                    }}
-                  </div>
-                </div>
-              </div>
-              <div class="p-section--shallow">
-                <input type="hidden" name="cmd" value="_cart" />
-                <input type="hidden" name="business" value="donations@ubuntu.com" />
-                <input type="hidden" name="lc" value="GB" />
-                <input type="hidden" name="upload" value="1" />
-                <input type="hidden" name="currency_code" value="USD" />
-                <input type="hidden" name="button_subtype" value="services" />
-                <input type="hidden" name="no_note" value="1" />
-                <input type="hidden" name="no_shipping" value="1" />
-                <input type="hidden" name="rm" value="1" />
-
-                <input type="hidden"
-                       name="return"
-                       value="http://{{ http_host }}/download/desktop/thank-you" />
-                <input type="hidden"
-                       name="cancel_return"
-                       value="http://{{ http_host }}/download/desktop" />
-
-                <input type="hidden"
-                       name="bn"
-                       value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted" />
-                <button type="submit"
-                        class="js-contribute-submit p-button--positive u-no-margin--bottom"
-                        tabindex="9">Contribute with PayPal</button>
-              </div>
-            </form>
-          </div>
-        </div>
-      </section>
-
-      {% if version %}
-
-        {% with title_link="/blog/desktop", group_id="1479" %}
-          {% include "download/shared/_latest-blogs_download.html" %}
+          </p>
+        {% else %}
+          <h1>You have not selected an image to download</h1>
+          <p>
+            Please <a href="/download/desktop">select an image</a> to download.
+          </p>
+        {% endif %}
+      </div>
+      <div class="col">
+        {% with returnUrl="/download/desktop", ga_event_title="Ubuntu Desktop download" %}
+          {% include 'shared/_download-newsletter.html' %}
         {% endwith %}
+      </div>
+    </div>
+  </section>
 
-      {% endif %}
+  {% include "download/shared/_downloads-resources.html" %}
 
-    {% endblock content %}
+  {% include "download/shared/_secure-enterprise-management.html" %}
 
-    {% block footer_extra %}
-      <script src="{{ versioned_static('js/dist/contributions.js') }}"></script>
+  {% include "download/shared/_more-from-canonical.html" %}
 
-      {% if version %}
-        <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-        <script defer>
-          var architecture = '{{ architecture }}';
-          var version = '{{ version }}';
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Help us to keep Ubuntu free to download, share and use by contributing to...</h2>
+      </div>
+      <div class="col">
+        <noscript>
+          <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
+        </noscript>
+        <form class="contribute__options"
+              action="https://www.paypal.com/cgi-bin/webscr"
+              id="contributions-form"
+              method="post"
+              target="_top">
 
-          if (version && architecture && architecture != 'amd64+mac') {
-            var GAlabel = version + '-desktop-' + architecture;
-            var imagePath = version + '/ubuntu-' + version + '-desktop-' + architecture + '.iso';
+          <div class="p-section--shallow">
+            <div id="community-projects">
+              <p class="p-heading--5 u-no-margin--bottom">Community projects</p>
+              <p>I support LoCo teams, UbuCons and other events, upstream projects and all the good work the community does.</p>
+              <div class="p-slider__wrapper">
+                <label for="amount-community" class="u-off-screen">Contribution to community projects in US dollars</label>
+                <input class="p-slider"
+                       min="0"
+                       max="125"
+                       value="3"
+                       step="1"
+                       id="amount-community"
+                       type="range" />
+                <label for="amount-community-input" class="u-off-screen">
+                  Contribution amount to community projects in US dollars
+                </label>
+                <input class="p-slider__input"
+                       style="min-width: 4rem"
+                       min="0"
+                       max="125"
+                       id="amount-community-input"
+                       name="amount_4"
+                       value="3"
+                       tabindex="4"
+                       type="number" />
+                <input type="hidden" name="item_name_4" value="Community projects" />
+              </div>
+            </div>
 
-            window.initImageDownload(imagePath, GAlabel);
-          }
-        </script>
-      {% endif %}
+            <div id="ubuntu-desktop">
+              <p class="p-heading--5 u-no-margin--bottom">Ubuntu Desktop</p>
+              <p>Make the desktop even more amazing.</p>
+              <div class="p-slider__wrapper">
+                <label for="amount-desktop" class="u-off-screen">Contribution to desktop projects in US dollars</label>
+                <input class="p-slider"
+                       min="0"
+                       max="125"
+                       value="3"
+                       step="1"
+                       id="amount-desktop"
+                       type="range" />
+                <label for="amount-desktop-input" class="u-off-screen">Contribution to desktop projects in US dollars</label>
+                <input class="p-slider__input"
+                       style="min-width: 4rem"
+                       min="0"
+                       max="125"
+                       id="amount-desktop-input"
+                       name="amount_1"
+                       value="3"
+                       tabindex="1"
+                       type="number" />
+                <input type="hidden" name="item_name_1" value="Ubuntu Desktop" />
+              </div>
+            </div>
 
-    {% endblock footer_extra %}
+            <div id="tip-to-canonical">
+              <p class="p-heading--5 u-no-margin--bottom">Tip to Canonical</p>
+              <p>Hats off for making Ubuntu possible. Keep it up.</p>
+              <div class="p-slider__wrapper">
+                <label for="amount-canonical" class="u-off-screen">Contribution to canonical projects in US dollars</label>
+                <input class="p-slider"
+                       min="0"
+                       max="125"
+                       value="3"
+                       step="1"
+                       id="amount-canonical"
+                       type="range" />
+                <label for="amount-canonical-input" class="u-off-screen">Contribution to canonical projects in US dollars</label>
+                <input class="p-slider__input"
+                       style="min-width: 4rem"
+                       min="0"
+                       max="125"
+                       id="amount-canonical-input"
+                       name="amount_5"
+                       value="3"
+                       tabindex="5"
+                       type="number" />
+                <input type="hidden" name="item_name_5" value="Tip to Canonical" />
+              </div>
+            </div>
+
+            <div id="ubuntu-for-things">
+              <p class="p-heading--5 u-no-margin--bottom">Ubuntu for IoT</p>
+              <p>I want a secure, upgradeable Internet of Things, powered by Ubuntu.</p>
+              <div class="p-slider__wrapper">
+                <label for="amount-things" class="u-off-screen">Contribution to IOT projects in US dollars</label>
+                <input class="p-slider"
+                       min="0"
+                       max="125"
+                       value="3"
+                       step="1"
+                       id="amount-things"
+                       type="range" />
+                <label for="amount-things-input" class="u-off-screen">Contribution to IOT projects in US dollars</label>
+                <input class="p-slider__input"
+                       style="min-width: 4rem"
+                       min="0"
+                       max="125"
+                       id="amount-things-input"
+                       name="amount_3"
+                       value="3"
+                       tabindex="3"
+                       type="number" />
+                <input type="hidden" name="item_name_3" value="Ubuntu for things" />
+              </div>
+            </div>
+
+            <div id="ubuntu-for-cloud">
+              <p class="p-heading--5 u-no-margin--bottom">Ubuntu Server & Cloud</p>
+              <p>I want Ubuntu Server running my servers, cloud and as a guest everywhere.</p>
+              <div class="p-slider__wrapper">
+                <label for="amount-cloud" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
+                <input class="p-slider"
+                       min="0"
+                       max="125"
+                       value="3"
+                       step="1"
+                       id="amount-cloud"
+                       type="range" />
+                <label for="amount-cloud-input" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
+                <input class="p-slider__input"
+                       style="min-width: 4rem"
+                       min="0"
+                       max="125"
+                       id="amount-cloud-input"
+                       name="amount_2"
+                       value="3"
+                       tabindex="2"
+                       type="number" />
+                <input type="hidden" name="item_name_2" value="Ubuntu for cloud computing" />
+              </div>
+            </div>
+          </div>
+
+          <hr class="p-rule" />
+
+          <div class="u-clearfix">
+            <div class="u-float-left">
+              <p class="u-no-margin--bottom">
+                Your contribution:&nbsp;<span>&#36;<span class="js-total-amount">16</span></span>
+              </p>
+              <p>
+                The same price as <span class="js-equivalent-description">Peace, Love and Linux t-shirt</span>
+              </p>
+            </div>
+            <div class="u-float-right u-hide--small">
+              <div class="p-image-wrapper u-align-center u-vertically-center">
+                {{ image(url="https://assets.ubuntu.com/v1/b26d26e5-t-shirt.png",
+                                alt="T-shirt",
+                                width="78",
+                                height="78",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "js-equivalent-image u-hide--medium u-hide--small"}) | safe
+                }}
+              </div>
+            </div>
+          </div>
+          <div class="p-section--shallow">
+            <input type="hidden" name="cmd" value="_cart" />
+            <input type="hidden" name="business" value="donations@ubuntu.com" />
+            <input type="hidden" name="lc" value="GB" />
+            <input type="hidden" name="upload" value="1" />
+            <input type="hidden" name="currency_code" value="USD" />
+            <input type="hidden" name="button_subtype" value="services" />
+            <input type="hidden" name="no_note" value="1" />
+            <input type="hidden" name="no_shipping" value="1" />
+            <input type="hidden" name="rm" value="1" />
+
+            <input type="hidden"
+                   name="return"
+                   value="http://{{ http_host }}/download/desktop/thank-you" />
+            <input type="hidden"
+                   name="cancel_return"
+                   value="http://{{ http_host }}/download/desktop" />
+
+            <input type="hidden"
+                   name="bn"
+                   value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted" />
+            <button type="submit"
+                    class="js-contribute-submit p-button--positive u-no-margin--bottom"
+                    tabindex="9">Contribute with PayPal</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  {% if version %}
+
+    {% with title_link="/blog/desktop", group_id="1479" %}
+      {% include "download/shared/_latest-blogs_download.html" %}
+    {% endwith %}
+
+  {% endif %}
+
+{% endblock content %}
+
+{% block footer_extra %}
+  <script src="{{ versioned_static('js/dist/contributions.js') }}"></script>
+
+  {% if version %}
+    <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+    <script defer>
+      var architecture = '{{ architecture }}';
+      var version = '{{ version }}';
+
+      if (version && architecture && architecture != 'amd64+mac') {
+        var GAlabel = version + '-desktop-' + architecture;
+        var imageName = 'ubuntu-' + version + '-desktop-' + architecture + '.iso';
+
+        if (architecture === 'arm64') {
+          // arm64 downloads are not hosted on releases.ubuntu.com so we go
+          // straight through cdimage
+          window.location.href = 'https://cdimage.ubuntu.com/releases/' + version + '/release/' + imageName;
+        } else {
+          window.initImageDownload(version + '/' + imageName, GAlabel);
+        }
+      }
+    </script>
+  {% endif %}
+
+{% endblock footer_extra %}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -70,7 +70,7 @@
               <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
             {% endif %}
             <br />
-            {% with version=version, system="desktop" if architecture != "arm64" else "desktop-arm64", architecture=architecture %}
+            {% with version=version, system="desktop", checksum_system="desktop-arm64" if architecture == "arm64" else "", architecture=architecture %}
               {% include "download/shared/_verify-checksums.html" %}
             {% endwith %}
           </p>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -35,13 +35,13 @@
           <div class="col-6 col-medium-3">
             <p>This is the default ISO image of the Ubuntu Server installer.</p>
             <hr class="p-rule" />
-            <a href="https://cdimage.ubuntu.com/releases/{{ releases_yaml.lts.short_version }}/release/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-arm64.iso"
+            <a href="/download/server/thank-you?version={{ releases_yaml.lts.full_version }}&amp;architecture=arm64&amp;lts=true"
                class="p-button--positive"
                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases_yaml.lts.short_version }}', 'eventValue' : undefined });">
               Download {{ releases_yaml.lts.full_version }} LTS
             </a>
             {% if releases_yaml.latest.short_version > releases_yaml.lts.short_version %}
-              &nbsp;&nbsp;<a href="https://cdimage.ubuntu.com/releases/{{ releases_yaml.latest.short_version }}/release/ubuntu-{{ releases_yaml.latest.full_version }}-live-server-arm64.iso"
+              <a href="/download/server/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=arm64"
    class="p-button"
    onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases_yaml.latest.short_version }}', 'eventValue' : undefined });">
               Download {{ releases_yaml.latest.full_version }}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -14,8 +14,13 @@
 
 {% block content %}
   <noscript>
-    <meta http-equiv="refresh"
-          content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso" />
+    {% if architecture == 'arm64' %}
+      <meta http-equiv="refresh"
+            content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-live-server-arm64.iso" />
+    {% else %}
+      <meta http-equiv="refresh"
+            content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso" />
+    {% endif %}
   </noscript>
 
   <section class="p-strip is-shallow u-no-padding--bottom">
@@ -25,9 +30,13 @@
           <h1>Thank you for downloading Ubuntu Server {{ version }}{{ " LTS" if lts }}</h1>
           <p>
             Your download should start in the background. If it doesn't,
-            <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
+            {% if architecture == 'arm64' %}
+              <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-live-server-arm64.iso">download&nbsp;now</a>.
+            {% else %}
+              <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
+            {% endif %}
             <br />
-            {% with version=version, system="live-server", architecture="amd64" %}
+            {% with version=version, system="live-server" if architecture != "arm64" else "live-server-arm64", architecture=architecture %}
               {% include "download/shared/_verify-checksums.html" %}
             {% endwith %}
           </p>
@@ -242,12 +251,19 @@
   <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
   <script defer>
+    var architecture = '{{ architecture }}';
     var version = '{{ version }}';
     if (version) {
-      var GAlabel = version + '-server-amd64';
-      var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
+      var GAlabel = version + '-server-' + (architecture || 'amd64');
+      var imageName = 'ubuntu-' + version + '-live-server-' + (architecture || 'amd64') + '.iso';
 
-      window.initImageDownload(imagePath, GAlabel);
+      if (architecture === 'arm64') {
+        // arm64 downloads are not hosted on releases.ubuntu.com so we go
+        // straight through cdimage
+        window.location.href = 'https://cdimage.ubuntu.com/releases/' + version + '/release/' + imageName;
+      } else {
+        window.initImageDownload(version + '/' + imageName, GAlabel);
+      }
     }
   </script>
 {% endblock footer_extra %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -13,15 +13,17 @@
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-  <noscript>
-    {% if architecture == 'arm64' %}
-      <meta http-equiv="refresh"
-            content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-live-server-arm64.iso" />
-    {% else %}
-      <meta http-equiv="refresh"
-            content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso" />
-    {% endif %}
-  </noscript>
+  {% if version %}
+    <noscript>
+      {% if architecture == 'arm64' %}
+        <meta http-equiv="refresh"
+              content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-live-server-arm64.iso" />
+      {% else %}
+        <meta http-equiv="refresh"
+              content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso" />
+      {% endif %}
+    </noscript>
+  {% endif %}
 
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row--50-50">
@@ -36,7 +38,7 @@
               <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
             {% endif %}
             <br />
-            {% with version=version, system="live-server" if architecture != "arm64" else "live-server-arm64", architecture=architecture %}
+            {% with version=version, system="live-server", checksum_system="live-server-arm64" if architecture == "arm64" else "", architecture=architecture %}
               {% include "download/shared/_verify-checksums.html" %}
             {% endwith %}
           </p>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -8,9 +8,10 @@ You can
      id="menu-4"
      aria-hidden="true"
      aria-label="Verification instructions:">
-  {% if releases_yaml.checksums[system] and releases_yaml.checksums[system][version] %}
+  {% set lookup = checksum_system if checksum_system else system %}
+  {% if releases_yaml.checksums[lookup] and releases_yaml.checksums[lookup][version] %}
     <p>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</p>
-    <pre>echo "{{ releases_yaml.checksums[system][version] }}" | shasum -a 256 --check</pre>
+    <pre>echo "{{ releases_yaml.checksums[lookup][version] }}" | shasum -a 256 --check</pre>
     <p>You should get the following output:</p>
     <pre>ubuntu-{{ version }}-{% if system != architecture %}{{ system }}-{% else %}preinstalled-server-{% endif %}{{ architecture }}.iso: OK</pre>
     <p>

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -48,7 +48,7 @@
                 <p class='p-heading--5'>Intel or AMD 64-bit architecture</p>
               </div>
               <div class='grid-col-2'>
-                <a class='p-button--positive' href='https://releases.ubuntu.com/noble/ubuntu-24.04.4-wsl-amd64.wsl'>Download</a>
+                <a class='p-button--positive' href='/download/wsl/thank-you?version=24.04.4&architecture=amd64'>Download</a>
                 <span class='u-text--muted'>373MB</span>
               </div>
             </div>
@@ -58,7 +58,7 @@
                 <p class='p-heading--5'>ARM 64-bit architecture</p>
               </div>
               <div class='grid-col-2'>
-                <a class='p-button--positive' href='https://cdimages.ubuntu.com/releases/noble/release/ubuntu-24.04.4-wsl-arm64.wsl'>Download</a>
+                <a class='p-button--positive' href='/download/wsl/thank-you?version=24.04.4&architecture=arm64'>Download</a>
                 <span class='u-text--muted'>374MB</span>
               </div>
             </div>
@@ -189,7 +189,7 @@
             {
               "content_html": "Download the Ubuntu Pro for WSL app",
               "attrs": {
-                "href": "/wsl/install"
+                "href": "/download/wsl/thank-you?architecture=pro"
               }
             }
           ],

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -52,7 +52,7 @@
               <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-wsl-amd64.wsl">download now</a>.
             {% endif %}
             <br />
-            {% with version=version, system="wsl" if architecture != "arm64" else "wsl-arm64", architecture=architecture %}
+            {% with version=version, system="wsl", checksum_system="wsl-arm64" if architecture == "arm64" else "", architecture=architecture %}
               {% include "download/shared/_verify-checksums.html" %}
             {% endwith %}
           </p>

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -34,8 +34,8 @@
   {% endif %}
 
   <section class="p-strip is-shallow u-no-padding--bottom">
-    <div class="row--50-50">
-      <div class="col">
+    <div class="grid-row--50-50">
+      <div class="grid-col">
         {% if architecture == 'pro' %}
           <h1>Thank you for downloading Ubuntu Pro for WSL</h1>
           <p>
@@ -63,7 +63,7 @@
           </p>
         {% endif %}
       </div>
-      <div class="col">
+      <div class="grid-col">
         {% with returnUrl="/download/wsl", ga_event_title="Ubuntu WSL download" %}
           {% include 'shared/_download-newsletter.html' %}
         {% endwith %}

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -1,0 +1,99 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Thank you {{ "for downloading Ubuntu Pro for WSL" if architecture == "pro" else "for downloading Ubuntu on WSL" }}{% endblock %}
+
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex" />
+{% endblock %}
+
+{% set pro_download_url = "https://github.com/canonical/ubuntu-pro-for-wsl/releases/latest/download/UbuntuProForWSL.msixbundle" %}
+
+{% block content %}
+
+  {% if architecture == 'pro' %}
+    <meta http-equiv="refresh"
+          content="3;url={{ pro_download_url }}" />
+  {% elif version %}
+    {% if architecture == 'arm64' %}
+      <noscript>
+        <meta http-equiv="refresh"
+              content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-wsl-arm64.wsl" />
+      </noscript>
+    {% else %}
+      <noscript>
+        <meta http-equiv="refresh"
+              content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-wsl-amd64.wsl" />
+      </noscript>
+    {% endif %}
+  {% endif %}
+
+  <section class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row--50-50">
+      <div class="col">
+        {% if architecture == 'pro' %}
+          <h1>Thank you for downloading Ubuntu Pro for WSL</h1>
+          <p>
+            Your download should start automatically. If it doesn't,
+            <a href="{{ pro_download_url }}">download now</a>.
+          </p>
+        {% elif version %}
+          <h1>Thank you for downloading Ubuntu {{ version }} on WSL</h1>
+          <p>
+            Your download should start automatically. If it doesn't,
+            {% if architecture == 'arm64' %}
+              <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-wsl-arm64.wsl">download now</a>.
+            {% else %}
+              <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-wsl-amd64.wsl">download now</a>.
+            {% endif %}
+            <br />
+            {% with version=version, system="wsl" if architecture != "arm64" else "wsl-arm64", architecture=architecture %}
+              {% include "download/shared/_verify-checksums.html" %}
+            {% endwith %}
+          </p>
+        {% else %}
+          <h1>You have not selected an image to download</h1>
+          <p>
+            Please <a href="/download/wsl">select an image</a> to download.
+          </p>
+        {% endif %}
+      </div>
+      <div class="col">
+        {% with returnUrl="/download/wsl", ga_event_title="Ubuntu WSL download" %}
+          {% include 'shared/_download-newsletter.html' %}
+        {% endwith %}
+      </div>
+    </div>
+  </section>
+
+{% endblock content %}
+
+{% block footer_extra %}
+  {% if architecture == 'pro' %}
+    <script defer>
+      window.location.href = '{{ pro_download_url }}';
+    </script>
+  {% elif version %}
+    <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+    <script defer>
+      var architecture = '{{ architecture }}';
+      var version = '{{ version }}';
+
+      if (version && architecture) {
+        var imageName = 'ubuntu-' + version + '-wsl-' + architecture + '.wsl';
+        var GAlabel = version + '-wsl-' + architecture;
+
+        if (architecture === 'arm64') {
+          window.location.href = 'https://cdimage.ubuntu.com/releases/' + version + '/release/' + imageName;
+        } else {
+          window.initImageDownload(version + '/' + imageName, GAlabel);
+        }
+      }
+    </script>
+  {% endif %}
+{% endblock footer_extra %}

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -1,5 +1,7 @@
 {% extends "download/_base_download.html" %}
 
+{% set hide_inner_wrapper = True %}
+
 {% block title %}Thank you {{ "for downloading Ubuntu Pro for WSL" if architecture == "pro" else "for downloading Ubuntu on WSL" }}{% endblock %}
 
 {% block meta_copydoc %}{% endblock meta_copydoc %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -577,7 +577,7 @@ app.add_url_rule(
 app.add_url_rule(
     (
         "/download"
-        "/<regex('server|desktop|cloud|raspberry-pi'):category>"
+        "/<regex('server|desktop|cloud|raspberry-pi|wsl'):category>"
         "/thank-you"
     ),
     view_func=download_thank_you,


### PR DESCRIPTION
## Done

- Add /thank-you pages for desktop and server arm64, and wsl downloads
- Adds checksums for the downloads and exposes them on the download page

**Key changes:**

**1. WSL Download Flow Improvements**
- Added a new `wsl/thank-you.html` template to handle WSL and Ubuntu Pro for WSL downloads, including correct redirects, download links, and checksum verification for both amd64 and arm64 architectures, as well as Ubuntu Pro for WSL.
- Updated WSL download links in `wsl.html` to route through the new thank-you page, ensuring consistent download tracking and user experience. [[1]](diffhunk://#diff-7dd52d22ed2cf89d70ead3e0c72d3786243f675581a76e1a190582885ccae139L51-R51) [[2]](diffhunk://#diff-7dd52d22ed2cf89d70ead3e0c72d3786243f675581a76e1a190582885ccae139L61-R61) [[3]](diffhunk://#diff-7dd52d22ed2cf89d70ead3e0c72d3786243f675581a76e1a190582885ccae139L192-R192)
- Extended the download thank-you route in `webapp/app.py` to support the new `wsl` category.

**2. ARM64 Download Flow Consistency**
- Updated desktop and server download links to route ARM64 downloads through their respective thank-you pages, adding appropriate redirects and verification logic for ARM64 images. [[1]](diffhunk://#diff-468423f9f45f339fb548f6f526513ae75cb2d7db68730bc6af4929bedb615034L219-R219) [[2]](diffhunk://#diff-c06a5f50b0c4273ba922de48675bbcf5ca0814f5deb610a910f05493c1c341eaR45-R49) [[3]](diffhunk://#diff-c06a5f50b0c4273ba922de48675bbcf5ca0814f5deb610a910f05493c1c341eaL61-L71) [[4]](diffhunk://#diff-c06a5f50b0c4273ba922de48675bbcf5ca0814f5deb610a910f05493c1c341eaL319-R331) [[5]](diffhunk://#diff-ade2279018627874521638d008b675342f9c81f89b6794d8dd71ad1a5eb069f3L38-R44) [[6]](diffhunk://#diff-e999ed00d596c95170c0b590c7dda2a5e8ffe9d0a85733e535033ea3749f3914R17-R23) [[7]](diffhunk://#diff-e999ed00d596c95170c0b590c7dda2a5e8ffe9d0a85733e535033ea3749f3914R33-R39) [[8]](diffhunk://#diff-e999ed00d596c95170c0b590c7dda2a5e8ffe9d0a85733e535033ea3749f3914R254-R266)

**3. Checksum and Metadata Updates**
- Added new checksum entries for ARM64 and WSL images (including `desktop-arm64`, `live-server-arm64`, and `wsl-arm64`) in `releases.yaml` to support verification on the thank-you pages. [[1]](diffhunk://#diff-2971fc0fc21c1f5ef410d394709e9dcd106c1dafc6360fbbdeec8457b638259dR74-R75) [[2]](diffhunk://#diff-2971fc0fc21c1f5ef410d394709e9dcd106c1dafc6360fbbdeec8457b638259dR85-R87) [[3]](diffhunk://#diff-2971fc0fc21c1f5ef410d394709e9dcd106c1dafc6360fbbdeec8457b638259dR125-R126)
- 
## QA

- Got to the following download pages, check all download links lead to a thank you page and checksums are available and accurate ([checksum come from here](https://cdimage.ubuntu.com/releases/))

https://ubuntu-com-16241.demos.haus/download/desktop
https://cdimage.ubuntu.com/releases/25.10/release/SHA256SUMS

https://ubuntu-com-16241.demos.haus/download/server/arm
https://cdimage.ubuntu.com/releases/24.04/release/SHA256SUMS

https://ubuntu-com-16241.demos.haus/download/wsl
https://cdimages.ubuntu.com/releases/noble/release/SHA256SUMS

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-35742
