### PR TITLE
Remove Pi EEPROM information as it has been added to docs

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -110,10 +110,8 @@
             <span class="u-text--muted">{{ releases_yaml.lts.raspi_server_iso_size }}</span>
           {% endif %}
 
-          <p>Raspberry Pi 5 requires an EEPROM date no earlier than 2025-02-11.</p>
-          <p>Raspberry Pi 4 requires an EEPROM date no earlier than 2022-11-25.</p>
-          <p>EEPROM can be updated by running <code>sudo rpi-eeprom-update -a</code> and rebooting.</p>
-          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Read more in our documentation&nbsp;&rsaquo;</a></p>
+          <p>Certain releases of Ubuntu require a minimum EEPROM date for compatibility for the Raspberry Pi 4 and 5.</p>
+          <p><a href="https://canonical-ubuntu-hardware-support.readthedocs-hosted.com/boards/how-to/ubuntu_supported/raspberry-pi/">Learn more in our documentation&nbsp;&rsaquo;</a></p>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Removed EEPROM information on /download/raspberry-pi as it has now been added to the documentation that's linked in that section.

## QA

- Open the [DEMO](https://ubuntu-com-16321.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

