### PR TITLE
copy: update rubik pi 3 link

### DIFF
--- a/templates/download/qualcomm-iot/tabs/development-board-tab.html
+++ b/templates/download/qualcomm-iot/tabs/development-board-tab.html
@@ -77,7 +77,7 @@
     title="Read image installation instructions of Ubuntu 24.04 for Rubik Pi 3">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for Rubik Pi 3 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-desktop-24.04/x01/Ubuntu_24.04_Rubik_Pi3_development_board_Release_Note.pdf"
+          Ubuntu 24.04 for Rubik Pi 3 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-desktop-24.04/x03/Ubuntu_24.04_Rubik_Pi3_development_board_Release_Note.pdf"
     title="Read full release notes of Ubuntu 24.04 for Rubik Pi 3">release notes</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- Update link as requested on [copy doc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?disco=AAAB39IAwuk)

## QA

- Go to /download/qualcomm-iot
- Search for "Ubuntu 24.04 for Rubik Pi 3 release notes"
- See that the link for "release notes" matches copy doc

## Issue / Card

Fixes [WD-36265](https://warthogs.atlassian.net/browse/WD-36265)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36265]: https://warthogs.atlassian.net/browse/WD-36265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ