### PR TITLE
Fix broken kernel.org commit links

### DIFF
--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -438,9 +438,9 @@
                               {% elif patch.type == "break-fix" %}
                                 <li class="p-list__item has-bullet">
                                   Introduced by
-                                  <a href="https://git.kernel.org/linus/{{ patch.content.introduced.split(' ')[0] }}">{{ patch.content.introduced[:7] }}</a>,
+                                  <a href="https://git.kernel.org/linus/{{ patch.content.introduced.split()[0] }}">{{ patch.content.introduced[:7] }}</a>,
                                   fixed by
-                                  <a href="https://git.kernel.org/linus/{{ patch.content.fixed.split(' ')[0] }}">{{ patch.content.fixed[:7] }}</a>
+                                  <a href="https://git.kernel.org/linus/{{ patch.content.fixed.split()[0] }}">{{ patch.content.fixed[:7] }}</a>
                                 </li>
                               {% elif patch.type == "link" %}
                                 {% if patch.content.suffix %}

--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -438,9 +438,9 @@
                               {% elif patch.type == "break-fix" %}
                                 <li class="p-list__item has-bullet">
                                   Introduced by
-                                  <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced[:7] }}</a>,
+                                  <a href="https://git.kernel.org/linus/{{ patch.content.introduced.split(' ')[0] }}">{{ patch.content.introduced[:7] }}</a>,
                                   fixed by
-                                  <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed[:7] }}</a>
+                                  <a href="https://git.kernel.org/linus/{{ patch.content.fixed.split(' ')[0] }}">{{ patch.content.fixed[:7] }}</a>
                                 </li>
                               {% elif patch.type == "link" %}
                                 {% if patch.content.suffix %}


### PR DESCRIPTION
## Summary

Fixes broken `git.kernel.org` links generated for CVE pages.

## Changes

* Strip version suffixes like `(7.0-rc7)` from commit hashes before generating kernel.org URLs
* Prevent invalid URLs caused by extra version text appended to commit hashes

## Verification

Verified that URLs generated without the version suffix open the correct kernel.org commit page instead of returning "No repositories found".

Fixes #16333