### PR TITLE
chore(workflow): reduce live links request per second

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -22,7 +22,7 @@ jobs:
           mkdir -p ~/.linkchecker
           cat > ~/.linkchecker/linkcheckerrc <<EOF
           [checking]
-          maxrequestspersecond=2
+          maxrequestspersecond=4
           recursionlevel=2
           timeout=1000
           sslverify=0

--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -1,10 +1,6 @@
 name: Links on ubuntu.com live
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   schedule:
     - cron: "20 7 * * *"
 

--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -1,8 +1,12 @@
 name: Links on ubuntu.com live
 
 on:
-  schedule:
-    - cron: "20 7 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+  # schedule:
+  #   - cron: "20 7 * * *"
 
 jobs:
   check-links:
@@ -22,6 +26,7 @@ jobs:
           recursionlevel=2
           timeout=1000
           sslverify=0
+          useragent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
 
           [filtering]
           checkextern=1

--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   pull_request:
-  # schedule:
-  #   - cron: "20 7 * * *"
+  schedule:
+    - cron: "20 7 * * *"
 
 jobs:
   check-links:
@@ -22,11 +22,10 @@ jobs:
           mkdir -p ~/.linkchecker
           cat > ~/.linkchecker/linkcheckerrc <<EOF
           [checking]
-          maxrequestspersecond=5
+          maxrequestspersecond=2
           recursionlevel=2
           timeout=1000
           sslverify=0
-          useragent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
 
           [filtering]
           checkextern=1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,8 +2,8 @@ name: PR checks
 on:
   push:
     branches:
-      - mains
-  # pull_request:
+      - main
+  pull_request:
 env:
   SECRET_KEY: insecure_test_key
 
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,9 @@
 name: PR checks
-on: 
+on:
   push:
     branches:
-      - main
-  pull_request:
+      - mains
+  # pull_request:
 env:
   SECRET_KEY: insecure_test_key
 
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Done

- Reduce the max requests per second on live link checker so it does not emulate a DDoS attack on the servers as there have been a limitation on the WAF.

## QA

- Check that the current live link https://github.com/canonical/ubuntu.com/actions/runs/26461709444/job/77911006822?pr=16383 passes compared to that on production https://github.com/canonical/ubuntu.com/actions/runs/26391858819
  which are just `Connection Error` errors
<img width="1692" height="82" alt="image" src="https://github.com/user-attachments/assets/b5bd826f-0221-41e0-a08a-31f7cc402007" />

- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
