### PR TITLE
Update blog post URL for Ubuntu 26.04 LTS release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -6,7 +6,7 @@ latest:
   release_date: "April 2026"
   eol: "April 2031"
   release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"
-  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-resolute-raccoon"
+  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon"
   mascot_image_large:
     url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182
@@ -23,7 +23,7 @@ lts:
   release_date: "April 2026"
   eol: "April 2031"
   release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"
-  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-resolute-raccoon"
+  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon"
   mascot_image_large:
     url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182


### PR DESCRIPTION
## Done

- URL will also contain "lts", amended both `blog_post_url` in latest and lts to match.

## QA

- Open the [DEMO](https://ubuntu-com-16267.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Copydoc: https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit?tab=t.0

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

