### PR TITLE
Update links to use relative paths in /workshop

### DIFF
--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -31,7 +31,7 @@
             <p>Innovate with agentic workflows while keeping your host system isolated.</p>
         {%- endif -%}
         {%- if slot == 'cta' -%}
-            <a href="https://documentation.ubuntu.com/canonical-workshop/latest/tutorial/part-1-get-started/"
+            <a href="/workshop/docs/tutorial/part-1-get-started/"
                class="p-button--positive">Get started</a>
             <a href="https://documentation.ubuntu.com/canonical-workshop/latest/"
                class="p-button">Read the docs</a>
@@ -100,7 +100,7 @@
         "type": "html",
         "content": "
         <p>
-            LXD 6.8+ is a prerequisite. <a href='https://documentation.ubuntu.com/canonical-workshop/latest/tutorial/part-1-get-started/#prerequisites'>Once that's installed</a>, install the Workshop snap using the --classic option:
+            LXD 6.8+ is a prerequisite. <a href='/workshop/docs/tutorial/part-1-get-started/#prerequisites'>Once that's installed</a>, install the Workshop snap using the --classic option:
         </p>
         "
         }
@@ -118,14 +118,14 @@
         "primary": {
         "content_html": "Get started",
         "attrs": {
-        "href": "https://documentation.ubuntu.com/canonical-workshop/latest/tutorial/part-1-get-started/"
+        "href": "/workshop/docs/tutorial/part-1-get-started/"
         }
         },
         "secondaries": [
         {
         "content_html": "Read the docs",
         "attrs": {
-        "href": "https://documentation.ubuntu.com/canonical-workshop/latest/"
+        "href": "/workshop/docs/
         }
         },
         ],
@@ -149,7 +149,7 @@
         "title": {
         "text": "Getting started with Workshop",
         "link_attrs": {
-        "href": "https://documentation.ubuntu.com/canonical-workshop/latest/tutorial/part-1-get-started/"
+        "href": "/workshop/docs/tutorial/part-1-get-started/"
         }
         },
         },
@@ -157,7 +157,7 @@
         "title": {
         "text": "Understand the Workshop architecture",
         "link_attrs": {
-        "href": "https://documentation.ubuntu.com/canonical-workshop/latest/explanation/architecture/components/"
+        "href": "/workshop/docs/explanation/architecture/components/"
         }
         },
         },
@@ -178,7 +178,7 @@
         "title": {
         "text": "Using Ubuntu in the enterprise? Get in touch",
         "link_attrs": {
-        "href": "https://ubuntu.com/desktop/contact-us",
+        "href": "/desktop/contact-us",
         }
         },
         }

--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -125,7 +125,7 @@
         {
         "content_html": "Read the docs",
         "attrs": {
-        "href": "/workshop/docs/
+        "href": "/workshop/docs/"
         }
         },
         ],

--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -33,7 +33,7 @@
         {%- if slot == 'cta' -%}
             <a href="/workshop/docs/tutorial/part-1-get-started/"
                class="p-button--positive">Get started</a>
-            <a href="https://documentation.ubuntu.com/canonical-workshop/latest/"
+            <a href="/workshop/docs/"
                class="p-button">Read the docs</a>
         {%- endif -%}
         {%- if slot == 'image' -%}


### PR DESCRIPTION
## Done

- Update readthedoc links to point to our ubuntu.com proxxy

## QA

- [DEMO](https://ubuntu-com-16392.demos.haus/workshop)
- Check the original readthedocs link and the new relative link points to the same documentation

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36840
