### PR TITLE
fix: broken WSL install help link on download thank-you page

### DIFF
--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,6 +1,14 @@
 You can
 <button class="p-button--link" onclick="verifyDownloadContent()">verify your download</button>
-{%- if not 'raspi' in system -%}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server' %}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server' %}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>
+{%- if not 'raspi' in system -%}
+  {%- if system == 'wsl' -%}
+    {%- set install_help_url = 'https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/' -%}
+  {%- elif system == 'live-server' -%}
+    {%- set install_help_url = '/tutorials/tutorial-install-ubuntu-server?backURL=https://ubuntu.com/download/server/thank-you' -%}
+  {%- else -%}
+    {%- set install_help_url = '/tutorials/tutorial-install-ubuntu-' ~ system ~ '?backURL=https://ubuntu.com/download/' ~ system ~ '/thank-you' -%}
+  {%- endif -%}
+  , or get <a href="{{ install_help_url }}">help on installing</a>
 {%- endif -%}
 .
 


### PR DESCRIPTION
## Done

- Fix the broken **“help on installing”** link on the WSL download thank-you page.
- The shared `_verify-checksums.html` snippet built `/tutorials/tutorial-install-ubuntu-wsl` when `system="wsl"`, but that tutorial slug does not exist.
- WSL install guidance now points to the official how to: [Install Ubuntu on WSL](https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/), consistent with `download/wsl.html` and other WSL pages

Fixes #16356

## QA

- [x] Checked out this branch and ran the site locally (`task` / http://127.0.0.1:8001)
- [x] Opened http://127.0.0.1:8001/download/wsl/thank-you?version=26.04&architecture=amd64
- [x] Confirmed **“help on installing”** links to https://documentation.ubuntu.com/wsl/stable/howto/install-ubuntu-wsl2/ (no 404)
- [x] Tested on desktop viewport (link visible and correct)
- [ ] Production check: https://ubuntu.com/download/wsl/thank-you?version=26.04&architecture=amd64

## Issue / Card

Fixes #16356

## Screenshots
<img width="3024" height="1818" alt="image" src="https://github.com/user-attachments/assets/321aafbd-a0b2-43ac-9353-22e92b9a4e77" />
<img width="3024" height="1812" alt="image" src="https://github.com/user-attachments/assets/16201db8-1dcc-48bf-b535-8a21305843cf" />


## Help

- [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)