### PR TITLE
WD-36833 BAU: Copy Update /download/risc-v/partner-built

### DIFF
--- a/templates/download/risc-v/spacemit-k3-com260-kit.html
+++ b/templates/download/risc-v/spacemit-k3-com260-kit.html
@@ -6,10 +6,10 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
       <div class="p-image-container is-highlighted">
-        {{ image(url="https://assets.ubuntu.com/v1/3c12616b-01.png",
+        {{ image(url="https://assets.ubuntu.com/v1/cddc2f7d-spacemit_k3_com260_kit.png",
           alt="",
-          width="2897",
-          height="2330",
+          width="1920",
+          height="1080",
           hi_def=True,
           loading="lazy",
           attrs={"class": "p-image-container__image"}) | safe

--- a/templates/download/risc-v/spacemit-k3-pico-itx.html
+++ b/templates/download/risc-v/spacemit-k3-pico-itx.html
@@ -6,10 +6,10 @@
     </div>
     <div class="grid-col-4 grid-col-medium-2 u-vertically-center u-align--center">
       <div class="p-image-container is-highlighted">
-        {{ image(url="https://assets.ubuntu.com/v1/8e30d3ce-1.png",
+        {{ image(url="https://assets.ubuntu.com/v1/31d5ba2f-spacemit_k3_pico_itx.png",
           alt="",
-          width="2752",
-          height="1536",
+          width="1920",
+          height="1080",
           hi_def=True,
           loading="lazy",
           attrs={"class": "p-image-container__image"}) | safe


### PR DESCRIPTION
## Done

- Updated the images for the SpacemiT K3 CoM260 Kit and K3 pico ITX under /download/risc-v/partner-built

## QA

- Open the [DEMO](https://ubuntu-com-16390.demos.haus/download/risc-v/partner-built)
- Make sure the images match the new assets for both [SpacemiT K3 CoM260 Kit](https://assets.ubuntu.com/manager/details?file_path=cddc2f7d-spacemit_k3_com260_kit.png) and [K3 pico ITX](https://assets.ubuntu.com/manager/details?file_path=31d5ba2f-spacemit_k3_pico_itx.png) in asset manager.
- [Copydoc](https://docs.google.com/document/d/11AUwjePeOGvT6H8xM4QYixzmUTRpG_uKPa_pSzR5ucs/edit?tab=t.fp8bvloknvy2)

## Issue / Card

Fixes [WD-36833](https://warthogs.atlassian.net/browse/WD-36833)

## Screenshots

<img width="2540" height="1314" alt="image" src="https://github.com/user-attachments/assets/104a871c-ed22-4bc8-bc83-fde9e9168997" />

<img width="2540" height="1314" alt="image" src="https://github.com/user-attachments/assets/61fb990a-01ca-438d-b00e-0f2970c50a93" />

[WD-36833]: https://warthogs.atlassian.net/browse/WD-36833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
