### PR TITLE
Swapping tutorial link with Server documentation on shared footer

### DIFF
--- a/templates/download/shared/_footer.html
+++ b/templates/download/shared/_footer.html
@@ -28,7 +28,7 @@
           </p>
           <hr class="p-rule--muted" />
           <p>
-            <a href="/tutorials/install-ubuntu-server">Install Ubuntu Server</a>
+            <a href="https://ubuntu.com/server/docs/tutorial/basic-installation/">Install Ubuntu Server</a>
           </p>
           <hr class="p-rule--muted" />
           <p>

--- a/templates/download/shared/_footer.html
+++ b/templates/download/shared/_footer.html
@@ -28,7 +28,7 @@
           </p>
           <hr class="p-rule--muted" />
           <p>
-            <a href="https://ubuntu.com/server/docs/tutorial/basic-installation/">Install Ubuntu Server</a>
+            <a href="/server/docs/tutorial/basic-installation/">Install Ubuntu Server</a>
           </p>
           <hr class="p-rule--muted" />
           <p>


### PR DESCRIPTION
## Done

- Changed the tutorial link for Installing Ubuntu Server with a Server documentation link that has the latest info

## QA

- Open the [DEMO](https://ubuntu-com-16285.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

