### PR TITLE
Fix TICS violations (scan 3)

### DIFF
--- a/charm/lib/charms/redis_k8s/v0/redis.py
+++ b/charm/lib/charms/redis_k8s/v0/redis.py
@@ -112,7 +112,7 @@ class RedisRequires(Object):
         """
         if not (relation_data := self.relation_data):
             return None
-            
+
         redis_host = relation_data.get("hostname")
 
         if app_data := self.app_data:


### PR DESCRIPTION
## TIOBE TICS Auto-Fix

This PR automatically fixes **1** TICS violations.

### Summary by Category

| Category | Fixed |
|----------|-------|
| Coding Standards | 1 |

### Changes

- **`/var/folders/3g/vcb_36wn231dxflybqtrn3_m0000gn/T/tiobefix_6rgbrl5k/charm/lib/charms/redis_k8s/v0/redis.py`** (L115): blank line contains whitespace
  - Rule: `W293` | Source: flake8

---
*Generated by TiobeFix — verify before merging*
