### PR TITLE
chore: add Workshop sitemap index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -45,4 +45,7 @@
   <sitemap>
     <loc>https://ubuntu.com/server/docs/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/workshop/docs/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

- Added https://ubuntu.com/workshop/docs/ to the sitemap index as suggested in [Migrating documentation](https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/#adding-sitemaps).
