### PR TITLE
Update YouTube video ID in /desktop

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -33,7 +33,7 @@
       </div>
       <div class="col">
         <div class="u-embedded-media">
-          <lite-youtube videoid="q5yM4ZYwB_s"
+          <lite-youtube videoid="ugIlNyRRkYY"
                   width="560"
                   height="315"
                   posterquality="maxresdefault"


### PR DESCRIPTION
## Done

- Updating video ID so that 26.04 LTS launch video is properly embedded

## QA

- Open the [DEMO](https://ubuntu-com-16297.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

