### PR TITLE
fix: remove canonical announcements blog redirect to c.com and update…

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -11,7 +11,9 @@
 {% block body_class %}blog-article{% endblock %}
 
 {%- block canonical_url -%}
-  {%- if article.author and article.author.id == 217 -%}
+  {%- if article.group and article.group.id == 2100 -%}
+    https://canonical.com/blog/{{ article.slug }}
+  {%- elif article.author and article.author.id == 217 -%}
     https://canonical.com/blog/{{ article.slug }}
   {%- elif 2996 in article.tags -%}
     https://snapcraft.io/blog/{{ article.slug }}
@@ -25,6 +27,9 @@
 {%- endblock canonical_url -%}
 
 {% block extra_metatags %}
+  {% if article.group and article.group.id == 2100 %}
+  <meta name="robots" content="noindex, follow" />
+  {% endif %}
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -840,16 +840,6 @@ class BlogRedirects(BlogView):
         if "article" not in context:
             return flask.abort(404)
 
-        # Redirect canonical announcements
-        group = context["article"].get("group")
-        if isinstance(group, dict) and group["id"] == 2100:
-            redirect_url = f"https://canonical.com/blog/{slug}"
-            # Append the original query string to the redirect URL
-            original_query_string = flask.request.query_string.decode("utf-8")
-            if original_query_string:
-                redirect_url += f"?{original_query_string}"
-            return flask.redirect(redirect_url)
-
         # Set blog notice date
         blog_notice = {}
         created_at, updated_at = dateutil.parser.parse(


### PR DESCRIPTION
## Done

- Removed canonical announcements blog redirects (group id 2100) to canonical.com
- Added meta tag to prevent cannonical announcement blogs from appearing in search results while still crawling

## QA

- Open the [DEMO](https://ubuntu-com-16363.demos.haus/blog)
  - Click on a "Canonical Announcements" blog post ([example](https://ubuntu-com-16363.demos.haus/blog/canonical-joins-the-rust-foundation-as-a-gold-member)) and observe that the browser does not redirect to canonical.com but remains on ubuntu.com
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-36473](https://warthogs.atlassian.net/browse/WD-36473)


[WD-36473]: https://warthogs.atlassian.net/browse/WD-36473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ