### PR TITLE
Update notification for Ubuntu summit

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -105,10 +105,10 @@
         <div class="p-notification--information u-no-margin--bottom is-dark">
           <div class="p-notification__content">
             <p class="p-notification__title p-heading--5">
-              <a href="https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare">The Standard Support period for Ubuntu 20.04 LTS has ended. Discover your options.</a>
+              <a href="https://www.youtube.com/live/Q5ysMzeqook?si=5mWemEw93HbDjZEw">Live from London: watch Ubuntu Summit 26.04.</a>
             </p>
             <p class="p-notification__message">
-              <span>Take action today</span>
+              <span>Join the conversation</span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Updates the homepage notification to reference Ubuntu Summit. See [copydoc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit?tab=t.0)
- This is a fallback for if discourse goes down

## QA

- Open the [DEMO](https://ubuntu-com-16388.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

