### PR TITLE
feat(intel-iot): add Intel® Core™ (Series 2)

### DIFF
--- a/templates/download/iot/intel-iot/index.html
+++ b/templates/download/iot/intel-iot/index.html
@@ -421,6 +421,8 @@
             <p>
               Hybrid SKUs combine up to 8 P-cores and 16 E-cores for 32 threads, delivering outstanding multi-threaded performance. P-core-only SKUs, ideal for networking and edge computing, offer high single-threaded performance. Featuring DDR5-4800/5600, DDR4-3200, Intel® UHD Graphics 770, PCIe 5.0, Thunderbolt 4, and Wi-Fi 7 support.
             </p>
+            <a href="https://www.intel.com/content/www/us/en/products/details/processors/core/edge.html"
+               aria-label="Learn about Intel Core Processors for Embedded Applications">Learn more about Intel® Core™ Processors for Embedded Applications&nbsp;&rsaquo;</a>
           </div>
           <hr class="p-rule--muted u-hide--medium u-hide--small" />
           <div class="p-equal-height-row">

--- a/templates/download/iot/intel-iot/index.html
+++ b/templates/download/iot/intel-iot/index.html
@@ -74,7 +74,7 @@
             <hr class="p-rule--muted" />
             <p>
               <a aria-controls="contact-modal"
-                 href="/download/iot/intel-iot/contact-us"
+                 href="/download/iot/intel-iot#get-in-touch"
                  class="p-button--positive js-invoke-modal">Get in touch</a>
             </p>
             <p>
@@ -179,6 +179,17 @@
               Intel&reg; Core&trade; Ultra (Series 1)
               <br />
               <span class="u-text--muted u-no-margin--bottom">Meteor Lake, Meteor Lake PS</span>
+            </button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="core-series-2-bartlett"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="core-series-2-bartlett-tab">
+              Intel&reg; Core&trade; (Series 2)
+              <br />
+              <span class="u-text--muted u-no-margin--bottom">Bartlett Lake</span>
             </button>
           </li>
           <li>
@@ -412,6 +423,74 @@
                     <a aria-label="Instructions for Ubuntu Server"
                        href="https://assets.ubuntu.com/v1/a0b71e1e-Installation+Instructions+Server+Image+Intel+IoT+Platforms.pdf">Instructions&nbsp;&rsaquo;</a>
                   </li>
+                  <li class="p-inline-list__item">
+                    <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-inline-list__item">
+                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release
+                      notes for
+                    24.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div tabindex="0"
+             role="tabpanel"
+             id="core-series-2-bartlett-tab"
+             aria-labelledby="core-series-2-bartlett"
+             aria-hidden="true">
+          <div class="p-section--shallow">
+            <h3 class="p-heading--2">Intel&reg; Core&trade; (Series 2)</h3>
+          </div>
+          <hr class="p-rule--muted u-hide--medium u-hide--small" />
+          <div class="col">
+            <p>
+              Hybrid SKUs combine up to 8 P-cores and 16 E-cores for 32 threads, delivering outstanding multi-threaded performance. P-core-only SKUs, ideal for networking and edge computing, offer high single-threaded performance. Featuring DDR5-4800/5600, DDR4-3200, Intel® UHD Graphics 770, PCIe 5.0, Thunderbolt 4, and Wi-Fi 7 support.
+            </p>
+          </div>
+          <hr class="p-rule--muted u-hide--medium u-hide--small" />
+          <div class="p-equal-height-row">
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <h4 class="p-heading--5">Ubuntu Desktop</h4>
+              </div>
+              <div class="p-equal-height-row__item">
+                <p>Modern and performant, with a rich ecosystem of applications.</p>
+                <p>
+                  <a class="p-button--positive"
+                     href="/download/desktop"
+                     aria-label="Download Ubuntu Desktop 24.04 LTS">Download
+                  24.04 LTS</a>
+                </p>
+                <hr class="p-rule--muted u-hide--medium u-hide--small" />
+                <ul class="u-responsive-realign p-inline-list">
+                  <li class="p-inline-list__item">
+                    <a aria-label="Learn more about Ubuntu Desktop"
+                       href="/desktop/developers">Learn
+                    more&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-inline-list__item">
+                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release notes for 24.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <h4 class="p-heading--5">Ubuntu Server</h4>
+              </div>
+              <div class="p-equal-height-row__item">
+                <p>Designed and engineered as a backbone for the internet</p>
+                <p>
+                  <a class="p-button--positive"
+                     href="/download/server"
+                     aria-label="Download Ubuntu Server 24.04 LTS">Download
+                  24.04 LTS</a>
+                </p>
+                <hr class="p-rule--muted u-hide--medium u-hide--small" />
+                <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
                     <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
                   </li>

--- a/templates/download/iot/intel-iot/index.html
+++ b/templates/download/iot/intel-iot/index.html
@@ -315,8 +315,7 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/desktop"
-                     aria-label="Download Ubuntu Desktop 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Desktop">Download Ubuntu Desktop</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
@@ -324,9 +323,6 @@
                     <a aria-label="Learn more about Ubuntu Desktop"
                        href="/desktop/developers">Learn
                     more&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release notes for 24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -340,18 +336,12 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/server"
-                     aria-label="Download Ubuntu Server 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Server">Download Ubuntu Server</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
                     <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release
-                      notes for
-                    24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -385,22 +375,14 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/desktop"
-                     aria-label="Download Ubuntu Desktop 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Desktop">Download Ubuntu Desktop</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
-                    <a aria-label="Instructions for Ubuntu Desktop"
-                       href="https://assets.ubuntu.com/v1/2715b851-Installation+Instructions+Desktop+Image+Intel+IoT+Platforms.pdf">Instructions&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
                     <a aria-label="Learn more about Ubuntu Desktop"
                        href="/desktop/developers">Learn
                     more&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release notes for 24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -414,22 +396,12 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/server"
-                     aria-label="Download Ubuntu Server 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Server">Download Ubuntu Server</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
-                    <a aria-label="Instructions for Ubuntu Server"
-                       href="https://assets.ubuntu.com/v1/a0b71e1e-Installation+Instructions+Server+Image+Intel+IoT+Platforms.pdf">Instructions&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
                     <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release
-                      notes for
-                    24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -461,8 +433,7 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/desktop"
-                     aria-label="Download Ubuntu Desktop 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Desktop">Download Ubuntu Desktop</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
@@ -470,9 +441,6 @@
                     <a aria-label="Learn more about Ubuntu Desktop"
                        href="/desktop/developers">Learn
                     more&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release notes for 24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -486,18 +454,12 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/server"
-                     aria-label="Download Ubuntu Server 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Server">Download Ubuntu Server</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
                     <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release
-                      notes for
-                    24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -915,13 +877,12 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/core"
-                     aria-label="Download Ubuntu Desktop Core 24">Download
-                  Core 24</a>
+                     aria-label="Download Ubuntu Core">Download Ubuntu Core</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
-                    <a aria-label="Docs for Ubuntu Core" href="/core/docs/uc24">Docs&nbsp;&rsaquo;</a>
+                    <a aria-label="Docs for Ubuntu Core" href="https://documentation.ubuntu.com/core/">Docs&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -935,8 +896,7 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/desktop"
-                     aria-label="Download Ubuntu Desktop 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Desktop">Download Ubuntu Desktop</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
@@ -944,9 +904,6 @@
                     <a aria-label="Learn more about Ubuntu Desktop"
                        href="/desktop/developers">Learn
                     more&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release notes for 24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>
@@ -960,18 +917,12 @@
                 <p>
                   <a class="p-button--positive"
                      href="/download/server"
-                     aria-label="Download Ubuntu Server 24.04 LTS">Download
-                  24.04 LTS</a>
+                     aria-label="Download Ubuntu Server">Download Ubuntu Server</a>
                 </p>
                 <hr class="p-rule--muted u-hide--medium u-hide--small" />
                 <ul class="u-responsive-realign p-inline-list">
                   <li class="p-inline-list__item">
                     <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release
-                      notes for
-                    24.04 LTS&nbsp;&rsaquo;</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
## Done

- download/iot/intel-iot: in first section, update link of "Get in touch" button from `/download/iot/intel-iot/contact-us` to `/download/iot/intel-iot#get-in-touch`
- download/iot/intel-iot: add Intel® Core™ (Series 2) to processor list and its tab content

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[JIRA ticket](https://warthogs.atlassian.net/browse/WD-36506)
[Coydoc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc)

## Screenshots

<img width="1835" height="1055" alt="Screenshot from 2026-05-07 09-59-22" src="https://github.com/user-attachments/assets/af1ddd9d-5a83-413b-b622-a5d3c863b1ff" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
