### PR TITLE
WD-36031: Copy update on /download/wsl

### DIFF
--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -34,7 +34,7 @@
       <hr class="p-rule" />
       <div class="col">
         <div class="p-section">
-          <h2>Ubuntu 26.04 LTS</h2>
+          <h2>Ubuntu {{ releases_yaml.lts.full_version }} LTS</h2>
         </div>
         <div class="p-image-wrapper u-hide--small">
           {{ image(url=releases_yaml.lts.mascot_image_large.url,
@@ -117,8 +117,8 @@
           <p>An updated set of language toolchains and compilers.</p>
           <hr class="p-rule--muted" />
           <p>
-            <a href="https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-resolute-raccoon">Press release&nbsp;&rsaquo;</a>&nbsp;&nbsp;
-            <a href="https://documentation.ubuntu.com/release-notes/26.04/">Release notes&nbsp;&rsaquo;</a>
+            <a href="{{ releases_yaml.lts.blog_post_url }}">Press release&nbsp;&rsaquo;</a>&nbsp;&nbsp;
+            <a href="{{ releases_yaml.lts.release_notes_url }}">Release notes&nbsp;&rsaquo;</a>
           </p>
         </div>
 

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -75,38 +75,40 @@
           </div>
         </div>
 
-        <nav class="p-tabs js-tabbed-content">
-          <ul class="p-tabs__list u-no-margin--bottom"
-              role="tablist"
-              data-maintain-hash="true">
-            <li class="p-tabs__item">
-              <a class="p-tabs__link"
-                 role="tab"
-                 aria-selected="true"
-                 id="release-notes-tab"
-                 href="#release-notes"
-                 aria-controls="release-notes">What's new</a>
-            </li>
-            <li class="p-tabs__item">
-              <a class="p-tabs__link"
-                 role="tab"
-                 aria-selected="false"
-                 id="system-requirements-tab"
-                 href="#system-requirements"
-                 aria-controls="system-requirements"
-                 tabindex="-1">System requirements</a>
-            </li>
-            <li class="p-tabs__item">
-              <a class="p-tabs__link"
-                 role="tab"
-                 aria-selected="false"
-                 id="how-to-install-tab"
-                 href="#how-to-install"
-                 aria-controls="how-to-install"
-                 tabindex="-1">How to install</a>
-            </li>
-          </ul>
-        </nav>
+        <div class="p-section--shallow">
+          <nav class="p-tabs js-tabbed-content">
+            <ul class="p-tabs__list u-no-margin--bottom"
+                role="tablist"
+                data-maintain-hash="true">
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="true"
+                   id="release-notes-tab"
+                   href="#release-notes"
+                   aria-controls="release-notes">What's new</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="system-requirements-tab"
+                   href="#system-requirements"
+                   aria-controls="system-requirements"
+                   tabindex="-1">System requirements</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="how-to-install-tab"
+                   href="#how-to-install"
+                   aria-controls="how-to-install"
+                   tabindex="-1">How to install</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
 
         <div id="release-notes"
              class="p-tabs__content"

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -11,7 +11,6 @@
 {% endblock meta_copydoc %}
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
-{% from "_macros/vf_tab-section.jinja" import vf_tab_section %}
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from "_macros/vf_resources.jinja" import vf_resources %}
@@ -30,108 +29,123 @@
   -%}
   {%- endcall -%}
 
-  {{- vf_tab_section(
-      title={
-          "text": "Ubuntu 24.04 LTS"
-      },
-      description={
-          "type": "html",
-          "content": "
-            <p>
-              The latest <abbr title='Long-term support'>LTS</abbr> version of Ubuntu on WSL.
-              LTS stands for long-term support – which means five years of free security and
-              maintenance updates, extended to 15 years with <a href='/pro'>Ubuntu Pro</a>.
-            </p>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-section">
+          <h2>Ubuntu 26.04 LTS</h2>
+        </div>
+        <div class="p-image-wrapper u-hide--small">
+          {{ image(url=releases_yaml.lts.mascot_image_large.url,
+                    alt=releases_yaml.lts.name,
+                    width=releases_yaml.lts.mascot_image_large.width,
+                    height=releases_yaml.lts.mascot_image_large.height,
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu on WSL. LTS stands for long-term support &ndash; which means five years of free security and maintenance updates, extended to 15 years with <a href="/pro">Ubuntu Pro</a>.
+          </p>
 
-            <div class='grid-row'>
-              <div class='grid-col-2'>
-                <p class='p-heading--5'>Intel or AMD 64-bit architecture</p>
-              </div>
-              <div class='grid-col-2'>
-                <a class='p-button--positive' href='https://releases.ubuntu.com/noble/ubuntu-24.04.4-wsl-amd64.wsl'>Download</a>
-                <span class='u-text--muted'>373MB</span>
-              </div>
+          <div class="row">
+            <div class="col-3">
+              <p class="p-heading--5">Intel or AMD 64-bit architecture</p>
             </div>
+            <div class="col-3">
+              <a class="p-button--positive"
+                 href="https://releases.ubuntu.com/noble/ubuntu-24.04.4-wsl-amd64.wsl">Download</a>
+              <span class="u-text--muted">373MB</span>
+            </div>
+          </div>
 
-            <div class='grid-row'>
-              <div class='grid-col-2'>
-                <p class='p-heading--5'>ARM 64-bit architecture</p>
-              </div>
-              <div class='grid-col-2'>
-                <a class='p-button--positive' href='https://cdimages.ubuntu.com/releases/noble/release/ubuntu-24.04.4-wsl-arm64.wsl'>Download</a>
-                <span class='u-text--muted'>374MB</span>
-              </div>
+          <div class="row">
+            <div class="col-3">
+              <p class="p-heading--5">ARM 64-bit architecture</p>
             </div>
-          "
-      },
-      tabs=[
-          {
-              "tab_html": "<h5 class='u-no-margin--bottom'>What’s new</h5>",
-              "type": "basic-section",
-              "item": {
-                  "items": [
-                      {
-                          "type": "description",
-                          "item": {
-                              "content": "
-                                <p>Rust 1.78, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades</p>
-                                <p class='link'>
-                                  <a href='https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890'>
-                                    Release notes ›
-                                  </a>
-                                </p>
-                              "
-                          }
-                      }
-                  ]
-              }
-          },
-          {
-              "tab_html": "<h5 class='u-no-margin--bottom'>System requirements</h5>",
-              "type": "basic-section",
-              "item": {
-                  "items": [
-                      {
-                          "type": "description",
-                          "item": {
-                              "content": "
-                                <p>Windows 11 (recommended) or Windows 10 with minimum version 21H2 on a physical machine</p>
-                                <p class='link'>
-                                  <a href='https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#what-you-will-need'>
-                                    Detailed requirements ›
-                                  </a>
-                                </p>
-                              "
-                          }
-                      }
-                  ]
-              }
-          },
-          {
-              "tab_html": "<h5 class='u-no-margin--bottom'>How to install</h5>",
-              "type": "basic-section",
-              "item": {
-                  "items": [
-                      {
-                          "type": "description",
-                          "item": {
-                              "content": "
-                                <p>To install, you can download and double-click the <code>.wsl</code> image, or open the PowerShell terminal and run <code>wsl --install</code></p>
-                                <p class='link'>
-                                  <a href='https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#install-and-enable-wsl'>
-                                    Detailed installation steps ›
-                                  </a>
-                                </p>
-                              "
-                          }
-                      }
-                  ]
-              }
-          }
-        
-          
-      ]
-  ) -}}
+            <div class="col-3">
+              <a class="p-button--positive"
+                 href="https://cdimages.ubuntu.com/releases/noble/release/ubuntu-24.04.4-wsl-arm64.wsl">Download</a>
+              <span class="u-text--muted">374MB</span>
+            </div>
+          </div>
+        </div>
+
+        <nav class="p-tabs js-tabbed-content">
+          <ul class="p-tabs__list u-no-margin--bottom"
+              role="tablist"
+              data-maintain-hash="true">
+            <li class="p-tabs__item">
+              <a class="p-tabs__link"
+                 role="tab"
+                 aria-selected="true"
+                 id="release-notes-tab"
+                 href="#release-notes"
+                 aria-controls="release-notes">What's new</a>
+            </li>
+            <li class="p-tabs__item">
+              <a class="p-tabs__link"
+                 role="tab"
+                 aria-selected="false"
+                 id="system-requirements-tab"
+                 href="#system-requirements"
+                 aria-controls="system-requirements"
+                 tabindex="-1">System requirements</a>
+            </li>
+            <li class="p-tabs__item">
+              <a class="p-tabs__link"
+                 role="tab"
+                 aria-selected="false"
+                 id="how-to-install-tab"
+                 href="#how-to-install"
+                 aria-controls="how-to-install"
+                 tabindex="-1">How to install</a>
+            </li>
+          </ul>
+        </nav>
+
+        <div id="release-notes"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="release-notes-tab">
+          <p>An updated set of language toolchains and compilers.</p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-resolute-raccoon">Press release&nbsp;&rsaquo;</a>&nbsp;&nbsp;
+            <a href="https://documentation.ubuntu.com/release-notes/26.04/">Release notes&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+
+        <div id="system-requirements"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="system-requirements-tab">
+          <p>Windows 11 (recommended) or Windows 10 with minimum version 21H2 on a physical machine</p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#what-you-will-need">Detailed requirements&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+
+        <div id="how-to-install"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="how-to-install-tab">
+          <p>
+            To install, you can download and double-click the <code>.wsl</code> image, or open the PowerShell terminal and run <code>wsl --install</code>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#install-and-enable-wsl">Detailed installation steps&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
 
   {{- vf_basic_section(
     title={"text": "Ubuntu is the number 1 choice<br class='u-hide--small u-hide--medium' /> for organizations using WSL"},
@@ -304,5 +318,6 @@
   -}}
 
   <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -30,9 +30,9 @@
   {%- endcall -%}
 
   <section class="p-section">
-    <div class="row--50-50">
+    <div class="grid-row--50-50">
       <hr class="p-rule" />
-      <div class="col">
+      <div class="grid-col">
         <div class="p-section">
           <h2>Ubuntu {{ releases_yaml.lts.full_version }} LTS</h2>
         </div>
@@ -46,28 +46,28 @@
           }}
         </div>
       </div>
-      <div class="col">
+      <div class="grid-col">
         <div class="p-section--shallow">
           <p>
             The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu on WSL. LTS stands for long-term support &ndash; which means five years of free security and maintenance updates, extended to 15 years with <a href="/pro">Ubuntu Pro</a>.
           </p>
 
-          <div class="row">
-            <div class="col-3">
+          <div class="grid-row">
+            <div class="grid-col-2">
               <p class="p-heading--5">Intel or AMD 64-bit architecture</p>
             </div>
-            <div class="col-3">
+            <div class="grid-col-2">
               <a class="p-button--positive"
                  href="https://releases.ubuntu.com/resolute/ubuntu-26.04-wsl-amd64.wsl">Download</a>
               <span class="u-text--muted">373MB</span>
             </div>
           </div>
 
-          <div class="row">
-            <div class="col-3">
+          <div class="grid-row">
+            <div class="grid-col-2">
               <p class="p-heading--5">ARM 64-bit architecture</p>
             </div>
-            <div class="col-3">
+            <div class="grid-col-2">
               <a class="p-button--positive"
                  href="https://cdimages.ubuntu.com/releases/resolute/release/ubuntu-26.04-wsl-arm64.wsl">Download</a>
               <span class="u-text--muted">374MB</span>

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -58,7 +58,7 @@
             </div>
             <div class="col-3">
               <a class="p-button--positive"
-                 href="https://releases.ubuntu.com/noble/ubuntu-24.04.4-wsl-amd64.wsl">Download</a>
+                 href="https://releases.ubuntu.com/resolute/ubuntu-26.04-wsl-amd64.wsl">Download</a>
               <span class="u-text--muted">373MB</span>
             </div>
           </div>
@@ -69,7 +69,7 @@
             </div>
             <div class="col-3">
               <a class="p-button--positive"
-                 href="https://cdimages.ubuntu.com/releases/noble/release/ubuntu-24.04.4-wsl-arm64.wsl">Download</a>
+                 href="https://cdimages.ubuntu.com/releases/resolute/release/ubuntu-26.04-wsl-arm64.wsl">Download</a>
               <span class="u-text--muted">374MB</span>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Reverted first section on `/download/wsl` to remove usage of `vf_tab_section` pattern. This pattern does not facilitate having an image underneath the title in the left column, which was required for this copy update. This action was suggested by Sites.
- Updated copy per the copy doc.

**N.B.**: The image that will show on the `/download/wsl` page is still the Noble Numbat mascot. I have just used the `releases_yaml.lts.mascot_image_large.url` value for the image URL. This was also suggested by Sites team, as the `releases.yaml` file itself will be updated to the new Resolute Raccoon mascot on the `26-04-feature-branch` branch.

## QA

- Open the [DEMO](https://ubuntu-com-16252.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure the copy matches the [copy doc](https://docs.google.com/document/d/16mQ6w4HGtaERD5QL-euieKYRtYb2ojVksdEocecLkto/edit?tab=t.0)

## Issue / Card

Fixes [wd-36031](https://warthogs.atlassian.net/browse/wd-36031)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

