### PR TITLE
Fixing typo on "up to 15 years"

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -48,7 +48,7 @@
           <p>
             The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop
             PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and
-            maintenance updates, extended to up to 15 years with <a href="/pro">Ubuntu Pro</a>.
+            maintenance updates, extended up to 15 years with <a href="/pro">Ubuntu Pro</a>.
           </p>
           <hr class="p-rule--muted" />
 


### PR DESCRIPTION
## Done

- Fixed a typo: "~to~ up to 15 years"; typo not present in copydoc

## QA

- Open the [DEMO](https://ubuntu-com-16286.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

