### PR TITLE
Update fallback takeover for 26.04 LTS

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -87,10 +87,10 @@
           <picture>
             <source srcset="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
                     media="(max-width: 1036px)" />
-            {{ image(url="https://assets.ubuntu.com/v1/caca7dd1-resolute_raccoon_white.svg",
+            {{ image(url=releases_yaml.lts.mascot_image_large.url,
                         alt="",
-                        width="300",
-                        height="300",
+                        width=releases_yaml.lts.mascot_image_large.width,
+                        height=releases_yaml.lts.mascot_image_large.height,
                         hi_def=True,
                         loading="auto",
                         attrs={"id": "takeover-image"}) | safe

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -87,7 +87,7 @@
           <picture>
             <source srcset="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
                     media="(max-width: 1036px)" />
-            {{ image(url="https://assets.ubuntu.com/v1/a0b5a882-resolute_raccoon_black.svg",
+            {{ image(url="https://assets.ubuntu.com/v1/caca7dd1-resolute_raccoon_white.svg",
                         alt="",
                         width="300",
                         height="300",

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -79,7 +79,7 @@
             <p>
               <a id="takeover-primary-url" href="/download" class="p-button--positive">Download for free</a>
               <a id="takeover-secondary-url"
-                 href="{{ releases_yaml.lts.blog_post_url }}">Read the deep dive&nbsp;&rsaquo;</a>
+                 href="{{ releases_yaml.lts.blog_post_url }}">Read the press release&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>
@@ -87,10 +87,10 @@
           <picture>
             <source srcset="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
                     media="(max-width: 1036px)" />
-            {{ image(url="https://assets.ubuntu.com/v1/33b5133c-Noble-Numbat-optimised.svg",
+            {{ image(url="https://assets.ubuntu.com/v1/a0b5a882-resolute_raccoon_black.svg",
                         alt="",
-                        width="197",
-                        height="150",
+                        width="300",
+                        height="300",
                         hi_def=True,
                         loading="auto",
                         attrs={"id": "takeover-image"}) | safe


### PR DESCRIPTION
## Done

- Updated deep dive link to press release
- Updated mascot and its dimensions

## QA

- Open the [DEMO](https://ubuntu-com-16367.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

