### PR TITLE
fix(WD-34325): OpenJDK logo issues

### DIFF
--- a/templates/toolchains/java.html
+++ b/templates/toolchains/java.html
@@ -25,13 +25,13 @@
     layout='25/75'
     ) -%}
     {%- if slot == 'signpost_image' -%}
-      {{ image(url="https://assets.ubuntu.com/v1/5a101b58-openjdk%20logo.png",
+      {{ image(url="https://assets.ubuntu.com/v1/da2f2b62-openjdk_logo.png",
             alt="OpenJDK",
-            width="220",
-            height="312",
+            width="852",
+            height="165",
             hi_def=True,
             loading="auto",
-            attrs={"style": "width: 100%;"}) | safe
+            ) | safe
       }}
     {%- endif -%}
     {%- if slot == 'description' -%}


### PR DESCRIPTION
## Done

- Removed hard-coded width
- Hide logo on small/medium screens

## QA

- Checkout this pull request
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/toolchains/java
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the logo looks clear, and is only visible on desktop

## Issue / Card

Fixes [WD-34325](https://warthogs.atlassian.net/browse/WD-34325)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-34325]: https://warthogs.atlassian.net/browse/WD-34325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
