### PR TITLE
Update tutorial link for Ubuntu installation

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -185,7 +185,7 @@
             <li class="p-list__item">Boot your laptop or PC from the USB flash drive</li>
           </ol>
           <hr class="p-rule--muted" />
-          <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+          <a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updating the tutorial link to https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/ (currently pointing to the bootable USB stick, which is already linked a few lines above).

## QA

- Open the [DEMO](https://ubuntu-com-16280.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

