### PR TITLE
Reduce size of additional info on /download pages for consistency

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,25 +1,20 @@
 latest:
-  slug: QuestingQuokka
-  name: "Questing Quokka"
-  short_version: "25.10"
-  full_version: "25.10"
-  desktop_version: "25.10"
-  core_version: "24"
-  release_date: "October 2025"
-  eol: "July 2026"
-  past_eol_date: false
-  release_notes_url: "https://documentation.ubuntu.com/release-notes/25.10/"
-  blog_post_url: "https://canonical.com/blog/canonical-releases-ubuntu-25-10-questing-quokka"
+  slug: ResoluteRaccoon
+  name: "Resolute Raccoon"
+  short_version: "26.04"
+  full_version: "26.04"
+  release_date: "April 2026"
+  eol: "April 2031"
+  release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"
+  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-resolute-raccoon"
   mascot_image_large:
-    url: "https://assets.ubuntu.com/v1/fe84bc06-questing_quokka_mascot_circle_bg.svg"
+    url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182
     height: 182
-  iso_download_size: "5.3GB"
-  arm_iso_download_size: "3.6GB"
-  server_iso_size: "1.9GB"
-  raspi_desktop_iso_size: "2.9GB"
-  raspi_server_iso_size: "1.2GB"
-  rasp_pi_core_24_size: "314MB"
+  iso_download_size: "5.9GB"
+  server_iso_size: "3GB"
+  raspi_desktop_iso_size: "2.6GB"
+  raspi_server_iso_size: "1.1GB"
 lts:
   slug: ResoluteRaccoon
   name: "Resolute Raccoon"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,12 +1,12 @@
 latest:
-  slug: ResoluteRaccoon
-  name: "Resolute Raccoon"
-  short_version: "26.04"
-  full_version: "26.04"
-  desktop_version: "26.04"
+  slug: QuestingQuokka
+  name: "Questing Quokka"
+  short_version: "25.10"
+  full_version: "25.10"
+  desktop_version: "25.10"
   core_version: "24"
-  release_date: "April 2026"
-  eol: "April 2011"
+  release_date: "October 2025"
+  eol: "July 2026"
   past_eol_date: false
   release_notes_url: "https://documentation.ubuntu.com/release-notes/25.10/"
   blog_post_url: "https://canonical.com/blog/canonical-releases-ubuntu-25-10-questing-quokka"
@@ -26,9 +26,9 @@ lts:
   short_version: "26.04"
   full_version: "26.04"
   release_date: "April 2026"
-  eol: "April 2010"
-  release_notes_url: "https://documentation.ubuntu.com/release-notes/24.04/"
-  blog_post_url: "https://ubuntu.com/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive"
+  eol: "April 2031"
+  release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"
+  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-resolute-raccoon"
   mascot_image_large:
     url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182

--- a/releases.yaml
+++ b/releases.yaml
@@ -30,9 +30,9 @@ lts:
   release_notes_url: "https://documentation.ubuntu.com/release-notes/24.04/"
   blog_post_url: "https://ubuntu.com/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive"
   mascot_image_large:
-    url: "https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png"
+    url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182
-    height: 135
+    height: 182
   iso_download_size: "5.9GB"
   server_iso_size: "3GB"
   raspi_desktop_iso_size: "2.6GB"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,12 +1,12 @@
 latest:
-  slug: QuestingQuokka
-  name: "Questing Quokka"
-  short_version: "25.10"
-  full_version: "25.10"
-  desktop_version: "25.10"
+  slug: ResoluteRaccoon
+  name: "Resolute Raccoon"
+  short_version: "26.04"
+  full_version: "26.04"
+  desktop_version: "26.04"
   core_version: "24"
-  release_date: "October 2025"
-  eol: "July 2026"
+  release_date: "April 2026"
+  eol: "April 2011"
   past_eol_date: false
   release_notes_url: "https://documentation.ubuntu.com/release-notes/25.10/"
   blog_post_url: "https://canonical.com/blog/canonical-releases-ubuntu-25-10-questing-quokka"
@@ -21,12 +21,12 @@ latest:
   raspi_server_iso_size: "1.2GB"
   rasp_pi_core_24_size: "314MB"
 lts:
-  slug: NobleNumbat
-  name: "Noble Numbat"
-  short_version: "24.04"
-  full_version: "24.04.4"
-  release_date: "April 2024"
-  eol: "April 2029"
+  slug: ResoluteRaccoon
+  name: "Resolute Raccoon"
+  short_version: "26.04"
+  full_version: "26.04"
+  release_date: "April 2026"
+  eol: "April 2010"
   release_notes_url: "https://documentation.ubuntu.com/release-notes/24.04/"
   blog_post_url: "https://ubuntu.com/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive"
   mascot_image_large:
@@ -38,21 +38,21 @@ lts:
   raspi_desktop_iso_size: "2.6GB"
   raspi_server_iso_size: "1.1GB"
 previous_lts:
-  slug: JammyJellyfish
+  slug: NobleNumbat
+  name: "Noble Numbat"
+  short_version: "24.04"
+  full_version: "24.04.4"
+  release_date: "April 2024"
+  eol: "April 2029"
+  release_notes_url: "https://documentation.ubuntu.com/release-notes/24.04/"
+  iso_download_size: "5.9GB"
+  server_iso_size: "3GB"
+previous_previous_lts:
   name: "Jammy Jellyfish"
   short_version: "22.04"
   full_version: "22.04.5"
   release_date: "April 2022"
   eol: "April 2027"
-  release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
-  iso_download_size: "4.4GB"
-  server_iso_size: "2GB"
-previous_previous_lts:
-  name: "Focal Fossa"
-  short_version: "20.04"
-  full_version: "20.04.6"
-  release_date: "April 2020"
-  eol: "April 2025"
 core_lts:
   version: "24"
   eol: "April 2034"

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -167,6 +167,7 @@
       </div>
     </div>
   </section>
+  {% if releases_yaml.latest.full_version != releases_yaml.lts.full_version %}
   <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
@@ -326,6 +327,7 @@
       </div>
     </div>
   </section>
+  {% endif %}
   {% include "download/shared/_downloads-resources.html" %}
   <section class="p-section">
     <div class="row--50-50">

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -95,7 +95,7 @@
         <p class="u-responsive-realign">
           <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases_yaml.lts.full_version }}', 'eventValue' : undefined });"
-             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases_yaml.lts.full_version }} LTS</a>
+             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop</a>
           {% if releases_yaml.lts.raspi_desktop_iso_size %}
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_desktop_iso_size }}</span>
           {% endif %}
@@ -105,49 +105,15 @@
         <p class="u-responsive-realign">
           <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.lts.full_version }}&amp;architecture=server-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases_yaml.lts.full_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Server {{ releases_yaml.lts.full_version }} LTS</a>
+             class="p-button">Download Ubuntu Server</a>
           {% if releases_yaml.lts.raspi_server_iso_size %}
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_server_iso_size }}</span>
           {% endif %}
-        </p>
-      </div>
-    </div>
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50 p-section">
-      <div class="col u-image-position">
-        <h2>Ubuntu {{ releases_yaml.latest.full_version }}</h2>
-        <div class="p-image-wrapper u-hide--small">
-          {{ image(url=releases_yaml.latest.mascot_image_large.url,
-                    alt=releases_yaml.latest.name,
-                    width=releases_yaml.latest.mascot_image_large.width,
-                    height=releases_yaml.latest.mascot_image_large.height,
-                    hi_def=True,
-                    loading="auto") | safe
-          }}
-        </div>
-      </div>
-      <div class="col">
-        <p>
-          The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases_yaml.latest.full_version }} comes with nine months of security and maintenance updates, until {{ releases_yaml.latest.eol }}.
-        </p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases_yaml.latest.full_version }}', 'eventValue' : undefined });"
-             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases_yaml.latest.full_version }}</a>
-          {% if releases_yaml.latest.raspi_desktop_iso_size %}
-            <span class="u-text--muted">{{ releases_yaml.latest.raspi_desktop_iso_size }}</span>
-          {% endif %}
-        </p>
-        <p>Minimum 4GBs of RAM and 16GB storage required</p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=server-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases_yaml.latest.full_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Server {{ releases_yaml.latest.full_version }}</a>
-          {% if releases_yaml.latest.raspi_server_iso_size %}
-            <span class="u-text--muted">{{ releases_yaml.latest.raspi_server_iso_size }}</span>
-          {% endif %}
+
+          <p>Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
+          <p>Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
+          <p>EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
+          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation&nbsp;&rsaquo;</a></p>
         </p>
       </div>
     </div>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -110,9 +110,9 @@
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_server_iso_size }}</span>
           {% endif %}
 
-          <p>Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
-          <p>Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
-          <p>EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
+          <p class="p-text--small">Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
+          <p class="p-text--small">Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
+          <p class="p-text--small">EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
           <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation&nbsp;&rsaquo;</a></p>
         </p>
       </div>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -18,7 +18,7 @@
       </div>
       <div class="col p-section--shallow">
         <p>
-          Ubuntu {{ releases_yaml.lts.full_version }} <abbr title="Long-term support">LTS</abbr> includes support for the very latest ARM-based server systems powered by certified 64-bit processors.
+          Ubuntu Server includes support for the very latest ARM-based server systems powered by certified 64-bit processors.
         </p>
         <p>
           Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.
@@ -66,11 +66,6 @@
              class="p-button"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases_yaml.lts.short_version }}', 'eventValue' : undefined });">
             Download {{ releases_yaml.lts.full_version }} LTS (64k page size)
-          </a>
-          <a href="https://cdimage.ubuntu.com/releases/{{ releases_yaml.latest.short_version }}/release/ubuntu-{{ releases_yaml.latest.full_version }}-live-server-arm64+largemem.iso"
-             class="p-button"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases_yaml.lts.short_version }}', 'eventValue' : undefined });">
-            Download {{ releases_yaml.latest.full_version }} (64k page size)
           </a>
           <p>
             <a href="/server/docs/choosing-between-the-arm64-and-arm64-largemem-installer-options">Find out if 64k page size is for you&nbsp;&rsaquo;</a>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -199,7 +199,7 @@
               <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
               <hr class="p-rule" />
               <a class="p-button"
-                 href="https://releases.ubuntu.com/{{ releases_yaml.lts.short_version }}/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-amd64.iso.torrent">{{ releases_yaml.latest.full_version }} Torrent for Server</a>
+                 href="https://releases.ubuntu.com/{{ releases_yaml.lts.short_version }}/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for Server {{ releases_yaml.latest.full_version }}</a>
             </div>
           </div>
           <hr class="p-rule" />

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -81,6 +81,7 @@
           </p>
           <hr class="p-rule" />
           <p class="u-responsive-realign">
+            <span style="margin-right: 1rem;">Intel or AMD 64-bit architecture</span>
             <a class="p-button--positive"
                href="/download/server/thank-you?version={{ releases_yaml.lts.full_version }}&amp;architecture=amd64&amp;lts=true"
                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases_yaml.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases_yaml.lts.full_version }} LTS
@@ -88,7 +89,7 @@
             {% if releases_yaml.lts.server_iso_size %}<span class="u-text--muted">{{ releases_yaml.lts.server_iso_size }}</span>{% endif %}
           </p>
           <p>
-            <a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a>
+            For other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
           <p>
             <a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a>
@@ -133,15 +134,13 @@
              role="tabpanel"
              aria-labelledby="release-notes-tab-lts">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Linux 6.8 kernel with low latency kernel features enabled by default</li>
+            <li class="p-list__item is-ticked">Linux 7.0</li>
             <li class="p-list__item is-ticked">
-              Frame pointers enabled by default for the majority of packages on x86 architectures
+              Dual-track system for container stacks: traditional with regular major updates, or stable to maintain consistent versions of core components
             </li>
             <li class="p-list__item is-ticked">
-              Rust 1.75, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades
+              Valkey 9, PostgreSQL 18, MySQL and MariaDB as long-term supported versions, and the introduction of DocumentDB
             </li>
-            <li class="p-list__item is-ticked">64-bit time_t by default on armhf to address the year 2038 issue</li>
-            <li class="p-list__item is-ticked">AppArmor-enforced unprivileged user namespaces restricted by default</li>
           </ul>
           <hr class="p-rule" />
           <p>
@@ -155,8 +154,7 @@
              role="tabpanel"
              aria-labelledby="system-requirements-tab-lts">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">1 GHz processor or better</li>
-            <li class="p-list__item is-ticked">1 GB system memory</li>
+            <li class="p-list__item is-ticked">1.5 GB system memory</li>
             <li class="p-list__item is-ticked">5 GB of free hard drive space</li>
             <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
           </ul>
@@ -170,132 +168,6 @@
              id="how-to-install-lts"
              role="tabpanel"
              aria-labelledby="how-to-install-tab-lts">
-          <p>To install Ubuntu Server:</p>
-          <ol class="p-list--divided">
-            <li class="p-list__item">Download the ISO image</li>
-            <li class="p-list__item">
-              Create a bootable USB flash drive with <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
-            </li>
-            <li class="p-list__item">Boot from the USB flash drive</li>
-          </ol>
-          <hr class="p-rule" />
-          <p>
-            <a href="/tutorials/install-ubuntu-server">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <hr class="p-rule" />
-    </div>
-
-    <div class="row--50-50 p-section">
-      <div class="col">
-        <div class="p-section">
-          <h2>Ubuntu {{ releases_yaml.latest.full_version }}</h2>
-        </div>
-        <div class="p-image-wrapper u-hide--small">
-          {{ image(url=releases_yaml.latest.mascot_image_large.url,
-                    alt=releases_yaml.latest.name,
-                    width=releases_yaml.latest.mascot_image_large.width,
-                    height=releases_yaml.latest.mascot_image_large.height,
-                    hi_def=True,
-                    loading="auto") | safe
-          }}
-        </div>
-      </div>
-      <div class="col">
-        <div class="p-section--shallow">
-          <p>
-            The latest version of Ubuntu Server, including nine months of security and maintenance updates until {{ releases_yaml.latest.eol }}.
-          </p>
-          <hr />
-          <p class="u-responsive-realign">
-            <a class="p-button--positive"
-               href="/download/server/thank-you?version={{ releases_yaml.latest.full_version }}&amp;architecture=amd64"
-               onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases_yaml.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases_yaml.latest.full_version }}
-            </a>
-            {% if releases_yaml.latest.server_iso_size %}
-              <span class="u-text--muted">{{ releases_yaml.latest.server_iso_size }}</span>
-            {% endif %}
-          </p>
-        </div>
-
-        <nav class="p-tabs js-tabbed-content"
-             id="second-child-tab"
-             data-maintain-hash="true">
-          <ul class="p-tabs__list u-no-margin--bottom" role="tablist">
-            <li class="p-tabs__item">
-              <a class="p-tabs__link"
-                 role="tab"
-                 aria-selected="true"
-                 id="release-notes-tab-latest"
-                 href="#release-notes-latest"
-                 aria-controls="release-notes-latest">What's new</a>
-            </li>
-            <li class="p-tabs__item">
-              <a class="p-tabs__link"
-                 role="tab"
-                 aria-selected="false"
-                 id="system-requirements-tab-latest"
-                 href="#system-requirements-latest"
-                 aria-controls="system-requirements-latest"
-                 tabindex="-1">System requirements</a>
-            </li>
-            <li class="p-tabs__item">
-              <a class="p-tabs__link"
-                 role="tab"
-                 aria-selected="false"
-                 id="how-to-install-tab-latest"
-                 href="#how-to-install-latest"
-                 aria-controls="how-to-install-latest"
-                 tabindex="-1">How to install</a>
-            </li>
-          </ul>
-        </nav>
-
-        <div class="p-tabs__content p-section"
-             id="release-notes-latest"
-             role="tabpanel"
-             aria-labelledby="release-notes-tab-latest">
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Linux 6.17 kernel</li>
-            <li class="p-list__item is-ticked">Updated Virtualization stack based on QEMU 10.1 and libvirt 11.6</li>
-          </ul>
-          <hr class="p-rule" />
-          <ul class="u-responsive-realign p-inline-list">
-            <li class="p-inline-list__item">
-              <a href="{{ releases_yaml.latest.blog_post_url }}"
-                 aria-label="{{ releases_yaml.latest.short_version }} Press Release">Press release&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="{{ releases_yaml.latest.release_notes_url }}"
-                 aria-label="{{ releases_yaml.latest.short_version }} release notes">Release notes&nbsp;&rsaquo;</a>
-            </li>
-          </ul>
-        </div>
-
-        <div class="p-tabs__content p-section"
-             id="system-requirements-latest"
-             role="tabpanel"
-             aria-labelledby="system-requirements-tab-latest">
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">1 GHz processor or better</li>
-            <li class="p-list__item is-ticked">1 GB system memory</li>
-            <li class="p-list__item is-ticked">2.5 GB of free hard drive space</li>
-            <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
-          </ul>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://documentation.ubuntu.com/server/reference/installation/system-requirements/">Detailed system requirements&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-
-        <div class="p-tabs__content p-section"
-             id="how-to-install-latest"
-             role="tabpanel"
-             aria-labelledby="how-to-install-tab-latest">
           <p>To install Ubuntu Server:</p>
           <ol class="p-list--divided">
             <li class="p-list__item">Download the ISO image</li>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -199,7 +199,7 @@
               <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
               <hr class="p-rule" />
               <a class="p-button"
-                 href="https://releases.ubuntu.com/{{ releases_yaml.lts.short_version }}/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for Server</a>
+                 href="https://releases.ubuntu.com/{{ releases_yaml.lts.short_version }}/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-amd64.iso.torrent">{{ releases_yaml.latest.full_version }} Torrent for Server</a>
             </div>
           </div>
           <hr class="p-rule" />

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -134,7 +134,7 @@
              role="tabpanel"
              aria-labelledby="release-notes-tab-lts">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Linux 7.0</li>
+            <li class="p-list__item is-ticked">Linux 7.0 kernel</li>
             <li class="p-list__item is-ticked">
               Dual-track system for container stacks: traditional with regular major updates, or stable to maintain consistent versions of core components
             </li>
@@ -199,9 +199,7 @@
               <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
               <hr class="p-rule" />
               <a class="p-button"
-                 href="https://releases.ubuntu.com/{{ releases_yaml.lts.short_version }}/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases_yaml.lts.full_version }} LTS</a>
-              <a class="p-button"
-                 href="https://releases.ubuntu.com/{{ releases_yaml.latest.short_version }}/ubuntu-{{ releases_yaml.latest.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases_yaml.latest.full_version }}</a>
+                 href="https://releases.ubuntu.com/{{ releases_yaml.lts.short_version }}/ubuntu-{{ releases_yaml.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for Server</a>
             </div>
           </div>
           <hr class="p-rule" />

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -88,7 +88,7 @@
             </a>
             {% if releases_yaml.lts.server_iso_size %}<span class="u-text--muted">{{ releases_yaml.lts.server_iso_size }}</span>{% endif %}
           </p>
-          <p>
+          <p class="p-text--small">
             For other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
           <p>

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -11,7 +11,6 @@
 {% endblock meta_copydoc %}
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
-{% from "_macros/vf_tab-section.jinja" import vf_tab_section %}
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from "_macros/vf_resources.jinja" import vf_resources %}
@@ -30,108 +29,125 @@
   -%}
   {%- endcall -%}
 
-  {{- vf_tab_section(
-      title={
-          "text": "Ubuntu 24.04 LTS"
-      },
-      description={
-          "type": "html",
-          "content": "
-            <p>
-              The latest <abbr title='Long-term support'>LTS</abbr> version of Ubuntu on WSL.
-              LTS stands for long-term support – which means five years of free security and
-              maintenance updates, extended to 15 years with <a href='/pro'>Ubuntu Pro</a>.
-            </p>
+  <section class="p-section">
+    <div class="grid-row--50-50">
+      <hr class="p-rule" />
+      <div class="grid-col">
+        <div class="p-section">
+          <h2>Ubuntu {{ releases_yaml.lts.full_version }} LTS</h2>
+        </div>
+        <div class="p-image-wrapper u-hide--small">
+          {{ image(url=releases_yaml.lts.mascot_image_large.url,
+                    alt=releases_yaml.lts.name,
+                    width=releases_yaml.lts.mascot_image_large.width,
+                    height=releases_yaml.lts.mascot_image_large.height,
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
+      </div>
+      <div class="grid-col">
+        <div class="p-section--shallow">
+          <p>
+            The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu on WSL. LTS stands for long-term support &ndash; which means five years of free security and maintenance updates, extended to 15 years with <a href="/pro">Ubuntu Pro</a>.
+          </p>
 
-            <div class='grid-row'>
-              <div class='grid-col-2'>
-                <p class='p-heading--5'>Intel or AMD 64-bit architecture</p>
-              </div>
-              <div class='grid-col-2'>
-                <a class='p-button--positive' href='https://releases.ubuntu.com/noble/ubuntu-24.04.4-wsl-amd64.wsl'>Download</a>
-                <span class='u-text--muted'>373MB</span>
-              </div>
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <p class="p-heading--5">Intel or AMD 64-bit architecture</p>
             </div>
+            <div class="grid-col-2">
+              <a class="p-button--positive"
+                 href="https://releases.ubuntu.com/resolute/ubuntu-26.04-wsl-amd64.wsl">Download</a>
+              <span class="u-text--muted">373MB</span>
+            </div>
+          </div>
 
-            <div class='grid-row'>
-              <div class='grid-col-2'>
-                <p class='p-heading--5'>ARM 64-bit architecture</p>
-              </div>
-              <div class='grid-col-2'>
-                <a class='p-button--positive' href='https://cdimages.ubuntu.com/releases/noble/release/ubuntu-24.04.4-wsl-arm64.wsl'>Download</a>
-                <span class='u-text--muted'>374MB</span>
-              </div>
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <p class="p-heading--5">ARM 64-bit architecture</p>
             </div>
-          "
-      },
-      tabs=[
-          {
-              "tab_html": "<h5 class='u-no-margin--bottom'>What’s new</h5>",
-              "type": "basic-section",
-              "item": {
-                  "items": [
-                      {
-                          "type": "description",
-                          "item": {
-                              "content": "
-                                <p>Rust 1.78, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades</p>
-                                <p class='link'>
-                                  <a href='https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890'>
-                                    Release notes ›
-                                  </a>
-                                </p>
-                              "
-                          }
-                      }
-                  ]
-              }
-          },
-          {
-              "tab_html": "<h5 class='u-no-margin--bottom'>System requirements</h5>",
-              "type": "basic-section",
-              "item": {
-                  "items": [
-                      {
-                          "type": "description",
-                          "item": {
-                              "content": "
-                                <p>Windows 11 (recommended) or Windows 10 with minimum version 21H2 on a physical machine</p>
-                                <p class='link'>
-                                  <a href='https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#what-you-will-need'>
-                                    Detailed requirements ›
-                                  </a>
-                                </p>
-                              "
-                          }
-                      }
-                  ]
-              }
-          },
-          {
-              "tab_html": "<h5 class='u-no-margin--bottom'>How to install</h5>",
-              "type": "basic-section",
-              "item": {
-                  "items": [
-                      {
-                          "type": "description",
-                          "item": {
-                              "content": "
-                                <p>To install, you can download and double-click the <code>.wsl</code> image, or open the PowerShell terminal and run <code>wsl --install</code></p>
-                                <p class='link'>
-                                  <a href='https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#install-and-enable-wsl'>
-                                    Detailed installation steps ›
-                                  </a>
-                                </p>
-                              "
-                          }
-                      }
-                  ]
-              }
-          }
-        
-          
-      ]
-  ) -}}
+            <div class="grid-col-2">
+              <a class="p-button--positive"
+                 href="https://cdimages.ubuntu.com/releases/resolute/release/ubuntu-26.04-wsl-arm64.wsl">Download</a>
+              <span class="u-text--muted">374MB</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-section--shallow">
+          <nav class="p-tabs js-tabbed-content">
+            <ul class="p-tabs__list u-no-margin--bottom"
+                role="tablist"
+                data-maintain-hash="true">
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="true"
+                   id="release-notes-tab"
+                   href="#release-notes"
+                   aria-controls="release-notes">What's new</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="system-requirements-tab"
+                   href="#system-requirements"
+                   aria-controls="system-requirements"
+                   tabindex="-1">System requirements</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="how-to-install-tab"
+                   href="#how-to-install"
+                   aria-controls="how-to-install"
+                   tabindex="-1">How to install</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+
+        <div id="release-notes"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="release-notes-tab">
+          <p>An updated set of language toolchains and compilers.</p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="{{ releases_yaml.lts.blog_post_url }}">Press release&nbsp;&rsaquo;</a>&nbsp;&nbsp;
+            <a href="{{ releases_yaml.lts.release_notes_url }}">Release notes&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+
+        <div id="system-requirements"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="system-requirements-tab">
+          <p>Windows 11 (recommended) or Windows 10 with minimum version 21H2 on a physical machine</p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#what-you-will-need">Detailed requirements&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+
+        <div id="how-to-install"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="how-to-install-tab">
+          <p>
+            To install, you can download and double-click the <code>.wsl</code> image, or open the PowerShell terminal and run <code>wsl --install</code>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/#install-and-enable-wsl">Detailed installation steps&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
 
   {{- vf_basic_section(
     title={"text": "Ubuntu is the number 1 choice<br class='u-hide--small u-hide--medium' /> for organizations using WSL"},
@@ -304,5 +320,6 @@
   -}}
 
   <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Reduced text size by adding `class="p-text--small"` for consistency across download pages.
## QA

- Open the [DEMO](https://ubuntu-com-16270.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

