### PR TITLE
fix: free trial chip in /pro/subscribe

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -3,7 +3,7 @@ import { Button } from "@canonical/react-components";
 import { FormContext } from "../../utils/FormContext";
 import { ProductUsers } from "../../utils/utils";
 
-export default function PaymentButton() {
+export default function PaymentButton({ ...props }) {
   const { quantity, product, productUser } = useContext(FormContext);
   let params = new URLSearchParams(document.location.search);
   let referral_id = params.get("referral_id") || "";
@@ -26,6 +26,7 @@ export default function PaymentButton() {
             e.preventDefault();
             location.href = "/pro/dashboard";
           }}
+          {...props}
         >
           Register
         </Button>
@@ -41,6 +42,7 @@ export default function PaymentButton() {
             localStorage.setItem("referral_id", referral_id);
             location.href = "/account/checkout";
           }}
+          {...props}
         >
           Continue to checkout
         </Button>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Col, Row, Select, StatusLabel } from "@canonical/react-components";
+import { Chip, Col, Row, Select } from "@canonical/react-components";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 import {
   isIoTDevice,
@@ -120,9 +120,12 @@ const ProductSummary = () => {
             style={{ display: "flex", alignItems: "flex-end" }}
           >
             {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
-              <StatusLabel appearance="positive" style={{ marginRight: "1rem" }}>
-                Free trial on checkout
-              </StatusLabel>
+              <Chip
+                appearance="positive"
+                style={{ marginRight: "1rem", marginBottom: "0" }}
+                value="Free trial on checkout"
+              >
+              </Chip>
             ) : null}
             <PaymentButton style={{ marginBottom: "0" }} />
           </Col>
@@ -210,9 +213,12 @@ const ProductSummary = () => {
           </Col>
           {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>
-              <StatusLabel appearance="positive" style={{ marginRight: "1rem" }}>
-                Free trial on checkout
-              </StatusLabel>
+              <Chip
+                appearance="positive"
+                style={{ marginRight: "1rem", marginBottom: "0" }}
+                value="Free trial on checkout"
+              >
+              </Chip>
             </Col>
           ) : null}
         </Row>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -124,7 +124,7 @@ const ProductSummary = () => {
                 Free trial on checkout
               </StatusLabel>
             ) : null}
-            <PaymentButton />
+            <PaymentButton style={{ marginBottom: "0" }} />
           </Col>
         </Row>
       </section>
@@ -206,7 +206,7 @@ const ProductSummary = () => {
             </p>
           </Col>
           <Col size={12}>
-            <PaymentButton />
+            <PaymentButton style={{ marginBottom: "0" }} />
           </Col>
           {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -117,10 +117,10 @@ const ProductSummary = () => {
             className={"u-align--right"}
             size={4}
             emptyLarge={9}
-            style={{ display: "flex", alignItems: "center" }}
+            style={{ display: "flex", alignItems: "flex-end" }}
           >
             {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
-              <StatusLabel appearance="positive">
+              <StatusLabel appearance="positive" style={{ marginRight: "1rem" }}>
                 Free trial on checkout
               </StatusLabel>
             ) : null}
@@ -210,7 +210,7 @@ const ProductSummary = () => {
           </Col>
           {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>
-              <StatusLabel appearance="positive">
+              <StatusLabel appearance="positive" style={{ marginRight: "1rem" }}>
                 Free trial on checkout
               </StatusLabel>
             </Col>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -124,8 +124,7 @@ const ProductSummary = () => {
                 appearance="positive"
                 style={{ marginRight: "1rem", marginBottom: "0" }}
                 value="Free trial on checkout"
-              >
-              </Chip>
+              ></Chip>
             ) : null}
             <PaymentButton style={{ marginBottom: "0" }} />
           </Col>
@@ -217,8 +216,7 @@ const ProductSummary = () => {
                 appearance="positive"
                 style={{ marginRight: "1rem", marginBottom: "0" }}
                 value="Free trial on checkout"
-              >
-              </Chip>
+              ></Chip>
             </Col>
           ) : null}
         </Row>


### PR DESCRIPTION
## Done

- Fix the visual of the free trial status beside the buy now button in /pro/subscribe

## QA

- Open the [DEMO](https://ubuntu-com-16309.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /pro/subscribe

## Issue / Card

Fixes #

## Screenshots

Before:
<img width="2494" height="373" alt="Screen Shot 2026-04-25 at 04 40 23" src="https://github.com/user-attachments/assets/07d0a30d-1978-4379-8105-78f5f3586869" />

After:
<img width="2494" height="350" alt="Screen Shot 2026-04-25 at 04 41 06" src="https://github.com/user-attachments/assets/dc3e1ae9-988e-424c-9ae4-9f77aefc08f9" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

