### PR TITLE
feat: update copy on /gcp page

### DIFF
--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -92,7 +92,7 @@
           </ul>
           <hr class="p-rule--muted" />
           <p>
-            <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud"
+            <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=1328555489352976167&imageProjectId=ubuntu-os-cloud"
                class="p-button u-no-margin--bottom">Launch Ubuntu Server 26.04 LTS</a>
           </p>
         </div>
@@ -121,7 +121,7 @@
           <hr class="p-rule--muted" />
           <ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
             <li class="p-inline-list__item">
-              <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=960077196939492817&imageProjectId=ubuntu-os-pro-cloud"
+              <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4129656438803367771&imageProjectId=ubuntu-os-pro-cloud"
                  class="p-button--positive u-no-margin--bottom">Launch Ubuntu Pro 26.04 LTS</a>
             </li>
             <li class="p-inline-list__item">
@@ -222,7 +222,7 @@
           <div class="col-3">
             <ul class="p-list--divided">
               <li class="p-list__item">
-                <a href="https://console.cloud.google.com/&sa=D&source=docs&ust=1777316862114378&usg=AOvVaw2PFh_eOio2O4qBcrvykuD2">26.04 LTS</a>
+                <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4129656438803367771&imageProjectId=ubuntu-os-pro-cloud">26.04 LTS</a>
               </li>
               <li class="p-list__item">
                 <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud">24.04 LTS</a>

--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -93,7 +93,7 @@
           <hr class="p-rule--muted" />
           <p>
             <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud"
-               class="p-button u-no-margin--bottom">Launch Ubuntu Server 24.04 LTS</a>
+               class="p-button u-no-margin--bottom">Launch Ubuntu Server 26.04 LTS</a>
           </p>
         </div>
       </div>
@@ -122,7 +122,7 @@
           <ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
             <li class="p-inline-list__item">
               <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=960077196939492817&imageProjectId=ubuntu-os-pro-cloud"
-                 class="p-button--positive u-no-margin--bottom">Launch Ubuntu Pro 24.04 LTS</a>
+                 class="p-button--positive u-no-margin--bottom">Launch Ubuntu Pro 26.04 LTS</a>
             </li>
             <li class="p-inline-list__item">
               <p>
@@ -221,6 +221,9 @@
         <div class="row">
           <div class="col-3">
             <ul class="p-list--divided">
+              <li class="p-list__item">
+                <a href="https://console.cloud.google.com/&sa=D&source=docs&ust=1777316862114378&usg=AOvVaw2PFh_eOio2O4qBcrvykuD2">26.04 LTS</a>
+              </li>
               <li class="p-list__item">
                 <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud">24.04 LTS</a>
               </li>


### PR DESCRIPTION
## Done

- Updated copy on `/gcp` page.

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare against updated [copy doc](https://docs.google.com/document/d/1Gvt9tNFDZkqkBcP0k79C6ueTJCmNZvwoXQoU19WEa8E/edit?tab=t.0)

## Issue / Card

Fixes [WD-36279](https://warthogs.atlassian.net/browse/WD-36279)


[WD-36279]: https://warthogs.atlassian.net/browse/WD-36279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ