### PR TITLE
ci: fix percy snapshot comparison against outdated baselines

### DIFF
--- a/.github/actions/percy-snapshot/action.yml
+++ b/.github/actions/percy-snapshot/action.yml
@@ -16,6 +16,12 @@ inputs:
   percy_token_write:
     required: true
     description: Percy token with write access
+  base_ref:
+    required: false
+    description: Name of the base branch that snapshots are being compared against
+  base_commit:
+    required: false
+    description: Commit SHA of the base branch to compare against
 outputs:
   build_link:
     description: Link to the Percy build triggered by this workflow
@@ -91,11 +97,11 @@ runs:
         # This is used to name the build on the Percy dashboard. For PRs, it is `pull/{pr_number}`, and for baseline, it is `main`.
         PERCY_BRANCH: ${{ inputs.branch_name }}
         # The branch that the snapshots are being taken against
-        PERCY_TARGET_BRANCH: main
+        PERCY_TARGET_BRANCH: ${{ inputs.base_ref }}
         # HEAD commit SHA signature that triggered this test
         PERCY_COMMIT: ${{ inputs.commitsh }}
-        # The commit SHA signature that the snapshots are being taken against. Since this is always run on `main`, this will be the commit signature of the last commit to main.
-        PERCY_TARGET_COMMIT: ${{ github.sha }}
+        # The commit SHA signature that the snapshots are being taken against.
+        PERCY_TARGET_COMMIT: ${{ inputs.base_commit }}
         # If PR number is set & a Percy-GHA integration is set up, this allows Percy to set status on the PR
         PERCY_PULL_REQUEST: ${{ inputs.pr_number }}
         # GH runner sometimes runs into issues loading assets (large images especially) in the default 30s timeout.

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -40,9 +40,21 @@ jobs:
           path: untrusted-pr-code
           persist-credentials: false
 
+      - name: Get merge base commit SHA
+        id: base_commit
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          cd trusted-logic
+          git fetch origin "$BASE_REF"
+          git fetch "${{ github.event.pull_request.head.repo.clone_url }}" "${{ github.event.pull_request.head.ref }}"
+          echo "sha=$(git merge-base FETCH_HEAD origin/$BASE_REF)" >> $GITHUB_OUTPUT
+
       - uses: ./trusted-logic/.github/actions/percy-snapshot
         with:
           project_root: ./untrusted-pr-code
+          base_ref: ${{ github.base_ref }}
+          base_commit: ${{ steps.base_commit.outputs.sha }}
           pr_number: ${{ github.event.pull_request.number }}
           branch_name: ${{ github.event.pull_request.head.ref }}
           commitsh: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -44,10 +44,12 @@ jobs:
         id: base_commit
         env:
           BASE_REF: ${{ github.base_ref }}
+          FORK_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          FORK_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           cd trusted-logic
           git fetch origin "$BASE_REF"
-          git fetch "${{ github.event.pull_request.head.repo.clone_url }}" "${{ github.event.pull_request.head.ref }}"
+          git fetch "$FORK_CLONE_URL" "$FORK_REF"
           echo "sha=$(git merge-base FETCH_HEAD origin/$BASE_REF)" >> $GITHUB_OUTPUT
 
       - uses: ./trusted-logic/.github/actions/percy-snapshot

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -21,9 +21,22 @@ jobs:
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Get merge base commit SHA
+        id: base_commit
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF"
+          echo "sha=$(git merge-base HEAD origin/$BASE_REF)" >> $GITHUB_OUTPUT
 
       - uses: ./.github/actions/percy-snapshot
         with:
+          base_ref: ${{ github.base_ref }}
+          base_commit: ${{ steps.base_commit.outputs.sha }}
           branch_name: ${{ github.head_ref }}
-          commitsh: ${{ github.sha }}
+          commitsh: ${{ github.event.pull_request.head.sha }}
           percy_token_write: ${{ secrets.PERCY_TOKEN_WRITE }}


### PR DESCRIPTION
## Done

- Use latest base branch commit for Percy snapshot comparison
- Apply changes on forked PR and pushes to main branch

## QA

- Compare [forked action](https://github.com/canonical/ubuntu.com/actions/runs/26148990054/job/76911354879?pr=16322)
  - Latest commit of this forked branch: `ca4f92b03e72a141c1951636d359373a969fc9ca`
  - Latest commit of main branch: `d32f9a9fad9dd847833698c557f072d6b1189e44`
  - You can find the logs under "Run ./.github/actions/percy-snapshot"
  ```  
    PERCY_BRANCH: percy-comparison
    PERCY_TARGET_BRANCH: main
    PERCY_COMMIT: ca4f92b03e72a141c1951636d359373a969fc9ca
    PERCY_TARGET_COMMIT: d32f9a9fad9dd847833698c557f072d6b1189e44
  ```

- Compare [PR to main action](https://github.com/canonical/ubuntu.com/actions/runs/26148917898/job/76911119956?pr=16370)
  - Latest commit of that branch: `289b5d47cb14e0f488f92782951366cd18038de6`
  - Latest commit of main branch: `d32f9a9fad9dd847833698c557f072d6b1189e44`
  - You can find the logs under "Run ./.github/actions/percy-snapshot"
  ```
  with:
    base_ref: main
    base_commit: d32f9a9fad9dd847833698c557f072d6b1189e44
    branch_name: percy-baseline
    commitsh: 289b5d47cb14e0f488f92782951366cd18038de6
  ```

## Issue / Card

Fixes [WD-35828](https://warthogs.atlassian.net/browse/WD-35828)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-35828]: https://warthogs.atlassian.net/browse/WD-35828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ