### PR TITLE
WD-36233 BAU: Copy Update /download/risc-v/canonical-built

### DIFF
--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -184,6 +184,16 @@
       </div>
     </section>
 
+    <hr class="p-rule is-fixed-width u-no-margin--bottom">
+
+    <section class="p-strip is-deep " id="full-width-default">
+      <div class="u-fixed-width">
+        <h2>Don’t see your platform?
+          <br><a href="/download/risc-v/partner-built">Find Ubuntu images built and hosted by Canonical’s partners</a>
+        </h2>
+      </div>
+    </section>
+
     {{ load_form("/download/risc-v/canonical-built") | safe }}
 
     <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -1,4 +1,5 @@
 {% extends "download/_base_download.html" %}
+{% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 
 {% block title %}Download Canonical-built Ubuntu for RISC-V Platforms{% endblock %}
 
@@ -184,16 +185,22 @@
       </div>
     </section>
 
-    <hr class="p-rule is-fixed-width u-no-margin--bottom">
-    
-    <section class="p-strip is-deep ">
-      <div class="u-fixed-width">
-        <h2>Don’t see your platform?</h2>
-          <a class=" " href="/download/risc-v/partner-built">Find Ubuntu images built and hosted by Canonical’s partners</a>
-        </div>
-
-      </div>
-    </section>
+    {% call(slot) vf_cta_section(
+        title_text='Don’t see your platform?',
+        variant='default',
+        layout='100',
+        attrs={'id': 'full-width-default'},
+        blocks=[
+          {
+            "type": "cta",
+            "item": {
+              "type": "html",
+              "content": "<a href='/download/risc-v/partner-built'>Find Ubuntu images built and hosted by Canonical’s partners</a>"
+            }
+          }
+        ]
+      ) -%}
+    {% endcall -%}
 
     {{ load_form("/download/risc-v/canonical-built") | safe }}
 

--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -185,12 +185,13 @@
     </section>
 
     <hr class="p-rule is-fixed-width u-no-margin--bottom">
-
-    <section class="p-strip is-deep " id="full-width-default">
+    
+    <section class="p-strip is-deep ">
       <div class="u-fixed-width">
-        <h2>Don’t see your platform?
-          <br><a href="/download/risc-v/partner-built">Find Ubuntu images built and hosted by Canonical’s partners</a>
-        </h2>
+        <h2>Don’t see your platform?</h2>
+          <a class=" " href="/download/risc-v/partner-built">Find Ubuntu images built and hosted by Canonical’s partners</a>
+        </div>
+
       </div>
     </section>
 


### PR DESCRIPTION
## Done

- Updated /download/risc-v/canonical-built to include a link to partner built risc-v page

## QA

- Open the [DEMO](https://ubuntu-com-16276.demos.haus/)
- [Copydoc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.j3gmuiz1cnlw#heading=h.wuo676n70ek8)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-36233](https://warthogs.atlassian.net/browse/WD-36233)


[WD-36233]: https://warthogs.atlassian.net/browse/WD-36233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
