### PR TITLE
fix: add image alt text

### DIFF
--- a/templates/blender/index.html
+++ b/templates/blender/index.html
@@ -52,6 +52,7 @@
       "item": {
         "is_highlighted": false,
         "attrs": image(url="https://assets.ubuntu.com/v1/566270f1-blender_logo.png",
+                    alt="Blender logo",
                     width="226",
                     height="195",
                     hi_def=True,


### PR DESCRIPTION
## Done

- Add image alt text that was causing /blender from rendering

## QA

- Go to /blender
- See that page loads

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
