### PR TITLE
Update and simplify installation instructions for the network installer

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -193,22 +193,17 @@ meta_copydoc %}
               <p>
                 The network installer is ideal if you have a computer that cannot run the graphical installer. It is also useful if you want to install Ubuntu on a large number of computers at once.
               </p>
-              <p>For 22.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
               <hr class="p-rule--muted" />
               <p>
-                <a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer?_gl=1*1t2mr3n*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.204825875.2084151835.1707729318-1126754318.1683186906">Instructions for the 22.04 LTS Ubuntu Live installer&nbsp;&rsaquo;</a>
+                <a href="https://ubuntu.com/server/docs/how-to/installation/how-to-netboot-the-server-installer-on-amd64/">Ubuntu live installer instructions for 26.04 LTS, 24.04 LTS, 22.04 LTS, and 20.04 LTS&nbsp;&rsaquo;</a>
+                <br/>
+                <small><a href="https://ubuntu.com/20-04">Standard support has ended for 20.04 LTS, now secured with Ubuntu Pro</a></small>
               </p>
               <hr class="p-rule--muted" />
               <p>
-                <a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the 20.04 Ubuntu Live installer&nbsp;&rsaquo;</a>
+                <a href="https://cdimage.ubuntu.com/netboot/18.04/">Download the network installer for Ubuntu 18.04 LTS&nbsp;&rsaquo;</a>
                 <br/>
-                <small><a href="https://ubuntu.com/20-04">Standard support ended, now secured with Ubuntu Pro</a></small>
-              </p>
-              <hr class="p-rule--muted" />
-              <p>
-                <a href="https://cdimage.ubuntu.com/netboot/18.04/">Download the network installer for 18.04 LTS&nbsp;&rsaquo;</a>
-                <br/>
-                <small><a href="https://ubuntu.com/18-04">Standard support ended, now secured with Ubuntu Pro</a></small>
+                <small><a href="https://ubuntu.com/18-04">Standard support has ended for 18.04 LTS ended, now secured with Ubuntu Pro</a></small>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Combined two instances of the same live installer instructions
- Updated the instructions link
- Spelled out which releases it applied to
- Aligned other release names to copy guidelines

## QA

- Open the [DEMO](https://ubuntu-com-16281.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

