### PR TITLE
chore: Update epic key

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -27,4 +27,4 @@ settings:
   sync_comments: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: "WD-30420"
+  epic_key: "WD-35976"


### PR DESCRIPTION
## Done

- Update key to point to the new jira epic WD-35976

## QA

- See that epic key is correct


