### PR TITLE
Update 26.04 Summit details with links & timetable

### DIFF
--- a/templates/summit/call-for-collaboration.html
+++ b/templates/summit/call-for-collaboration.html
@@ -24,6 +24,10 @@
       <p>
         Above all, it's a celebration of what Ubuntu has achieved so far, and an invitation to collaborate with us in delivering an even faster pace of innovation in the future.
       </p>
+      <div class="p-cta-block">
+        <a class="p-button--positive"
+           href="https://ubu.link/ubuntusummit-extended">Organize an Ubuntu Summit Extended</a>
+      </div>
     {%- endif -%}
   {% endcall -%}
 
@@ -66,7 +70,7 @@
       <div class="row">
         <div class="col-6 col-start-large-7">
           <p>
-            The Ubuntu Summit 26.04's call for remote lightning talks is open and we are looking for speakers who desire to share their bold vision of the future. Here are just a few themes that align with the Summit spirit:
+            The Ubuntu Summits are open to remote lightning talks from speakers who desire to share their bold vision of the future. Here are just a few themes that align with the Summit spirit:
           </p>
           <hr class="p-rule--muted" />
           <ul class="p-list--divided">
@@ -74,6 +78,9 @@
             <li class="p-list__item is-ticked">Innovation in open ecosystems and communities.</li>
             <li class="p-list__item is-ticked">Crossing the divide from proprietary to open source.</li>
           </ul>
+          <p>
+            To be considered for the following Summit, submit your proposal below.
+          </p>
           <div class="p-cta-block">
             <a class="p-button--positive" href="https://ubu.link/ubuntusummit-cfp">Submit your abstract</a>
           </div>
@@ -140,7 +147,7 @@
             While the physical event takes place in London, watch parties and Summit extended events are hosted all over the world by local communities.
           </p>
           <div class="p-cta-block">
-            <a href="/blog/ubuntu-summit-25-10-is-coming-to-your-circle-of-friends-from-london"
+            <a href="/blog/ubuntu-summit-26-04-is-coming-save-the-date-and-share-your-story"
                class="p-button"
                aria-label="Learn more about ubuntu summit 25.10">Learn more</a>
           </div>
@@ -189,6 +196,9 @@
             Traversed a whole range of topics, from Rust and ARM64 to sustainability and the impact of open source on teenage lives.
           </li>
         </ul>
+        <p>
+          To be considered for the following Summit, submit your proposal below.
+        </p>
         <div class="p-cta-block">
           <a class="p-button--positive" href="https://ubu.link/ubuntusummit-cfp">Submit your abstract</a>
         </div>

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -91,7 +91,7 @@
           While the physical event takes place in London, watch parties and Summit extended events are hosted all over the world by local communities.
         </p>
         <div class="p-cta-block">
-          <a href="/blog/ubuntu-summit-25-10-is-coming-to-your-circle-of-friends-from-london" aria-label="Learn more about The Ubuntu Summit">
+          <a href="/blog/ubuntu-summit-26-04-is-coming-save-the-date-and-share-your-story" aria-label="Learn more about The Ubuntu Summit">
             Learn more&nbsp;&rsaquo;
           </a>
         </div>

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -33,7 +33,7 @@
           </p>
           <div class="p-cta-block">
             <a href="https://discourse.ubuntu.com/t/register-for-ubuntu-summit/65270" class="p-button--positive">Register for the Summit</a>
-            <a href="https://ubuntu.com/summit/call-for-collaboration" class="p-button">Find out how you can contribute</a>
+            <a href="https://discourse.ubuntu.com/t/ubuntu-summit-26-04-timetable/81507" class="p-button">View the timetable</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updating the link to the latest Summit blog, promoting 26.04 Summit.
- Adding link to 26.04 timetable.

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
