### PR TITLE
fix: use correct Vanilla class for CTA on /robotics/ros-esm

### DIFF
--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -422,7 +422,7 @@
         </div>
       </div>
       <div class="grid-row">
-        <div class="grid-start-col-5 grid-col-4">
+        <div class="grid-col-start-large-5 grid-col-4">
           <hr class="p-rule--muted is-fixed-width" />
           <span style="margin-right: 1rem;">Want to know more?</span>
           <a href="/internet-of-things/contact-us?product=robotics"


### PR DESCRIPTION
## Done

- Updated to use correct Vanilla class for CTA

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Navigate to `/robotics/ros-esm`
- Check the "The benefits of an Ubuntu Pro subscription" section and ensure the CTA there matches the [Figma](https://www.figma.com/design/xxxrpexajIgaq6cyY0UfSu/ubuntu.com-robotics---Sites?node-id=2003-4123&t=b4ICG7RVMCaKx2Da-1)

## Issue / Card

[WD-36407](https://warthogs.atlassian.net/browse/WD-36407)

## Screenshots

Before fix:
<img width="1788" height="813" alt="Screenshot 2026-04-30 093237" src="https://github.com/user-attachments/assets/83089152-3bcb-4357-a178-0bdb09fa998c" />

After fix:
<img width="1769" height="814" alt="image" src="https://github.com/user-attachments/assets/1f5f932d-b157-46b9-8d36-a0713e8d1fff" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36407]: https://warthogs.atlassian.net/browse/WD-36407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ