### PR TITLE
fix(pro): improve magic attach confirmation copy

### DIFF
--- a/templates/pro/attach/confirmation.html
+++ b/templates/pro/attach/confirmation.html
@@ -21,8 +21,8 @@
         </div>
         <div class="p-notification__meta">
             <div class="p-notification__actions">
-                <a class="p-notification__action"><button onclick="history.back()"> Try another code</button></a>
-                <a class="p-notification__action" href="/pro/dashboard"><button>Your subscriptions</button></a>
+                <a class="p-notification__action p-button" href="/pro/attach"> Try another code</a>
+                <a class="p-notification__action p-button" href="/pro/dashboard">Your subscriptions</a>
             </div>
         </div>
     </div>

--- a/templates/pro/attach/confirmation.html
+++ b/templates/pro/attach/confirmation.html
@@ -1,6 +1,6 @@
 {% extends "advantage/base_advantage.html" %}
 
-{% block title %}Ubuntu Advantage - Magic Attach{% endblock %}
+{% block title %}Ubuntu Pro - Magic Attach{% endblock %}
 {% block meta_description %}Magically attach devices with your {% endblock %}
 
 {% block content %}
@@ -9,13 +9,13 @@
     {% if 'success' in status %}
     <div class="p-notification--positive m-auto w-50" id="notification-success">
         <div class="p-notification__content">
-            <h5 class="p-notification__title">Success</h5>
-            <p class="p-notification__message">Successfully Attached Machine</p>
+            <h5 class="p-notification__title">Continue on your machine</h5>
+            <p class="p-notification__message">You can go back to the app or terminal now.</p>
         </div>
         <div class="p-notification__meta">
             <div class="p-notification__actions">
                 <a class="p-notification__action"><button onclick="history.back()"> Try another code</button></a>
-                <a class="p-notification__action" href="/pro/dashboard"><button>Your Subscriptions</button></a>
+                <a class="p-notification__action" href="/pro/dashboard"><button>Your subscriptions</button></a>
             </div>
         </div>
     </div>
@@ -28,7 +28,7 @@
         <div class="p-notification__meta">
             <div class="p-notification__actions">
                 <a class="p-notification__action"><button onclick="history.back()"> Try another code</button></a>
-                <a class="p-notification__action" href="/pro/dashboard"><button>Your Subscriptions</button></a>
+                <a class="p-notification__action" href="/pro/dashboard"><button>Your subscriptions</button></a>
             </div>
         </div>
     </div>

--- a/templates/pro/attach/confirmation.html
+++ b/templates/pro/attach/confirmation.html
@@ -12,12 +12,6 @@
             <h5 class="p-notification__title">Continue on your machine</h5>
             <p class="p-notification__message">You can go back to the app or terminal now.</p>
         </div>
-        <div class="p-notification__meta">
-            <div class="p-notification__actions">
-                <a class="p-notification__action"><button onclick="history.back()"> Try another code</button></a>
-                <a class="p-notification__action" href="/pro/dashboard"><button>Your subscriptions</button></a>
-            </div>
-        </div>
     </div>
     {% else %}
     <div class="p-notification--negative m-auto w-100" id="notification-error">

--- a/templates/pro/attach/index.html
+++ b/templates/pro/attach/index.html
@@ -1,6 +1,6 @@
 {% extends "advantage/base_advantage.html" %}
 
-{% block title %}Ubuntu Advantage - Magic Attach{% endblock %}
+{% block title %}Ubuntu Pro - Magic Attach{% endblock %}
 {% block meta_description %}Magically attach devices with your {% endblock %}
 
 {% block content %}

--- a/templates/pro/attach/instructions.html
+++ b/templates/pro/attach/instructions.html
@@ -16,24 +16,24 @@
         </div>
         <div class="col-6">
             <p>Ubuntu Pro can be enabled from the Security Center app. <em>On 24.04 LTS and older, use the Software & Updates app instead.</em></p>
-            <ol className="p-stepped-list">
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+            <ol class="p-stepped-list">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         Go to the "Ubuntu Pro" page and click on "Enable Ubuntu Pro".
                     </p>
                 </li>
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         Select "Enable with Ubuntu Pro account".
                     </p>
                 </li>
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         Continue in browser as instructed, or copy the six-character code and paste it in the field above on this page.
                     </p>
                 </li>
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         Select the subscription you want to attach to, and submit.
                     </p>
                 </li>
@@ -52,19 +52,19 @@
         <div class="col-6">
             <p>
                 During installation, you'll be asked whether you want to Upgrade to Ubuntu Pro.
-            <ol className="p-stepped-list">
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+            <ol class="p-stepped-list">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         Choose "Enable Ubuntu Pro".
                     </p>
                 </li>
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         On the next screen you will be presented with a six-character code as part of the first option.
                     </p>
                 </li>
-                <li className="p-stepped-list__item">
-                    <p className="p-stepped-list__title">
+                <li class="p-stepped-list__item">
+                    <p class="p-stepped-list__title">
                         Enter the code into the field above on this page, select the subscription you want to attach to, submit.
                     </p>
                 </li>

--- a/templates/pro/attach/instructions.html
+++ b/templates/pro/attach/instructions.html
@@ -11,27 +11,30 @@
 <div tabindex="0" role="tabpanel" id="desktop-tab" aria-labelledby="MADesktop">
     <div class="row">
         <div class="col-6">
-            {{ image( url="https://assets.ubuntu.com/v1/8c3fd6d1-magic_attach_visual_aid_desktop.png",
-            alt="", width="1174", height="615", hi_def=True, loading="auto" ) | safe }}
+            {{ image( url="https://assets.ubuntu.com/v1/5baafba5-security_center_magic_attach_1.png",
+            alt="", width="1704", height="1408", hi_def=True, loading="auto" ) | safe }}
         </div>
         <div class="col-6">
-            <p>
-            Ubuntu Pro can be enabled from the Software & Updates application.
+            <p>Ubuntu Pro can be enabled from the Security Center app. <em>On 24.04 LTS and older, use the Software & Updates app instead.</em></p>
             <ol className="p-stepped-list">
                 <li className="p-stepped-list__item">
                     <p className="p-stepped-list__title">
-                        Go to the "Ubuntu Pro" tab and click "Enable Ubuntu Pro".
+                        Go to the "Ubuntu Pro" page and click on "Enable Ubuntu Pro".
                     </p>
                 </li>
                 <li className="p-stepped-list__item">
                     <p className="p-stepped-list__title">
-                        On the next screen you will be presented with a
-                        six-character code as part of the first option.
+                        Select "Enable with Ubuntu Pro account".
                     </p>
                 </li>
                 <li className="p-stepped-list__item">
                     <p className="p-stepped-list__title">
-                        Enter the code into the field above on this page, select the subscription you want to attach to, submit.
+                        Continue in browser as instructed, or copy the six-character code and paste it in the field above on this page.
+                    </p>
+                </li>
+                <li className="p-stepped-list__item">
+                    <p className="p-stepped-list__title">
+                        Select the subscription you want to attach to, and submit.
                     </p>
                 </li>
             </ol>


### PR DESCRIPTION
The Ubuntu Pro magic attach pages have imprecise and outdated copy. The confirmation screen misleadingly states that the "machine is attached" on success, when it's not true: token is sent to the machine, but the attachment process still needs to complete there.

## Changes

- Replace copy in success notification to not convey machine is attached already
- Remove buttons in success notification: they are arguably not needed on success
- Update page titles from "Ubuntu Advantage" to "Ubuntu Pro"
- Change button labels to sentence case ("Your Subscriptions" → "Your subscriptions")
- Update instructions on /pro/attach to cover Security Center

The new copy follows Vanilla Framework content guidelines: verb-first title, no punctuation in title, punctuation in message, and actionable language that reflects the actual flow (user needs to return to their Pro client to finish).

## Screenshot

<img width="2560" height="636" alt="0 0 0 0_8001_pro_attach_confirmation-demo_state=success (2)" src="https://github.com/user-attachments/assets/06e08894-041b-4631-885d-82510e59aec3" />

<img width="2560" height="1534" alt="0 0 0 0_8001_pro_attach" src="https://github.com/user-attachments/assets/8b1787ed-556b-49fc-a00a-953ed2f65653" />

## Type of change
Documentation / copy update (non-breaking)

UDENG-8692