### PR TITLE
WD-36278: Update /azure/pro page to accommodate Ubuntu 26.04

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -29,15 +29,17 @@
       </p>
     {%- endif -%}
     {%- if slot == 'image' -%}
-      <div class="p-image-container--16-9 is-highlighted">
-        {{ image(url="https://assets.ubuntu.com/v1/6562ba06-azure-bubble-slash-pro-hero-image.png",
-                alt="",
-                width="307",
-                height="128",
-                hi_def=True,
-                loading="auto",
-                attrs={"class": "p-image-container__image"}) | safe
-        }}
+      <div class="u-embedded-media">
+        <iframe
+          class="u-embedded-media__element"
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/ZyM7s6iFMrE"
+          title="Ubuntu Pro for Azure video"
+          frameborder="0"
+          allow="autoplay; encrypted-media; picture-in-picture"
+          allowfullscreen
+        ></iframe>
       </div>
     {%- endif -%}
   {% endcall -%}
@@ -65,17 +67,17 @@
     <div class="row--50-50 p-section--shallow">
       <hr class="p-rule" />
       <div class="col">
-        <h2>Launch Ubuntu&nbsp;Pro 24.04&nbsp;LTS</h2>
+        <h2>Launch Ubuntu&nbsp;Pro 26.04&nbsp;LTS</h2>
       </div>
       <div class="col">
         <div class="p-section--shallow">
           <p>
-            Ubuntu Pro 24.04 delivers additional layers of security and compliance services with security patches covering a wider range of packages, until 2034.
+            Ubuntu Pro 26.04 delivers additional layers of security and compliance services with security patches covering a wider range of packages, until 2036.
           </p>
         </div>
         <hr class="p-rule--muted" />
         <a class="p-button--positive"
-           href="https://portal.azure.com/#create/canonical.ubuntu-24_04-ltsubuntu-pro">Launch Ubuntu Pro 24.04 LTS</a>
+           href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-pro-26_04-lts">Launch Ubuntu Pro 26.04 LTS</a>
         <hr class="p-rule--muted" />
         <p>
           <a href="/azure/contact-us"
@@ -93,6 +95,18 @@
           </div>
           <div class="col-6 col-medium-3">
             <ul class="p-list--divided">
+              <li class="p-list__item">
+                <div class="row">
+                  <div class="col-3">
+                    <p class="u-no-margin--bottom">
+                      <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy?tab=Overview">24.04 LTS&nbsp;&rsaquo;</a>
+                    </p>
+                  </div>
+                  <div class="col-3">
+                    <p class="u-no-margin--bottom">Maintained until 2032</p>
+                  </div>
+                </div>
+              </li>
               <li class="p-list__item">
                 <div class="row">
                   <div class="col-3">
@@ -126,18 +140,6 @@
                   </div>
                   <div class="col-3">
                     <p class="u-no-margin--bottom">Maintained until 2028</p>
-                  </div>
-                </div>
-              </li>
-              <li class="p-list__item">
-                <div class="row">
-                  <div class="col-3">
-                    <p class="u-no-margin--bottom">
-                      <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=Overview">16.04 LTS&nbsp;&rsaquo;</a>
-                    </p>
-                  </div>
-                  <div class="col-3">
-                    <p class="u-no-margin--bottom">Maintained until 2026</p>
                   </div>
                 </div>
               </li>

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -16,6 +16,10 @@
   is-paper
 {% endblock body_class %}
 
+{% block extra_metatags %}
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+{% endblock extra_metatags %}
+
 {% block content %}
 
   {% call(slot) vf_hero(
@@ -30,16 +34,17 @@
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="u-embedded-media">
-        <iframe
-          class="u-embedded-media__element"
+        <lite-youtube videoId="ZyM7s6iFMrE"
           width="560"
           height="315"
-          src="https://www.youtube.com/embed/ZyM7s6iFMrE"
-          title="Ubuntu Pro for Azure video"
-          frameborder="0"
-          allow="autoplay; encrypted-media; picture-in-picture"
-          allowfullscreen
-        ></iframe>
+          posterquality="maxresdefault"
+          videotitle="Ubuntu Pro for Azure"
+          class="u-embedded-media__element"
+        >
+        <a href="https://www.youtube.com/watch?v=ZyM7s6iFMrE" title="Play Video">
+            <span class="lyt-visually-hidden">Ubuntu Pro for Azure</span>
+        </a>
+        </lite-youtube>
       </div>
     {%- endif -%}
   {% endcall -%}

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -103,7 +103,7 @@
                     </p>
                   </div>
                   <div class="col-3">
-                    <p class="u-no-margin--bottom">Maintained until 2032</p>
+                    <p class="u-no-margin--bottom">Maintained until 2034</p>
                   </div>
                 </div>
               </li>

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -99,7 +99,7 @@
                 <div class="row">
                   <div class="col-3">
                     <p class="u-no-margin--bottom">
-                      <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy?tab=Overview">24.04 LTS&nbsp;&rsaquo;</a>
+                      <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-noble?tab=Overview">24.04 LTS&nbsp;&rsaquo;</a>
                     </p>
                   </div>
                   <div class="col-3">


### PR DESCRIPTION
## Done

As specified in [this copydoc](https://docs.google.com/document/d/1WaQ5n3GxwZzbX0T6rLiRNejFvxIPIHd5V5XgdAwKmSw):

- Change the image used at the top of the page into the specified video in the copy doc
- Change mentions of Ubuntu 24.04 into Ubuntu 26.04 where appropriate, with date adjustments for EOL
- Update the link in the 'Launch Ubuntu Pro 26.04 LTS' button to the specified link in the copy doc
- Remove Ubuntu 16.04 LTS from the previous releases list
- Add Ubuntu 24.04 LTS to the previous releases list

Some of the dates on the copydoc I believe aren't correct - I've adjusted where necessary, please let me know if I've made a mistake!

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-36278](https://warthogs.atlassian.net/browse/WD-36278)

## Screenshots

N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36278]: https://warthogs.atlassian.net/browse/WD-36278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ