### PR TITLE
fix(certified): add 26.04 LTS to components list

### DIFF
--- a/templates/certified/model-details/_components-section.html
+++ b/templates/certified/model-details/_components-section.html
@@ -22,7 +22,7 @@
         </thead>
 
         <tbody>
-          {% set releases = ["24.04 LTS", "22.04 LTS", "20.04 LTS", "18.04 LTS", "Core 24", "Core 22", "Core 20", "Core 18"] %}
+          {% set releases = ["26.04 LTS", "24.04 LTS", "22.04 LTS", "20.04 LTS", "18.04 LTS", "Core 24", "Core 22", "Core 20", "Core 18"] %}
           {% for component in components %}
             {% for i in range(releases|length) %}
               {% set release = releases[i] %}


### PR DESCRIPTION
## Done

- Add 26.04 LTS to the list of releases checked for certified components

## QA

## Issue / Card

Fixes [C3-1420](https://warthogs.atlassian.net/browse/C3-1420)

## Screenshots

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[C3-1420]: https://warthogs.atlassian.net/browse/C3-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ