### PR TITLE
Update /download/server with copy, press release, and updated tut

### DIFF
--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -190,7 +190,7 @@
           </ol>
           <hr class="p-rule" />
           <p>
-            <a href="https://ubuntu.com/server/docs/tutorial/basic-installation/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+            <a href="/server/docs/tutorial/basic-installation/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -98,7 +98,7 @@
             For other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
           <p class="p-text--small">
-            For other architectures, <a href="#architectures">click here.</a>
+            For other architectures, <a href="#architectures">click here</a>.
           </p>
         </div>
 

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -98,7 +98,7 @@
             For other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
           <p class="p-text--small">
-            For other architectures, <a href="#architectures">click here</a>.
+            <a href="#architectures">Find our alternative architectures here</a>.
           </p>
         </div>
 

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -97,8 +97,8 @@
           <p class="p-text--small">
             For other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
-          <p>
-            <a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a>
+          <p class="p-text--small">
+            For other architectures, <a href="#architectures">click here.</a>
           </p>
         </div>
 
@@ -148,11 +148,17 @@
               Valkey 9, PostgreSQL 18, MySQL and MariaDB as long-term supported versions, and the introduction of DocumentDB
             </li>
           </ul>
-          <hr class="p-rule" />
-          <p>
-            <a href="{{ releases_yaml.lts.release_notes_url }}"
-               aria-label="{{ releases_yaml.lts.short_version }} LTS release notes">Release notes&nbsp;&rsaquo;</a>
-          </p>
+          <hr class="p-rule--muted" />
+          <ul class="u-responsive-realign p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="{{ releases_yaml.lts.blog_post_url }}"
+                 aria-label="{{ releases_yaml.lts.full_version }} LTS press release">Press release&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="{{ releases_yaml.lts.release_notes_url }}"
+                 aria-label="{{ releases_yaml.lts.full_version }} LTS release notes">Release notes&nbsp;&rsaquo;</a>
+            </li>
+          </ul>
         </div>
 
         <div class="p-tabs__content p-section"
@@ -184,7 +190,7 @@
           </ol>
           <hr class="p-rule" />
           <p>
-            <a href="/tutorials/install-ubuntu-server">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+            <a href="https://ubuntu.com/server/docs/tutorial/basic-installation/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updated copy for alternative architectures to be coherent with the one for alternative downloads (along with similar text size)
- Added press release link to match /download/desktop
- Replaced outdated tutorial link with one to Server documentation that has updated content

## QA

- Open the [DEMO](https://ubuntu-com-16287.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

