### PR TITLE
Add custom download URL for Thundercom Rubik Pi3 platforms

### DIFF
--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -28,6 +28,9 @@ def get_download_url(model_details):
     if "qualcomm" in make and "dragonwing" in configuration_name:
         return "https://ubuntu.com/download/qualcomm-iot#evaluation-kit"
 
+    if "thundercomm" in make and "rubik pi 3" in configuration_name:
+        return "https://ubuntu.com/download/qualcomm-iot#rubikpi3"
+
     if "renesas" in make and "rz/g" in configuration_name:
         return "https://ubuntu.com/download/renesas-iot"
 


### PR DESCRIPTION
Fix C3-1401

## Done

We recently issued a certificate for a customer project (Thundercomm Rubik pi 3). This project has a dedicated page with download instructions and release notes, so the Download button on our public certificate page should point to this instead of the generic Ubuntu download page. This PR does this.

This is similar to #15853 done a few months ago.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/C3-1401
