### PR TITLE
Update Server installation tutorial links

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -53,7 +53,7 @@
             <div class="p-section--shallow">
               <a href="https://cdimage.ubuntu.com/releases">Alternative and previous releases&nbsp;&rsaquo;</a>
               &nbsp;&nbsp;
-              <a href="/tutorials/install-ubuntu-server#1-overview">How to install&nbsp;&rsaquo;</a>
+              <a href="/server/docs/tutorial/basic-installation/">How to install&nbsp;&rsaquo;</a>
             </div>
           </div>
         </div>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -85,7 +85,7 @@
           <div class="col-6 col-medium-3">
             <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
             <p>
-              <a href="/tutorials/tutorial-install-ubuntu-server">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a>
+              <a href="/server/docs/tutorial/basic-installation/">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -244,7 +244,7 @@
             <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
             <hr class="p-rule" />
             <p>
-              <a href="/tutorials/tutorial-install-ubuntu-server">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a>
+              <a href="/server/docs/tutorial/basic-installation/">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>

--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -85,7 +85,7 @@
             <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
             <hr class="p-rule" />
             <p>
-              <a href="/tutorials/tutorial-install-ubuntu-server">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a>
+              <a href="/server/docs/tutorial/basic-installation/">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>

--- a/templates/shared/contextual_footers/_download_all_installation.html
+++ b/templates/shared/contextual_footers/_download_all_installation.html
@@ -2,8 +2,8 @@
   <h3 class="p-heading--4">Installation guides</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
-      <li><a href="/tutorials/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install desktop guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Desktop</a></li>
-      <li><a href="/tutorials/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install server guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Server</a></li>
+      <li><a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install desktop guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Desktop</a></li>
+      <li><a href="/server/docs/tutorial/basic-installation/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install server guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Server</a></li>
       <li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install openstack', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Install OpenStack&nbsp;&rsaquo;</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_download_server_installation.html
+++ b/templates/shared/contextual_footers/_download_server_installation.html
@@ -3,7 +3,7 @@
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
     <li>
-      <a href="/tutorials/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">
+      <a href="/server/docs/tutorial/basic-installation/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">
         Installation instructions for Ubuntu Server
       </a>
     </li>


### PR DESCRIPTION
## Done

- Update Server installation tutorial links

## QA

- Open the [DEMO](https://ubuntu-com-16293.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

