### PR TITLE
WD-36825 - copy update /pro/subscribe

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
@@ -37,9 +37,9 @@ test("Infra support is disabled if desktop is selected", () => {
   expect(screen.getByTestId("full-support")).not.toBeDisabled();
 });
 
-test("Infra and full support are disabled if Xenial is selected", () => {
+test("Infra and full support are disabled if Bionic is selected", () => {
   render(
-    <FormProvider initialVersion={LTSVersions.xenial}>
+    <FormProvider initialVersion={LTSVersions.bionic}>
       <Support />
     </FormProvider>,
   );

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -24,10 +24,10 @@ const Support = () => {
   };
 
   const isInfraOnlyDisabled =
-    productType === ProductTypes.desktop || version === LTSVersions.xenial;
+    productType === ProductTypes.desktop || version === LTSVersions.bionic;
 
   const isFullSupportDisabled =
-    feature === Features.infra || version === LTSVersions.xenial;
+    feature === Features.infra || version === LTSVersions.bionic;
 
   return (
     <div

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.test.tsx
@@ -24,9 +24,9 @@ test("Version section displays the matching features to the selected version", a
     screen.getByText(/^All subscriptions for Ubuntu Pro 22.04 LTS include:/),
   );
 
-  await userEvent.click(screen.getByText("16.04 LTS"));
+  await userEvent.click(screen.getByText("18.04 LTS"));
   expect(
-    screen.getByText(/^All subscriptions for Ubuntu Pro 16.04 LTS include:/),
+    screen.getByText(/^All subscriptions for Ubuntu Pro 18.04 LTS include:/),
   );
 });
 

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -19,21 +19,17 @@ const KVMDrivers = "Certified Windows Drivers for KVM guests";
 const CISBenchmark =
   "Certified CIS benchmark tooling and DISA-STIG configuration guide";
 const CISBenchmarkAndAutomation =
-  "Ubuntu Security Guide (USG) for certified CIS benchmark tooling and DISA-STIG tooling & automation";
+  "Ubuntu Security Guide (USG) for CIS benchmark tooling and DISA-STIG tooling & automation";
 const FIPS_140_2 =
   "FIPS 140-2 Level 1 cryptographic packages for FedRAMP, HIPAA and PCI-DSS compliance";
 const FIPS_140_3 =
   "FIPS 140-3 Level 1 cryptographic packages for FedRAMP, HIPAA and PCI-DSS compliance";
 const CIS =
   "Ubuntu Security Guide (USG) for CIS and DISA STIG benchmark tooling & automation";
-const CISComingSoon = (
-  <>
-    Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
-  </>
-);
+const CISComingSoon = "Ubuntu Security Guide (USG) for CIS benchmark tooling & automation";
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate =
-  "Expanded Security Maintenance (ESM) for packages in 'main' repository until";
+  "Expanded Security Maintenance (ESM) for packages in 'main' and 'universe' repositories until";
 const DesktopESMEndDate =
   "Expanded Security Maintenance (ESM) for packages in 'main' and 'universe' repositories until";
 const AAD =
@@ -42,6 +38,15 @@ const AAD =
 const PhysicalServerVersionDetails: {
   [key in LTSVersions]: Array<React.ReactNode>;
 } = {
+  [LTSVersions.resolute]: [
+    `${ESMEndDate} 2036`,
+    livepatch,
+    `${CISComingSoon} [Coming soon]`,
+    KVMDrivers,
+    landscape,
+    knowledgeBase,
+    realtimeKernel,
+  ],
   [LTSVersions.noble]: [
     `${ESMEndDate} 2034`,
     livepatch,
@@ -80,21 +85,20 @@ const PhysicalServerVersionDetails: {
     landscape,
     knowledgeBase,
   ],
-  [LTSVersions.xenial]: [
-    `${ESMEndDate} 2026`,
-    livepatch,
-    FIPS_140_2,
-    CISBenchmark,
-    CommonCriteria,
-    KVMDrivers,
-    landscape,
-    knowledgeBase,
-  ],
 };
 
 const DesktopVersionDetails: {
   [key in LTSVersions]: Array<React.ReactNode>;
 } = {
+  [LTSVersions.resolute]: [
+    `${ESMEndDate} 2036`,
+    AAD,
+    livepatch,
+    `${CISComingSoon} [Coming soon]`,
+    landscape,
+    knowledgeBase,
+    realtimeKernel,
+  ],
   [LTSVersions.noble]: [
     `${DesktopESMEndDate} 2034`,
     AAD,
@@ -108,7 +112,7 @@ const DesktopVersionDetails: {
     `${DesktopESMEndDate} 2032`,
     AAD,
     livepatch,
-    FIPS_140_3,
+    "FIPS 140-3 Level 1 cryptographic packages for FedRAMP compliance",
     CIS,
     landscape,
     knowledgeBase,
@@ -118,22 +122,13 @@ const DesktopVersionDetails: {
     `${DesktopESMEndDate} 2030`,
     AAD,
     livepatch,
-    FIPS_140_2,
+    "FIPS 140-2 Level 1 cryptographic packages for FedRAMP compliance",
     CISBenchmarkAndAutomation,
     landscape,
     knowledgeBase,
   ],
   [LTSVersions.bionic]: [
     `${DesktopESMEndDate} 2028`,
-    livepatch,
-    FIPS_140_2,
-    CISBenchmark,
-    CommonCriteria,
-    landscape,
-    knowledgeBase,
-  ],
-  [LTSVersions.xenial]: [
-    `${DesktopESMEndDate} 2026`,
     livepatch,
     FIPS_140_2,
     CISBenchmark,

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -31,8 +31,6 @@ const CISComingSoon =
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate =
   "Expanded Security Maintenance (ESM) for packages in 'main' and 'universe' repositories until";
-const DesktopESMEndDate =
-  "Expanded Security Maintenance (ESM) for packages in 'main' and 'universe' repositories until";
 const AAD =
   "Advanced Active Directory integration including native GPO policy support, custom script execution and privilege management";
 
@@ -101,7 +99,7 @@ const DesktopVersionDetails: {
     realtimeKernel,
   ],
   [LTSVersions.noble]: [
-    `${DesktopESMEndDate} 2034`,
+    `${ESMEndDate} 2034`,
     AAD,
     livepatch,
     CISComingSoon,
@@ -110,7 +108,7 @@ const DesktopVersionDetails: {
     realtimeKernel,
   ],
   [LTSVersions.jammy]: [
-    `${DesktopESMEndDate} 2032`,
+    `${ESMEndDate} 2032`,
     AAD,
     livepatch,
     "FIPS 140-3 Level 1 cryptographic packages for FedRAMP compliance",
@@ -120,7 +118,7 @@ const DesktopVersionDetails: {
     realtimeKernel,
   ],
   [LTSVersions.focal]: [
-    `${DesktopESMEndDate} 2030`,
+    `${ESMEndDate} 2030`,
     AAD,
     livepatch,
     "FIPS 140-2 Level 1 cryptographic packages for FedRAMP compliance",
@@ -129,7 +127,7 @@ const DesktopVersionDetails: {
     knowledgeBase,
   ],
   [LTSVersions.bionic]: [
-    `${DesktopESMEndDate} 2028`,
+    `${ESMEndDate} 2028`,
     livepatch,
     FIPS_140_2,
     CISBenchmark,

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -26,7 +26,8 @@ const FIPS_140_3 =
   "FIPS 140-3 Level 1 cryptographic packages for FedRAMP, HIPAA and PCI-DSS compliance";
 const CIS =
   "Ubuntu Security Guide (USG) for CIS and DISA STIG benchmark tooling & automation";
-const CISComingSoon = "Ubuntu Security Guide (USG) for CIS benchmark tooling & automation";
+const CISComingSoon =
+  "Ubuntu Security Guide (USG) for CIS benchmark tooling & automation";
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate =
   "Expanded Security Maintenance (ESM) for packages in 'main' and 'universe' repositories until";

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -134,7 +134,7 @@ export const FormProvider = ({
   }, [support, sla]);
 
   useEffect(() => {
-    if (version === LTSVersions.xenial) {
+    if (version === LTSVersions.bionic) {
       setSupport(Support.none);
     }
   }, [version, support]);

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -132,11 +132,11 @@ export enum PublicClouds {
 }
 
 export enum LTSVersions {
+  resolute = "26.04",
   noble = "24.04",
   jammy = "22.04",
   focal = "20.04",
   bionic = "18.04",
-  xenial = "16.04",
 }
 
 export enum Support {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -28,6 +28,7 @@ endblock meta_copydoc %} {% block content %}
   </section>
 </div>
 
+<!-- form app -->
 <script
   src="{{ versioned_static('js/dist/uaSubscribe.js') }}"
   type="module"
@@ -66,7 +67,5 @@ endblock meta_copydoc %} {% block content %}
 
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
 </script>
-
-{{ load_form("/pro/subscribe") | safe }}
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Modified the `/pro/subscription` form to include the changes from the copy doc.
    - Remove release 16.04
    - Add release 26.04
    - Some minor changes

## QA

- Open the [DEMO](https://ubuntu-com-16391.demos.haus/pro/subscribe)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro/subscribe
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-36825](https://warthogs.atlassian.net/browse/WD-36825)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36825]: https://warthogs.atlassian.net/browse/WD-36825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
