### PR TITLE
Update "no results" message on /certified with additional suggestions

### DIFF
--- a/templates/certified/search/_no-results.html
+++ b/templates/certified/search/_no-results.html
@@ -1,7 +1,8 @@
-<h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
-<p>You can do this by:</p>
+<h3 class="p-heading--4">There is no certified hardware that matches that search.</h3>
+<p>You can:</p>
 <ul class="p-list">
-  <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
-  <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
-  <li class="p-list__item is-ticked">Trying a different spelling</li>
+  <li class="p-list__item is-ticked">Search for individual components like a processor or a network card to see if your hardware has parts certified with other models.</li>
+  <li class="p-list__item is-ticked">Go to the <a href="/download">Ubuntu Download pages</a> to find images that can work with your hardware, even uncertified.</li>
+  <li class="p-list__item is-ticked"><a href="https://canonical.com/partners/become-a-partner">Request a certification</a> for the model you are looking for. We continuously work with vendors to expand our range of certified hardware.</li>
+  <li class="p-list__item is-ticked">Try another search using different spelling.</li>
 </ul>


### PR DESCRIPTION
## Done

- Update the message displayed when there are no results on /certified, per suggestions from UX

## QA

- Open the [DEMO](https://ubuntu-com-16292.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

