### PR TITLE
feat: add test error page route for testing HTTP error responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 
 # Build stage: Install python dependencies
 # ===

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -358,6 +358,12 @@ init_forms()
 # Routes
 # ===
 
+
+@app.route("/_test-error/<int:code>")
+def _test_error_page(code):
+    flask.abort(code)
+
+
 # Simple routes
 app.add_url_rule("/asset/<file_name>", view_func=json_asset_query)
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Open the [DEMO](https://ubuntu-com-16301.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-34654](https://warthogs.atlassian.net/browse/WD-34654)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-34654]: https://warthogs.atlassian.net/browse/WD-34654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ