### PR TITLE
Updating /download for 26.04 LTS

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -30,15 +30,6 @@ meta_copydoc %}
             Ubuntu is the world's favorite Linux operating system. Run it on your laptop, workstation, server, or IoT device, with five years of free security updates.
           </p>
         </div>
-        <div class="u-vertically-center">
-          {{ image(url="https://assets.ubuntu.com/v1/622b4fe1-numpy-numbat-on-dell-xps-13.jpg",
-                    alt="",
-                    width="1801",
-                    height="954",
-                    hi_def=True,
-                    loading="auto") | safe
-          }}
-        </div>
       </div>
     </div>
   </section>
@@ -65,7 +56,7 @@ meta_copydoc %}
               <hr class="p-rule" />
               <div class="p-section--shallow">
                 <a href="/download/desktop" class="p-button--positive">Download Ubuntu Desktop</a>
-                <a href="/tutorials/upgrading-ubuntu-desktop#1-before-you-start"
+                <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/"
                    class="p-button">Upgrade Ubuntu</a>
               </div>
             </div>
@@ -98,7 +89,7 @@ meta_copydoc %}
             </div>
             <div class="col-6 col-medium-3">
               <p>
-                Access the power of a full Ubuntu terminal environment on Windows with Windows Subsystem for Linux.
+                Access the power of a full Ubuntu terminal environment with Windows Subsystem for Linux.
               </p>
               <hr class="p-rule" />
               <a href="/download/wsl" class="p-button--positive">Get Ubuntu on WSL</a>


### PR DESCRIPTION
## Done

- Removed laptop photo with 24.04 LTS
- Adjusted copy & updated links, visible in /download copydoc

## QA

- Open the [DEMO](https://ubuntu-com-16284.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

