### PR TITLE
Update the TPM/FDE link

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1291,4 +1291,4 @@ resolute/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/resolute
 AMI/MiniISO: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/ubuntu-mini-iso-24.04.4-mini-iso-amd64.iso"
 
 # Redirects for TPM/FDE documentation
-desktop/tpm-fde-requirements/?: "https://documentation.ubuntu.com/desktop/en/26.04/reference/hardware-backed-disk-encryption-requirements/"
+desktop/tpm-fde-requirements/?: "https://documentation.ubuntu.com/desktop/en/latest/reference/hardware-backed-disk-encryption-requirements/"

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1291,4 +1291,4 @@ resolute/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/resolute
 AMI/MiniISO: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/ubuntu-mini-iso-24.04.4-mini-iso-amd64.iso"
 
 # Redirects for TPM/FDE documentation
-desktop/tpm-fde-requirements/?: "https://documentation.ubuntu.com/desktop/en/latest/explanation/hardware-backed-disk-encryption/"
+desktop/tpm-fde-requirements/?: "https://documentation.ubuntu.com/desktop/en/26.04/reference/hardware-backed-disk-encryption-requirements/"


### PR DESCRIPTION
## Done

- Ubuntu 26.04 having been released, update a documentation link to its disk encryption feature.

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
