### PR TITLE
WD-36049 Update /download/raspberry-pi for 26.04

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -109,45 +109,11 @@
           {% if releases_yaml.lts.raspi_server_iso_size %}
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_server_iso_size }}</span>
           {% endif %}
-        </p>
-      </div>
-    </div>
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50 p-section">
-      <div class="col u-image-position">
-        <h2>Ubuntu {{ releases_yaml.latest.full_version }}</h2>
-        <div class="p-image-wrapper u-hide--small">
-          {{ image(url=releases_yaml.latest.mascot_image_large.url,
-                    alt=releases_yaml.latest.name,
-                    width=releases_yaml.latest.mascot_image_large.width,
-                    height=releases_yaml.latest.mascot_image_large.height,
-                    hi_def=True,
-                    loading="auto") | safe
-          }}
-        </div>
-      </div>
-      <div class="col">
-        <p>
-          The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases_yaml.latest.full_version }} comes with nine months of security and maintenance updates, until {{ releases_yaml.latest.eol }}.
-        </p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases_yaml.latest.full_version }}', 'eventValue' : undefined });"
-             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases_yaml.latest.full_version }}</a>
-          {% if releases_yaml.latest.raspi_desktop_iso_size %}
-            <span class="u-text--muted">{{ releases_yaml.latest.raspi_desktop_iso_size }}</span>
-          {% endif %}
-        </p>
-        <p>Minimum 4GBs of RAM and 16GB storage required</p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=server-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases_yaml.latest.full_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Server {{ releases_yaml.latest.full_version }}</a>
-          {% if releases_yaml.latest.raspi_server_iso_size %}
-            <span class="u-text--muted">{{ releases_yaml.latest.raspi_server_iso_size }}</span>
-          {% endif %}
+
+          <p>Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
+          <p>Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
+          <p>EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
+          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation</a>.</p>
         </p>
       </div>
     </div>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -95,7 +95,7 @@
         <p class="u-responsive-realign">
           <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases_yaml.lts.full_version }}', 'eventValue' : undefined });"
-             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases_yaml.lts.full_version }} LTS</a>
+             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop</a>
           {% if releases_yaml.lts.raspi_desktop_iso_size %}
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_desktop_iso_size }}</span>
           {% endif %}
@@ -105,7 +105,7 @@
         <p class="u-responsive-realign">
           <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.lts.full_version }}&amp;architecture=server-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases_yaml.lts.full_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Server {{ releases_yaml.lts.full_version }} LTS</a>
+             class="p-button">Download Ubuntu Server</a>
           {% if releases_yaml.lts.raspi_server_iso_size %}
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_server_iso_size }}</span>
           {% endif %}
@@ -113,7 +113,7 @@
           <p>Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
           <p>Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
           <p>EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
-          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation</a>.</p>
+          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation&nbsp;&rsaquo;</a>.</p>
         </p>
       </div>
     </div>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -113,7 +113,7 @@
           <p>Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
           <p>Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
           <p>EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
-          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation&nbsp;&rsaquo;</a>.</p>
+          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation&nbsp;&rsaquo;</a></p>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Updated `/download/raspberry-pi` for 26.04.

## QA

- Go to https://ubuntu-com-16247.demos.haus/download/raspberry-pi
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152) and compare with the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?tab=t.0#)

Alternatively, check out this feature branch and:
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
    
## Issue / Card

Fixes WD-36049