### PR TITLE
chore: disable pro, account, and login routes

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -85,7 +85,6 @@ from webapp.shop.advantage.views import (
     post_offer,
     pro_activate_activation_key,
     pro_get_request_attributes,
-    pro_page_view,
     put_account_user_role,
     put_contract_entitlements,
 )
@@ -531,11 +530,7 @@ app.add_url_rule(
     "/account/last-purchase-ids/<account_id>",
     view_func=get_last_purchase_ids,
 )
-app.add_url_rule(
-    "/pro",
-    view_func=pro_page_view,
-    methods=["GET"],
-)
+
 app.add_url_rule(
     "/pro/purchase",
     view_func=post_advantage_purchase,

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -69,6 +69,11 @@ def empty_session(user_session):
 
 @open_id.loginhandler
 def login_handler():
+    return (
+        flask.render_template("500.html"),
+        500,
+    )
+
     api_url = get_flask_env(
         "CONTRACTS_API_URL", "https://contracts.canonical.com"
     )

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -196,7 +196,7 @@ def get_contract_token(advantage_mapper, **kwargs):
     return flask.jsonify({"contract_token": contract_token})
 
 
-@shop_decorator(area="advantage", response="html")
+@shop_decorator(area="advantage", permission="user", response="html")
 def advantage_shop_view(advantage_mapper, **kwargs):
     account = None
     if user_info(flask.session):

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -35,40 +35,6 @@ from webapp.shop.schemas import (
 )
 
 
-@shop_decorator(area="advantage", response="html")
-def pro_page_view(advantage_mapper, **kwargs):
-    """
-    Renders the /pro page. If there is a logged in user it checks for active
-    subscriptions so we can display a contact form, otherwise renders the page
-    without any form. Anonymous requests don't see the form either.
-    """
-    show_beta_request = False
-    user = user_info(flask.session)
-    if user:
-        try:
-            subscriptions = advantage_mapper.get_user_subscriptions(
-                email=None, marketplaces=["canonical-ua"]
-            )
-            for subscription in subscriptions:
-                if (
-                    subscription.marketplace == "canonical-ua"
-                    and subscription.statuses["has_access_to_support"]
-                ):
-                    show_beta_request = True
-                    break
-        except Exception:
-            sentry_sdk.capture_exception(
-                extra={
-                    "message": "Could not get user subscriptions on pro page"
-                }
-            )
-
-    return flask.render_template(
-        "pro/index.html",
-        show_beta_request=show_beta_request,
-    )
-
-
 @shop_decorator(area="advantage", permission="user", response="html")
 def advantage_view(advantage_mapper, is_in_maintenance, **kwargs):
     is_technical = False

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -1,6 +1,5 @@
 # Packages
 import json
-import sentry_sdk
 from typing import List
 
 import flask


### PR DESCRIPTION
## Done

- Disable /pro, /account, and /login routes

## QA

- You should see a 500 error on the following pages and all sub-routes:
  - [/login](https://ubuntu-com-16329.demos.haus/login)
  - [/pro/dashboard](https://ubuntu-com-16329.demos.haus/pro/dashboard)
  - [/account](https://ubuntu-com-16329.demos.haus/account)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

