### PR TITLE
fix: prevent setTabIndex crash and stabilize navigation Playwright tests

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -432,12 +432,16 @@ function setTabIndex(target) {
   // In some cases there is no target so we don't need to update the tab index
   if (target) {
     const targetLiItems = target.querySelectorAll("li");
-    targetLiItems.forEach((element, index) => {
+    targetLiItems.forEach((element) => {
       if (
         element.parentNode === target ||
         element.parentNode.parentNode === target
       ) {
-        element.children[0].setAttribute("tabindex", "0");
+        // Some li items (#all-canonical, #canonical-login) are populated
+        // asynchronously and may be empty when setTabIndex runs.
+        element
+          .querySelector(":scope > a, :scope > button")
+          ?.setAttribute("tabindex", "0");
       }
     });
   }
@@ -450,10 +454,14 @@ function setTabIndex(target) {
       ".p-navigation__item--dropdown-toggle.is-active",
     );
     if (currActiveNavItem) {
-      currActiveNavItem.children[0].setAttribute("tabindex", "0");
+      currActiveNavItem
+        .querySelector(":scope > a, :scope > button")
+        ?.setAttribute("tabindex", "0");
     } else {
       mainList.querySelectorAll(":scope > li").forEach((element) => {
-        element.children[0].setAttribute("tabindex", "0");
+        element
+          .querySelector(":scope > a, :scope > button")
+          ?.setAttribute("tabindex", "0");
       });
     }
   }

--- a/tests/playwright/helpers/navigation.ts
+++ b/tests/playwright/helpers/navigation.ts
@@ -132,9 +132,14 @@ export class NavigationComponent {
       .waitFor({ state: "attached", timeout: 10000 });
     await link.click();
     await expect(this.sectionItem(sectionId)).toHaveClass(/is-active/);
-    await this.dropdownWindow.waitFor({ state: "visible", timeout: 5000 });
+    // .dropdown-window is always in the DOM and hidden via `transform`, which
+    // Playwright's visibility check ignores. Wait for the open-state classes
+    // and the overlay (hidden via `visibility: hidden`) instead, then wait
+    // for the slide animation to settle.
+    await expect(this.dropdownWindow).toHaveClass(/is-active/);
+    await this.dropdownOverlay.waitFor({ state: "visible", timeout: 5000 });
     const dropdownHandle = await this.dropdownWindow.elementHandle();
-    if (!dropdownHandle) throw new Error("Dropdown window not visible");
+    if (!dropdownHandle) throw new Error("Dropdown window not found");
     await dropdownHandle.waitForElementState("stable", { timeout: 5000 });
   }
 

--- a/tests/playwright/helpers/navigation.ts
+++ b/tests/playwright/helpers/navigation.ts
@@ -132,6 +132,10 @@ export class NavigationComponent {
       .waitFor({ state: "attached", timeout: 10000 });
     await link.click();
     await expect(this.sectionItem(sectionId)).toHaveClass(/is-active/);
+    await this.dropdownWindow.waitFor({ state: "visible", timeout: 5000 });
+    const dropdownHandle = await this.dropdownWindow.elementHandle();
+    if (!dropdownHandle) throw new Error("Dropdown window not visible");
+    await dropdownHandle.waitForElementState("stable", { timeout: 5000 });
   }
 
   async openSearch(): Promise<void> {


### PR DESCRIPTION
Two flaky navigation Playwright tests were failing intermittently. Root-causing them surfaced one real production bug and one test-helper race.

## Done

- Guard the three `element.children[0].setAttribute(...)` calls in `setTabIndex` with optional chaining so empty LIs are skipped instead of throwing.
- Make `openDropdown` wait for the dropdown to become visible and reach a stable layout before returning, so subsequent overlay clicks compute a reliable position.

## QA

- Check that all Playwright Tests Pass

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

