### PR TITLE
fix: update raspberry-pi compatibility table

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -175,10 +175,10 @@
               <th style="width: 15%;"></th>
               <th style="width: 10%;"></th>
               <th style="width: 18%">
-                Ubuntu {{ releases_yaml.lts.short_version }} <abbr title="Long-term support">LTS</abbr>
+                Ubuntu 24.04 LTS <abbr title="Long-term support">LTS</abbr>
               </th>
-              <th style="width: 15%">Ubuntu {{ releases_yaml.latest.short_version }}</th>
-              <th style="width: 15%">Ubuntu Core {{ releases_yaml.latest.core_version }}</th>
+              <th style="width: 15%">Ubuntu 24.10</th>
+              <th style="width: 15%">Ubuntu Core 24</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
## Done

- Removes automations based on .yaml file to match [copydoc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?tab=t.0#)

## QA

- Open the [DEMO](https://ubuntu-com-16304.demos.haus//download/raspberry-pi)
- Compare table against [copydoc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?tab=t.0#)

## Issue / Card

Fixes [WD-36284](https://warthogs.atlassian.net/browse/WD-36284)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-36284]: https://warthogs.atlassian.net/browse/WD-36284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ