### PR TITLE
[WD-36043] Update release cycle graphs for 26.04 LTS

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -138,16 +138,28 @@ export var serverAndDesktopReleases = [
     status: "PRO_LEGACY_SUPPORT",
   },
   {
-    startDate: new Date("2025-04-01T00:00:00"),
-    endDate: new Date("2026-01-05T00:00:00"),
-    taskName: "25.04 (Plucky Puffin)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2025-10-01T00:00:00"),
     endDate: new Date("2026-07-07T00:00:00"),
     taskName: "25.10 (Questing Quokka)",
     status: "INTERIM_RELEASE",
+  },
+  {
+    startDate: new Date("2026-04-01T00:00:00"),
+    endDate: new Date("2028-09-30T00:00:00"),
+    taskName: "26.04 LTS (Resolute Raccoon)",
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
+  },
+  {
+    startDate: new Date("2028-09-30T00:00:00"),
+    endDate: new Date("2031-04-01T00:00:00"),
+    taskName: "26.04 LTS (Resolute Raccoon)",
+    status: "MAINTENANCE_UPDATES",
+  },
+  {
+    startDate: new Date("2031-04-01T00:00:00"),
+    endDate: new Date("2036-04-09T00:00:00"),
+    taskName: "26.04 LTS (Resolute Raccoon)",
+    status: "ESM",
   },
 ];
 
@@ -1286,8 +1298,8 @@ export var microStackStatus = {
 };
 
 export var desktopServerReleaseNames = [
+  "26.04 LTS (Resolute Raccoon)",
   "25.10 (Questing Quokka)",
-  "25.04 (Plucky Puffin)",
   "24.04 LTS (Noble Numbat)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -136,7 +136,7 @@ export var serverAndDesktopReleases = [
     endDate: new Date("2039-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",
     status: "PRO_LEGACY_SUPPORT",
-  },  
+  },
   {
     startDate: new Date("2026-04-23T00:00:00"),
     endDate: new Date("2036-04-23T00:00:00"),

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -136,30 +136,30 @@ export var serverAndDesktopReleases = [
     endDate: new Date("2039-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",
     status: "PRO_LEGACY_SUPPORT",
+  },  
+  {
+    startDate: new Date("2026-04-23T00:00:00"),
+    endDate: new Date("2036-04-23T00:00:00"),
+    taskName: "26.04 LTS (Resolute Raccoon)",
+    status: "MAIN_UNIVERSE",
   },
   {
-    startDate: new Date("2025-10-01T00:00:00"),
-    endDate: new Date("2026-07-07T00:00:00"),
-    taskName: "25.10 (Questing Quokka)",
-    status: "INTERIM_RELEASE",
-  },
-  {
-    startDate: new Date("2026-04-01T00:00:00"),
-    endDate: new Date("2028-09-30T00:00:00"),
+    startDate: new Date("2026-04-23T00:00:00"),
+    endDate: new Date("2031-04-23T00:00:00"),
     taskName: "26.04 LTS (Resolute Raccoon)",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
-    startDate: new Date("2028-09-30T00:00:00"),
-    endDate: new Date("2031-04-01T00:00:00"),
-    taskName: "26.04 LTS (Resolute Raccoon)",
-    status: "MAINTENANCE_UPDATES",
-  },
-  {
-    startDate: new Date("2031-04-01T00:00:00"),
-    endDate: new Date("2036-04-09T00:00:00"),
+    startDate: new Date("2031-04-23T00:00:00"),
+    endDate: new Date("2036-04-23T00:00:00"),
     taskName: "26.04 LTS (Resolute Raccoon)",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2036-04-23T00:00:00"),
+    endDate: new Date("2041-04-23T00:00:00"),
+    taskName: "26.04 LTS (Resolute Raccoon)",
+    status: "PRO_LEGACY_SUPPORT",
   },
 ];
 
@@ -1299,7 +1299,6 @@ export var microStackStatus = {
 
 export var desktopServerReleaseNames = [
   "26.04 LTS (Resolute Raccoon)",
-  "25.10 (Questing Quokka)",
   "24.04 LTS (Noble Numbat)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -370,7 +370,7 @@ function getMaxNumberOfLines(svg, textList, width) {
   ));
   svg.style.position = "absolute";
   svg.style.visibility = "hidden";
-  svg.width = width;
+  svg.setAttribute("width", width);
   document.body.appendChild(svg);
 
   var maxNumberOfLines = 1;

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -16,14 +16,7 @@
       <td>Apr 2026</td>
       <td>Apr 2031</td>
       <td>Apr 2036</td>
-      <td aria-label="Not applicable">-</td>
-    </tr>
-    <tr>
-      <td colspan="2">25.10 (Questing Quokka)</td>
-      <td>Oct 2025</td>
-      <td>Jul 2026</td>
-      <td aria-label="Not applicable">-</td>
-      <td aria-label="Not applicable">-</td>
+      <td>Apr 2041</td>
     </tr>
     <tr>
       <td colspan="2">

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -10,16 +10,18 @@
   </thead>
   <tbody>
     <tr>
-      <td colspan="2">25.10 (Questing Quokka)</td>
-      <td>Oct 2025</td>
-      <td>Jul 2026</td>
-      <td aria-label="Not applicable">-</td>
+      <td colspan="2">
+        <strong>26.04 LTS (Resolute Raccoon)</strong>
+      </td>
+      <td>Apr 2026</td>
+      <td>Apr 2031</td>
+      <td>Apr 2036</td>
       <td aria-label="Not applicable">-</td>
     </tr>
     <tr>
-      <td colspan="2">25.04 (Plucky Puffin)</td>
-      <td>Apr 2025</td>
-      <td>Jan 2026</td>
+      <td colspan="2">25.10 (Questing Quokka)</td>
+      <td>Oct 2025</td>
+      <td>Jul 2026</td>
       <td aria-label="Not applicable">-</td>
       <td aria-label="Not applicable">-</td>
     </tr>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -84,7 +84,7 @@
           for Ubuntu releases
         </h2>
       </div>
-      <div class="col" id="server-desktop-eol-key" style="padding-top:1rem;"></div>
+      <div class="col u-hide--small" id="server-desktop-eol-key" style="padding-top:1rem;"></div>
     </div>
     <div class="u-fixed-width">
       <div class="u-hide--small" id="server-desktop-eol"></div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -338,7 +338,7 @@
           <tbody>
             <tr>
               <td>
-                <strong>26.04 LTS (Resolute Raccoon)</strong>
+                <strong>26.04 LTS</strong>
               </td>
               <td>Apr 2026</td>
               <td>Apr 2031</td>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -338,6 +338,14 @@
           <tbody>
             <tr>
               <td>
+                <strong>26.04 LTS (Resolute Raccoon)</strong>
+              </td>
+              <td>Apr 2026</td>
+              <td>Apr 2031</td>
+              <td>Apr 2036</td>
+            </tr>
+            <tr>
+              <td>
                 <strong>24.04 LTS</strong>
               </td>
               <td>Apr 2024</td>


### PR DESCRIPTION
## QA

The release diagrams on the following pages should add 26.04 LTS and remove 25.04:

- https://ubuntu-com-16246.demos.haus/desktop/developers
- https://ubuntu-com-16246.demos.haus/server
- https://ubuntu-com-16246.demos.haus/security/esm
- https://ubuntu-com-16246.demos.haus/about

## Issue

https://warthogs.atlassian.net/browse/WD-36043

