### PR TITLE
Update /download/cloud with latest info

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -17,14 +17,14 @@
     <div class="row--50-50">
       <div class="col p-section--shallow">
         <h1>
-          Optimised Ubuntu
+          Optimized Ubuntu
           <br />
           on public clouds
         </h1>
       </div>
       <div class="col">
         <p>
-          Ubuntu builds optimised and certified images of <a href="/server">Ubuntu Server</a> for partners like Amazon AWS, Microsoft Azure, Google Cloud, IBM Cloud and Oracle Cloud.
+          Ubuntu builds optimized and certified images of <a href="/server">Ubuntu Server</a> for partners like Amazon AWS, Microsoft Azure, Google Cloud, IBM Cloud and Oracle Cloud.
         </p>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">5 years of maintenance and security updates with Ubuntu LTS</li>
@@ -51,15 +51,23 @@
           </div>
           <div class="col-6 col-medium-3">
             <p>
-              <a href="/pro">Ubuntu Pro</a> expands Ubuntu Server to provide enterprise-grade support, security and compliance on top of Ubuntu LTS.
+              <a href="/pro">Ubuntu Pro</a> is Canonical’s comprehensive subscription for open source security, support, and compliance.
+            </p>
+            <p>
+              Ubuntu Pro expands Ubuntu Server to provide long term security maintenance, out-of-the-box FIPS, DISA-STIG, and FedRAMP hardening across all platforms for your entire cloud journey – from public hyperscalers like AWS, Azure, and GCP, to private OpenStack or hybrid deployments.
+            </p>
+            <p>
+              Get comprehensive security and compliance features directly through cloud marketplaces, with support, simplified billing, pricing that scales predictably with your cloud usage – all without changing your existing cloud workflows.
             </p>
             <ul class="p-list--divided">
-              <li class="p-list__item is-ticked">10 years of maintenance and security updates for over 25,000 packages</li>
               <li class="p-list__item is-ticked">
-                Kernel security updates applied without reboot with <a href="/security/livepatch">Livepatch</a>
+                Get up to 15 years of security fixes and timely patches for critical vulnerabilities for Ubuntu
               </li>
               <li class="p-list__item is-ticked">
-                FIPS certified components and <a href="/security/security-standards">compliance</a> profiles such as CIS and DISA-STIG
+                Maximize uptime through kernel security updates applied without reboot with <a href="/security/livepatch">Livepatch</a>
+              </li>
+              <li class="p-list__item is-ticked">
+                Get FIPS certified components and <a href="/security/security-standards">compliance</a> profiles such as CIS and DISA-STIG
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

- Updated copy so it's not out of date at time of launch. Looks like a web request wasn't raised for this.

## Not done
- Buttons, blog ID, and info that is still under discussion in the copydoc (for simplicity). Page owner can raise a copydoc in the future for whatever is not resolved.

## QA

- Open the [DEMO](https://ubuntu-com-16282.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

