### PR TITLE
Copy update: /download/risc-v

### DIFF
--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -41,7 +41,7 @@
         </p>
         <p>
           <strong>
-            Note: We have upgraded the required RISC-V ISA profile to RVA23S64 with the 25.10 release. Hardware that is not RVA23-ready continues to be supported by our 24.04 LTS release.
+            Note: We have upgraded the required RISC-V ISA profile to RVA23S64 with the 25.10 release. Hardware that is not RVA23-ready continues to be supported by our 24.04.4 LTS release.
           </strong>
         </p>
       {%- endif -%}

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -29,9 +29,7 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/24.04.4/release/ubuntu-24.04.4-preinstalled-server-riscv64.img.xz">Download 24.04.4 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.10/release/ubuntu-25.10-preinstalled-server-riscv64.img.xz">Download 25.10</a>
+           href="https://cdimage.ubuntu.com/releases/26.04/release/ubuntu-26.04-preinstalled-server-riscv64.img.xz">Download 26.04 LTS</a>
       </p>
     </div>
   </div>
@@ -47,9 +45,7 @@
     <div class="col-6">
       <p>
         <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/24.04.4/release/ubuntu-24.04.4-live-server-riscv64.iso">Download 24.04.4 LTS live installer</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.10/release/ubuntu-25.10-live-server-riscv64.iso">Download 25.10 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/26.04/release/ubuntu-26.04-live-server-riscv64.iso">Download 26.04 LTS live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/qemu-riscv/">How to install Ubuntu on QEMU RISC-V</a>


### PR DESCRIPTION
## Done
Updated RISC-V download pages for 26.04 LTS in line with the [copy doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.q8v2ezpfqvp0).

## QA
- Open the [demo](https://ubuntu-com-16253.demos.haus/download/risc-v)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/risc-v
- Ensure the page is line with the copy doc

## Issue
https://warthogs.atlassian.net/browse/WD-36044