### PR TITLE
copyupdate: /training WD-36656

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -230,9 +230,11 @@
               <p itemprop="description" class="u-sv3">
                 A highly modular training for SRE teams who need to manage Canonical OpenStack. The modules follow different levels, ranging from basics to pro tips, allowing you to tailor the full training program to your team's skills and needs. The peer training sessions are designed to ensure your team acquires experience on specific tasks in a controlled environment and with necessary supervision to correct any errors. Each module spans one to two weeks, depending on the topic.
               </p>
-              <a class="p-button--positive u-hide--medium u-hide--small"
-                 href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
-              <a class="u-hide--medium u-hide--small" href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
+              <div class="p-cta-block u-hide--medium u-hide--small">
+                <a class="p-button--positive"
+                   href="/contact-us">Contact us to book</a>
+                <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -425,62 +427,62 @@
                        aria-labelledby="advanced-course-outline"
                        hidden="hidden">
                     <ol class="p-stepped-list">
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 1: Virtualization with QEMU/KVM and libvirt
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 2: LXD System Containers
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 3: OpenSSH at Scale
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 4: Boot and System Initialization
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 5: Advanced Storage
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 6: Advanced Filesystem Concepts
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 7: ZFS on Ubuntu
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 8: Advanced Networking with Netplan
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 9: Security: PAM, ACLs, AppArmor, and Ubuntu Pro
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 10: Advanced Snap Packaging and Ubuntu Core
-                        </p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">
-                          Module 11: Time Synchronization
-                        </p>
-                      </li>
-                    </ol>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Virtualization with QEMU/KVM and libvirt
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        LXD System Containers
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        OpenSSH at Scale
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Boot and System Initialization
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Advanced Storage
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Advanced Filesystem Concepts
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        ZFS on Ubuntu
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Advanced Networking with Netplan
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Security: PAM, ACLs, AppArmor, and Ubuntu Pro
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Advanced Snap Packaging and Ubuntu Core
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Time Synchronization
+                      </p>
+                    </li>
+                  </ol>
                   </div>
                 </div>
               </div>
@@ -489,15 +491,6 @@
                    href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
-              <div class="row u-hide--large">
-                <div class="col-12">
-                  <p>
-                    <a class="p-button--positive"
-                       href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
-                    <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-                  </p>
-                </div>
-              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -524,8 +517,11 @@
           </div>
           <div class="row u-hide--large">
             <div class="col-6">
-              <a class="p-button--positive"
-                 href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
+              <p class="training-cta--stacked">
+                <a class="p-button--positive"
+                  href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
+                <a  href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
+              </p>
             </div>
           </div>
         </section>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -232,9 +232,7 @@
               </p>
               <a class="p-button--positive u-hide--medium u-hide--small"
                  href="/contact-us">Contact us to book</a>
-              <div class="p-cta-block u-hide--medium u-hide--small">
-                <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
-              </div>
+              <a class="u-hide--medium u-hide--small"  href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -427,43 +425,69 @@
                        aria-labelledby="advanced-course-outline"
                        hidden="hidden">
                     <ol class="p-stepped-list">
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">Virtualization</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">LXD</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">OpenSSH</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">System initialization</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">Advanced storage</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">Advanced filesystem</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">ZFS</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">Advanced networking</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">Security</p>
-                      </li>
-                      <li class="p-stepped-list__item">
-                        <p class="p-stepped-list__title">Snaps</p>
-                      </li>
-                    </ol>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 1: Virtualization with QEMU/KVM and libvirt
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 2: LXD System Containers
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 3: OpenSSH at Scale
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 4: Boot and System Initialization
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 5: Advanced Storage
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 6: Advanced Filesystem Concepts
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 7: ZFS on Ubuntu
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 8: Advanced Networking with Netplan
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 9: Security: PAM, ACLs, AppArmor, and Ubuntu Pro
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 10: Advanced Snap Packaging and Ubuntu Core
+                      </p>
+                    </li>
+                    <li class="p-stepped-list__item">
+                      <p class="p-stepped-list__title">
+                        Module 11: Time Synchronization
+                      </p>
+                    </li>
+                  </ol>
                   </div>
                 </div>
               </div>
               <p class="u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
+                <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>
             <div class="col-3">

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -231,8 +231,8 @@
                 A highly modular training for SRE teams who need to manage Canonical OpenStack. The modules follow different levels, ranging from basics to pro tips, allowing you to tailor the full training program to your team's skills and needs. The peer training sessions are designed to ensure your team acquires experience on specific tasks in a controlled environment and with necessary supervision to correct any errors. Each module spans one to two weeks, depending on the topic.
               </p>
               <a class="p-button--positive u-hide--medium u-hide--small"
-                 href="/contact-us">Contact us to book</a>
-              <a class="u-hide--medium u-hide--small"  href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
+                 href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
+              <a class="u-hide--medium u-hide--small" href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -425,62 +425,62 @@
                        aria-labelledby="advanced-course-outline"
                        hidden="hidden">
                     <ol class="p-stepped-list">
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 1: Virtualization with QEMU/KVM and libvirt
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 2: LXD System Containers
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 3: OpenSSH at Scale
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 4: Boot and System Initialization
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 5: Advanced Storage
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 6: Advanced Filesystem Concepts
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 7: ZFS on Ubuntu
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 8: Advanced Networking with Netplan
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 9: Security: PAM, ACLs, AppArmor, and Ubuntu Pro
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 10: Advanced Snap Packaging and Ubuntu Core
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Module 11: Time Synchronization
-                      </p>
-                    </li>
-                  </ol>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 1: Virtualization with QEMU/KVM and libvirt
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 2: LXD System Containers
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 3: OpenSSH at Scale
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 4: Boot and System Initialization
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 5: Advanced Storage
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 6: Advanced Filesystem Concepts
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 7: ZFS on Ubuntu
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 8: Advanced Networking with Netplan
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 9: Security: PAM, ACLs, AppArmor, and Ubuntu Pro
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 10: Advanced Snap Packaging and Ubuntu Core
+                        </p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">
+                          Module 11: Time Synchronization
+                        </p>
+                      </li>
+                    </ol>
                   </div>
                 </div>
               </div>
@@ -489,6 +489,15 @@
                    href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
+              <div class="row u-hide--large">
+                <div class="col-12">
+                  <p>
+                    <a class="p-button--positive"
+                       href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
+                    <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
+                  </p>
+                </div>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">


### PR DESCRIPTION
## Done

- copyupdate (copydoc https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?tab=t.0)

## QA

- Open the [DEMO](https://ubuntu-com-16372.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /training.
- Ensure the Advanced Ubuntu Server training section has a link to the pdf outline of the training.
- Ensure that the 

## Issue / Card
WD-36656

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

