### PR TITLE
chore: update NVIDIA logo URL in /nvidia

### DIFF
--- a/templates/nvidia/index.html
+++ b/templates/nvidia/index.html
@@ -499,10 +499,10 @@
     "logos": [
     {
     "attrs": image(
-    url="https://assets.ubuntu.com/v1/1f419e4d-accelerated_by_nvidia.png",
+    url="https://assets.ubuntu.com/v1/bddf8d3e-nvidia_logo.svg",
     alt="NVIDIA DRIVE",
-    width="378",
-    height="312",
+    width="150",
+    height="104",
     hi_def=True,
     loading="lazy",
     attrs={"class": "p-image-container__image"},

--- a/templates/nvidia/index.html
+++ b/templates/nvidia/index.html
@@ -500,7 +500,7 @@
     {
     "attrs": image(
     url="https://assets.ubuntu.com/v1/bddf8d3e-nvidia_logo.svg",
-    alt="NVIDIA DRIVE",
+    alt="NVIDIA logo",
     width="150",
     height="104",
     hi_def=True,

--- a/tests/playwright/helpers/navigation-data.ts
+++ b/tests/playwright/helpers/navigation-data.ts
@@ -166,6 +166,7 @@ const EXCLUDED_SECTIONS = new Set([
   "account",     // Requires login — redirects to /login
   "Distributor", // Requires login — redirects to /login
   "credentials", // redirects to https://canonical.com/academy
+  "legal", // redirects to https://canonical.com/legal
 ]);
 
 const isValidSection = ([key, section]: [string, SecondaryNavSection]) =>


### PR DESCRIPTION
## Done

- Update the NVIDIA logo in the divided section

Driveby:
- Fix failing test (it was caused due to a redirect added to /legal and the test was trying to test the /legal page but it now redirects to https://canonical.com/legal)

## QA

- Open the [DEMO](https://ubuntu-com-16334.demos.haus/nvidia)
- Check that the Nvidia logo is updated based on this comment https://warthogs.atlassian.net/browse/WD-36406?focusedCommentId=1083603
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-36406](https://warthogs.atlassian.net/browse/WD-36406)

## Screenshots
### Before
<img width="3008" height="1604" alt="image" src="https://github.com/user-attachments/assets/198f53bd-8ab0-4d3c-b0a4-2ffb89c919cd" />

### After
<img width="2928" height="1566" alt="image" src="https://github.com/user-attachments/assets/804e0686-ca25-41a2-b625-f1e6ed827d72" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-36406]: https://warthogs.atlassian.net/browse/WD-36406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ