### PR TITLE
copy-update(WD-36130): update the /download/core for the new LTS

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -56,7 +56,7 @@ previous_previous_lts:
   release_date: "April 2022"
   eol: "April 2027"
 core_lts:
-  version: "24"
+  version: "26"
   eol: "April 2034"
 openstack_lts:
   slug: Yoga

--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -90,7 +90,7 @@ meta_copydoc %}
              aria-labelledby="release-notes-tab">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">Smarter OTA updates</li>
-            <li class="p-list__item is-ticked">Chisel-built systems</li>
+            <li class="p-list__item is-ticked">Chisel-built system</li>
             <li class="p-list__item is-ticked">Livepatch integration</li>
           </ul>
           <hr class="p-rule is-muted" />

--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -51,11 +51,11 @@ meta_copydoc %}
         <div class="p-section--shallow">
           <p>Build your Ubuntu Core image for your application and targeted hardware.</p>
           <p>
-            Ubuntu Core {{ releases_yaml.core_lts.version }} is the latest LTS version of Ubuntu for deployment on embedded devices and edge systems. LTS stands for long-term support &mdash; which means 10 years of security and maintenance updates guaranteed until {{ releases_yaml.core_lts.eol }}.
+            Ubuntu Core {{ releases_yaml.core_lts.version }} is the latest LTS version of Ubuntu for deployment on embedded devices and edge systems. LTS stands for long-term support &mdash; which means 10 years of security and maintenance updates, extended to up to 15 years with <a href="/pro">Ubuntu Pro</a>.
           </p>
           <hr class="p-rule" />
           <p>
-            <a class="p-button--positive" href="/core/docs/getting-started">Build your Core {{ releases_yaml.core_lts.version }}</a>
+            <a class="p-button--positive" href="/core/docs/getting-started">Build your Core {{ releases_yaml.core_lts.version }} image</a>
           </p>
         </div>
         <!-- Start tab container -->
@@ -89,10 +89,9 @@ meta_copydoc %}
              role="tabpanel"
              aria-labelledby="release-notes-tab">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Optimised factory installation</li>
-            <li class="p-list__item is-ticked">Improvements to image builds</li>
-            <li class="p-list__item is-ticked">Enhanced GPU operations</li>
-            <li class="p-list__item is-ticked">Open device management</li>
+            <li class="p-list__item is-ticked">Smarter OTA updates</li>
+            <li class="p-list__item is-ticked">Chisel-built systems</li>
+            <li class="p-list__item is-ticked">Livepatch integration</li>
           </ul>
           <hr class="p-rule is-muted" />
           <p>


### PR DESCRIPTION
## Done

Copy update to `ubuntu.com/download/core` based on https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit?tab=t.0

## QA

- Open https://ubuntu-com-16335.demos.haus/download/core
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/core
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

https://warthogs.atlassian.net/browse/WD-36130

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
