### PR TITLE
Remove padding from CTA blocks

### DIFF
--- a/templates/download/risc-v/deepcomputing-fml13v01-partner.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01-partner.html
@@ -2,7 +2,7 @@
   aria-hidden="true">
   <div class="grid-row p-section--shallow">
     <div class="grid-col-2 grid-col-medium-1">
-      <h3 class="u-hide--small p-heading--2">Deep<wbr />Computing FML13V01</h2>
+      <h3 class="u-hide--small p-heading--2">Deep<wbr />Computing FML13V01</h3>
     </div>
     <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
       <div class="p-image-container is-highlighted">
@@ -20,7 +20,7 @@
   <div class="grid-row">
     <hr class="p-rule--muted" />
     <div class="grid-col-2 grid-col-medium-1">
-      <h4 class="p-heading--5">Ubuntu 24.04 Desktop preinstalled image</h5>
+      <h4 class="p-heading--5">Ubuntu 24.04 Desktop preinstalled image</h4>
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow DeepComputing's instructions when installing the image. This vendor image fully supports the FrameWork laptop with the DeepComputing FML13V01 motherboard.</p>

--- a/templates/download/risc-v/deepcomputing-fml13v01-partner.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01-partner.html
@@ -24,7 +24,7 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow DeepComputing's instructions when installing the image. This vendor image fully supports the FrameWork laptop with the DeepComputing FML13V01 motherboard.</p>
-      <div class="p-cta-block">
+      <div class="p-cta-block u-no-padding--bottom">
         <a href="https://github.com/DC-DeepComputing/fml13v01/releases" class="p-button">Download DeepComputing FML13V01 image</a>
       </div>
     </div>

--- a/templates/download/risc-v/eswin-ebc7700-sbc.html
+++ b/templates/download/risc-v/eswin-ebc7700-sbc.html
@@ -2,7 +2,7 @@
   aria-hidden="true">
   <div class="grid-row p-section--shallow">
     <div class="grid-col-2 grid-col-medium-1">
-      <h3 class="u-hide--small p-heading--2">ESWIN EBC7700 SBC</h2>
+      <h3 class="u-hide--small p-heading--2">ESWIN EBC7700 SBC</h3>
     </div>
     <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
       <div class="p-image-container is-highlighted">
@@ -20,7 +20,7 @@
   <div class="grid-row">
     <hr class="p-rule--muted" />
     <div class="grid-col-2 grid-col-medium-1">
-      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h5>
+      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h4>
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow ESWIN's instructions when installing the EBC7700 SBC image. </p>

--- a/templates/download/risc-v/eswin-ebc7700-sbc.html
+++ b/templates/download/risc-v/eswin-ebc7700-sbc.html
@@ -24,7 +24,7 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow ESWIN's instructions when installing the EBC7700 SBC image. </p>
-      <div class="p-cta-block">
+      <div class="p-cta-block u-no-padding--bottom">
         <a href="https://github.com/eswincomputing/ebc7700-sbc-ubuntu/tree/main?tab=readme-ov-file" class="p-button">Download ESWIN EBC7700 SBC image</a>
       </div>
     </div>

--- a/templates/download/risc-v/eswin-ebc7702-mini-dtx-mainboard.html
+++ b/templates/download/risc-v/eswin-ebc7702-mini-dtx-mainboard.html
@@ -2,7 +2,7 @@
   aria-hidden="true">
   <div class="grid-row p-section--shallow">
     <div class="grid-col-2 grid-col-medium-1">
-      <h3 class="u-hide--small p-heading--2">ESWIN EBC7702 Mini-DTX Mainboard</h2>
+      <h3 class="u-hide--small p-heading--2">ESWIN EBC7702 Mini-DTX Mainboard</h3>
     </div>
     <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
       <div class="p-image-container is-highlighted">
@@ -20,7 +20,7 @@
   <div class="grid-row">
     <hr class="p-rule--muted" />
     <div class="grid-col-2 grid-col-medium-1">
-      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h5>
+      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h4>
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow ESWIN's instructions when installing the EBC7702 Mini-DTX Mainboard image. </p>

--- a/templates/download/risc-v/eswin-ebc7702-mini-dtx-mainboard.html
+++ b/templates/download/risc-v/eswin-ebc7702-mini-dtx-mainboard.html
@@ -24,7 +24,7 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow ESWIN's instructions when installing the EBC7702 Mini-DTX Mainboard image. </p>
-      <div class="p-cta-block">
+      <div class="p-cta-block u-no-padding--bottom">
         <a href="https://github.com/eswincomputing/ebc7702-dev-board-ubuntu" class="p-button">Download ESWIN EBC7702 Mini-DTX Mainboard image</a>
       </div>
     </div>

--- a/templates/download/risc-v/milk-v-titan.html
+++ b/templates/download/risc-v/milk-v-titan.html
@@ -24,7 +24,7 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow Milk-V’s instructions when installing the Milk-V Titan image.</p>
-      <div class="p-cta-block">
+      <div class="p-cta-block u-no-padding--bottom">
         <a href="https://github.com/milkv-titan" class="p-button">Download Milk-V Titan image</a>
       </div>
     </div>

--- a/templates/download/risc-v/sifive-hifive-premier-p550.html
+++ b/templates/download/risc-v/sifive-hifive-premier-p550.html
@@ -24,7 +24,7 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow SiFive’s instructions when installing the HiFive Premier P550 image.</p>
-      <div class="p-cta-block">
+      <div class="p-cta-block u-no-padding--bottom">
         <a href="https://github.com/sifiveinc/hifive-premier-p550-ubuntu" class="p-button">Download SiFive HiFive Premier P550 image</a>
       </div>
     </div>

--- a/templates/download/risc-v/sifive-hifive-premier-p550.html
+++ b/templates/download/risc-v/sifive-hifive-premier-p550.html
@@ -2,7 +2,7 @@
   aria-hidden="true">
   <div class="grid-row p-section--shallow">
     <div class="grid-col-2 grid-col-medium-1">
-      <h3 class="u-hide--small p-heading--2">SiFive HiFive Premier P550</h2>
+      <h3 class="u-hide--small p-heading--2">SiFive HiFive Premier P550</h3>
     </div>
     <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
       <div class="p-image-container is-highlighted">
@@ -20,7 +20,7 @@
   <div class="grid-row">
     <hr class="p-rule--muted" />
     <div class="grid-col-2 grid-col-medium-1">
-      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h5>
+      <h4 class="p-heading--5">Ubuntu 24.04 Server preinstalled image</h4>
     </div>
     <div class="grid-col-4 grid-col-medium-2">
       <p>Please follow SiFive’s instructions when installing the HiFive Premier P550 image.</p>


### PR DESCRIPTION
## Done

- Remove padding from CTA blocks for each board option in the https://ubuntu.com/download/risc-v/partner-built page

## QA

- Open the [DEMO](https://ubuntu-com-16314.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to https://ubuntu.com/download/risc-v/partner-built page
- Check for each board that the *CTA block* does not have bottom *padding* (the button itself has bottom margin which is not meant to be removed)

## Issue / Card

Fixes [WD-36380](https://warthogs.atlassian.net/browse/WD-36380)

## Screenshots

Padding to be removed: 
<img width="987" height="460" alt="image" src="https://github.com/user-attachments/assets/1fe449a4-f948-4fb9-b964-e4dfd0be710e" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36380]: https://warthogs.atlassian.net/browse/WD-36380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
