### PR TITLE
Update /download/server/power with POWER11 info WD-36047

### DIFF
--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -29,6 +29,7 @@
           Ubuntu Server for IBM POWER brings Ubuntu Server and Ubuntu Server for Cloud to the POWER platform (little endian), opening the door to the scale-out and cloud markets. POWER is optimised for workloads in the mobile, social, cloud, Big Data, analytics and machine learning spaces. With its unique deployment toolset (including Juju and MAAS), Ubuntu makes the management of those workloads trivial.
         </p>
         <p>Starting with Ubuntu 22.04 LTS, POWER9 and POWER10 processors are supported.</p>
+        <p>And with Ubuntu 24.04 LTS, POWER11 is now supported. Ubuntu 26.04 LTS is recommended.</p>
         <p>
           The last versions to support POWER8 are Ubuntu 21.10 and Ubuntu 20.04 LTS, the latter of which is still supported under Ubuntu Pro.
         </p>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -31,7 +31,7 @@
         <p>Starting with Ubuntu 22.04 LTS, POWER9 and POWER10 processors are supported.</p>
         <p>And with Ubuntu 24.04 LTS, POWER11 is now supported. Ubuntu 26.04 LTS is recommended.</p>
         <p>
-          The last versions to support POWER8 are Ubuntu 21.10 and Ubuntu 20.04 LTS, the latter of which is still supported under Ubuntu Pro.
+          The last version to support POWER8 is Ubuntu 20.04 LTS, which is still supported under Ubuntu Pro.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added information for Ubuntu 24.04 LTS POWER11 support.

## QA

- Open the [DEMO](https://ubuntu-com-16271.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

