### PR TITLE
security(WD-36593): SRI - use cryptographic hashes for external resources

### DIFF
--- a/templates/16-04/_release-chart-1604.html
+++ b/templates/16-04/_release-chart-1604.html
@@ -93,5 +93,7 @@
     </table>
   </div>
 </div>
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"></script>
 <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>

--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -18,7 +18,9 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/18-04/_release-chart-1604.html
+++ b/templates/18-04/_release-chart-1604.html
@@ -93,5 +93,7 @@
     </table>
   </div>
 </div>
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"></script>
 <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -194,7 +194,10 @@
     tag_name="ubuntu",
     tag_id="1564") }}
 
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"
+          defer></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
 

--- a/templates/aws/shared/_aws-pie-chart.html
+++ b/templates/aws/shared/_aws-pie-chart.html
@@ -3,7 +3,9 @@
 <p class="u-no-margin--bottom"><small>Ubuntu Pro has both <a href="https://help.ubuntu.com/community/Repositories/Ubuntu">Ubuntu main and universe</a> repositories under our security team's watch. Updated packages are streamed to AWS in-region mirrors and built into our AMIs, which are refreshed daily and promoted weekly to <a href="https://aws.amazon.com/marketplace">AWS Marketplace</a>.</small></p>
 
 
-<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"
+        integrity="sha384-gOxMGMgqQH8iYyQE8rmgpaokSRE608gSIXXdC2a/yT+OywUqbNmTCQa3qNO4wvyc"
+        crossorigin="anonymous"></script>
 
 <script>
 function drawChart() {

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -17,7 +17,9 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -591,6 +591,9 @@
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/containers") | safe }}
 
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"
+          defer></script>
   <script src="{{ versioned_static('js/dist/chiseled-chart.js') }}" defer></script>
 {% endblock %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -24,7 +24,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/cpu-compatibility/index.html
+++ b/templates/cpu-compatibility/index.html
@@ -252,7 +252,10 @@
   </div>
 </section>
 
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"
+        defer></script>
 <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
 
 {% endblock content %}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -636,7 +636,10 @@
 
   {% include "desktop/partial/_desktop-latest-news.html" %}
 
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"
+          defer></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
   <script src="{{ versioned_static('js/dist/developer-chart.js')}}" defer></script>

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -15,7 +15,9 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/engage/de_why-openstack.html
+++ b/templates/engage/de_why-openstack.html
@@ -197,7 +197,10 @@
 
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/engage/de/warum-openstack") | safe }}
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"
+          defer></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
 {% endblock content %}

--- a/templates/engage/es_why-openstack.html
+++ b/templates/engage/es_why-openstack.html
@@ -178,7 +178,10 @@
 
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/engage/es/por-que-openstack") | safe }}
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"
+          defer></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
 {% endblock content %}

--- a/templates/engage/fr_why-openstack.html
+++ b/templates/engage/fr_why-openstack.html
@@ -156,6 +156,9 @@ https://docs.google.com/document/d/1Nvam2qif5UPjTyUPWxhJo1XPiFDM-Eb5FxfSWCbNX8c
 
 <!-- Set default Marketo information for contact form below-->
 {{ load_form("/engage/fr/pourquoi-openstack") | safe }}
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"
+        defer></script>
 <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -853,7 +853,9 @@
             <div class="u-hide--medium u-hide--large col-6">
               <div id="openstack-table"></div>
             </div>
-            <script src="https://d3js.org/d3.v6.min.js"></script>
+            <script src="https://d3js.org/d3.v6.min.js"
+                    integrity="sha384-ma33ZEb8L5emtidZhYJFZNIFdht2E8f5wHQMKQGom0aIx9rRKm86XXCjGxOISpM9"
+                    crossorigin="anonymous"></script>
             <script src="{{ versioned_static('js/dist/openstackDeploymentChart.js') }}"></script>
           </div>
           <div class="p-cta-block">

--- a/templates/openstack/shared/_openstack-aws-pie-chart.html
+++ b/templates/openstack/shared/_openstack-aws-pie-chart.html
@@ -1,6 +1,8 @@
 <figure id="ubuntu-pie" class="ubuntu-pie"></figure>
 
-<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"
+        integrity="sha384-gOxMGMgqQH8iYyQE8rmgpaokSRE608gSIXXdC2a/yT+OywUqbNmTCQa3qNO4wvyc"
+        crossorigin="anonymous"></script>
 
 <script>
 // FF/Opera does not support offsetWidth for tspan's. If undefined

--- a/templates/openstack/shared/_openstack-pie-chart.html
+++ b/templates/openstack/shared/_openstack-pie-chart.html
@@ -3,7 +3,9 @@
 <p class="u-no-margin--bottom"><small>Ubuntu powers 55% of OpenStack in production. Source: <a href="https://www.openstack.org/assets/survey/April2017SurveyReport.pdf" class="external">OpenStack survey &mdash; April 2017 [PDF 10.6MB]</a></small></p>
 
 
-<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"
+        integrity="sha384-gOxMGMgqQH8iYyQE8rmgpaokSRE608gSIXXdC2a/yT+OywUqbNmTCQa3qNO4wvyc"
+        crossorigin="anonymous"></script>
 
 <script>
 function drawChart() {

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -22,7 +22,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -26,7 +26,9 @@
   <p class="chart-legend-lts"><span class="p-heading--5">Packages covered with LTS</span><br/><span class="chart-legend-subtext">Standard security maintenance, packages with CVE fixes available for 5 years</span></p>
   <p class="chart-legend-pro"><span class="p-heading--5">Packages covered with Ubuntu Pro</span><br/><span class="chart-legend-subtext">ESM and Legacy, packages with CVE fixes available for 10+5 years</span></p>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+        integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+        crossorigin="anonymous"></script>
 
 <script>
   const ctx = document.getElementById('myChart');

--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -20,7 +20,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/robotics/what-is-ros.html
+++ b/templates/robotics/what-is-ros.html
@@ -18,7 +18,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -22,7 +22,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -162,7 +162,9 @@
 
     </div>
   </section>
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
 
   <section class="p-section">

--- a/templates/security/fedramp.html
+++ b/templates/security/fedramp.html
@@ -18,7 +18,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -15,7 +15,9 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block meta_copydoc %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -449,10 +449,10 @@
       </div>
     </div>
   </div>
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+          integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+          crossorigin="anonymous"></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
-
-  <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -453,6 +453,7 @@
           integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
           crossorigin="anonymous"></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
+  <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -8,7 +8,10 @@
   <div class="row">{% include "shared/_kernel-release-diagram.html" %}</div>
 </section>
 
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"
+        defer></script>
 <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
         defer></script>
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -110,5 +110,7 @@
   </div>
 </div>
 
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"></script>
 <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -20,6 +20,8 @@
     <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
 
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
+            integrity="sha384-TI/T2gDQjjlI4xuVcADfKuha0uICGVNowMXFblCWGz6MMkwVNIEuc59dlu6rQuNE"
+            crossorigin="anonymous"
             defer></script>
     <script src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
     <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>

--- a/templates/templates/image-testing_base.html
+++ b/templates/templates/image-testing_base.html
@@ -5,7 +5,10 @@
   <meta name="robots" content="noindex" />
   <title>Testing images | Ubuntu</title>
   <link rel="preconnect" href="https://res.cloudinary.com">
-  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
+          integrity="sha384-TI/T2gDQjjlI4xuVcADfKuha0uICGVNowMXFblCWGz6MMkwVNIEuc59dlu6rQuNE"
+          crossorigin="anonymous"
+          defer></script>
 </head>
 <body>
   {% block content %}{% endblock %}


### PR DESCRIPTION
## Done

- SRI attributes added to external resources

**Resources included in SRI**

- lazysizes+noscript+native-loading.5.1.2.min.js
- d3.min.js (assets.ubuntu.com)
- d3-version3.5.6.min.js
- lite-youtube.min.js
- chart.js
- d3.v6.min.js

**Resources intentionally excluded from SRI:**

- Google Ads (googleadservices.com/pagead/conversion.js) — ~18 files, content changes frequently
- Google Tag Manager (googletagmanager.com/gtm.js) — dynamically loaded
- Google reCAPTCHA (google.com/recaptcha/api.js) — content changes
- Stripe.js (js.stripe.com/v3/) — PCI compliance requires direct loading; Stripe updates dynamically
- Twitter widgets/oct.js (platform.twitter.com) — content changes
- BrightTalk embed (brighttalk.com/.../player-embed.js) — content changes
- Typeform embed (embed.typeform.com/embed.js) — dynamically injected

## QA

- Open the [DEMO](https://ubuntu-com-16359.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit all the pages affected by change, and verify they load, appear, and work as expected
- Monitor dev console for any resource loading related errors

## Issue / Card

Fixes [WD-36593](https://warthogs.atlassian.net/browse/WD-36593)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36593]: https://warthogs.atlassian.net/browse/WD-36593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
