### PR TITLE
WD-36331: copy update to /download/raspberry-pi certified table

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -175,9 +175,8 @@
               <th style="width: 15%;"></th>
               <th style="width: 10%;"></th>
               <th style="width: 18%">
-                Ubuntu 24.04 LTS <abbr title="Long-term support">LTS</abbr>
+                Ubuntu 26.04 <abbr title="Long-term support">LTS</abbr>
               </th>
-              <th style="width: 15%">Ubuntu 24.10</th>
               <th style="width: 15%">Ubuntu Core 24</th>
             </tr>
           </thead>
@@ -197,7 +196,6 @@
                 }}
               </td>
               <td>Yes, certified</td>
-              <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
             <tr>
@@ -214,7 +212,6 @@
                                 attrs={"class": "u-hide--small"},) | safe
                 }}
               </td>
-              <td>Yes</td>
               <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
@@ -233,7 +230,6 @@
                 }}
               </td>
               <td>Yes, certified</td>
-              <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
             <tr>
@@ -250,13 +246,12 @@
                                 attrs={"class": "u-hide--small"},) | safe
                 }}
               </td>
-              <td>Yes, certified</td>
               <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
             <tr>
               <th>
-                <p>Raspberry Pi 4</p>
+                <p>Raspberry Pi 4B</p>
               </th>
               <td>
                 {{ image(url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
@@ -269,7 +264,6 @@
                 }}
               </td>
               <td>Yes, certified</td>
-              <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
           </tbody>


### PR DESCRIPTION
## Done

- Update the table according to the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?tab=t.0).

## QA

- Open the [DEMO](https://ubuntu-com-16311.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card
- [WD-36331](https://warthogs.atlassian.net/browse/WD-36331)
- [Copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?tab=t.0)

## Screenshots

<img width="1095" height="459" alt="image" src="https://github.com/user-attachments/assets/5ed8fb77-95b2-4b97-9bf4-b4d62bdb44e4" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36331]: https://warthogs.atlassian.net/browse/WD-36331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
