### PR TITLE
Remove managed Kubeflow on Azure beta sign-up banner

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -15,10 +15,7 @@
 {% endblock body_class %}
 
 {% block content %}
-  <div class="p-strip is-shallow u-no-padding--bottom">
-    <div class="u-fixed-width">{% include "shared/_azure-banner.html" %}</div>
-  </div>
-  <section class="p-section--hero">
+<section class="p-section--hero">
     <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -15,7 +15,7 @@
 {% endblock body_class %}
 
 {% block content %}
-<section class="p-section--hero">
+  <section class="p-section--hero">
     <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">


### PR DESCRIPTION
## Summary
- Removes the banner on the Azure page that invited users to sign up for the managed Kubeflow on Azure beta preview

## Test plan
- [ ] Visit the Azure page and confirm the banner no longer appears

Fixes https://warthogs.atlassian.net/browse/WD-36608

🤖 Generated with [Claude Code](https://claude.com/claude-code)