### PR TITLE
fix: update call-to-action text for Canonical-built Ubuntu images

### DIFF
--- a/templates/download/risc-v/partner-built.html
+++ b/templates/download/risc-v/partner-built.html
@@ -126,7 +126,7 @@
         "type": "cta",
         "item": {
           "type": "html",
-          "content": 'Don’t see your platform?<br /> Find more Ubuntu images built and hosted by Canonical <a href="/download/risc-v/canonical-built">here&nbsp;&rsaquo;</a>'
+          "content": "Don't see your platform?<br /><a href=\"/download/risc-v/canonical-built\">Find Ubuntu images built and hosted by Canonical</a>",
         }
       }
     ]


### PR DESCRIPTION
## Summary
- fix to match the CTA on [copydoc](https://docs.google.com/document/d/11AUwjePeOGvT6H8xM4QYixzmUTRpG_uKPa_pSzR5ucs/edit?tab=t.c2kcdgatjp4u#heading=h.eto59uxtlv76) .

## Test plan
- [x] Visit `/download/risc-v/partner-built` and verify the CTA at the bottom of the page renders correctly
- [x] Confirm the link navigates to `/download/risc-v/canonical-built`


