### PR TITLE
copy-update(WD-36277): update /azure links with new LTS

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -34,8 +34,8 @@
           <p>Beyond Ubuntu, Canonical also offers Charmed Apps on Microsoft Azure, enabling hybrid environments.</p>
         </div>
         <div class="p-cta-block">
-          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview"
-             class="p-button--positive">Launch Ubuntu 24.04 on Azure</a>
+          <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-26_04-lts"
+             class="p-button--positive">Launch Ubuntu 26.04 on Azure</a>
           <a href="/azure/contact-us" class="js-invoke-modal">Talk to us about Ubuntu on Azure&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -103,7 +103,7 @@
             <li class="p-list__item is-ticked">Community and update level support</li>
           </ul>
           <div class="p-cta-block">
-            <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts"
+            <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-26_04-lts"
                class="p-button">Launch Ubuntu on Azure</a>
           </div>
         </div>
@@ -164,6 +164,9 @@
           <div class="col-3">
             <ul class="p-list--divided">
               <li class="p-list__item">
+                <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-pro-26_04-lts">26.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
                 <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts">24.04 LTS&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">
@@ -177,9 +180,6 @@
               </li>
               <li class="p-list__item">
                 <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial">16.04 LTS&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-trusty">14.04 LTS&nbsp;&rsaquo;</a>
               </li>
             </ul>
           </div>
@@ -274,7 +274,7 @@
         </ul>
         <hr class="p-rule--muted" />
         <div class="p-cta-block">
-          <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-24_04-lts?tab=Overview"
+          <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-pro-26_04-lts?tab=PlansAndPrice"
              class="p-button">Launch an Ubuntu CVM</a>
           <a href="/confidential-computing">Learn more about CVMs&nbsp;&rsaquo;</a>
         </div>

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -139,7 +139,7 @@
           <hr class="p-rule--muted" />
           <ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
             <li class="p-inline-list__item">
-              <a href="https://documentation.ubuntu.com/azure/en/latest/azure-how-to/instances/get-ubuntu-pro/"
+              <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-pro-26_04-lts"
                  class="p-button--positive">Get Ubuntu Pro on Azure</a>
             </li>
             <li class="p-inline-list__item">
@@ -275,7 +275,7 @@
         <hr class="p-rule--muted" />
         <div class="p-cta-block">
           <a href="https://marketplace.microsoft.com/en-us/product/canonical.ubuntu-pro-26_04-lts?tab=PlansAndPrice"
-             class="p-button">Launch an Ubuntu CVM</a>
+             class="p-button">Launch an Ubuntu 26.04 CVM</a>
           <a href="/confidential-computing">Learn more about CVMs&nbsp;&rsaquo;</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

Update `/azure` with the new 26.04 links and copy as depicted in: https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit?tab=t.0

## QA

- Open the https://ubuntu-com-16313.demos.haus/azure
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-36277

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
