### PR TITLE
fix(TEMP): disable takeovers pulled from discourse

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1513,7 +1513,7 @@
                   // Otherwise, randomly choose one of the takeovers and store it for next time
                   selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
                 }
-                showTakeover(selectedTakeovers, selectedIndex);
+                // showTakeover(selectedTakeovers, selectedIndex);
 
                 // Store the current takeover index
                 localStorage.setItem("selected_takeover_index", selectedIndex);


### PR DESCRIPTION
## Done

- disable takeovers pulled from discourse as there is a bug and it is rendering old ones

## QA

- Open the [DEMO](https://ubuntu-com-16324.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

