### PR TITLE
ci(percy): only run snapshot comparison on initial push and manually after

### DIFF
--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -30,7 +30,9 @@ jobs:
     # Ensure we only run for forks (internal PRs use a different workflow)
     if: >
       github.event.pull_request.head.repo.full_name != github.repository &&
-      (github.event_name != 'labeled' || github.event.label.name == 'run-percy')
+      (github.event.action != 'labeled' || github.event.label.name == 'run-percy') &&
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
 
     # The environment "percy-testing" handles the approval gate
     environment: percy-testing

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -7,9 +7,17 @@ on:
       - main
     types:
       - opened
-      - synchronize
       - reopened
       - ready_for_review
+      - labeled
+    paths:
+      - "templates/**"
+      - "static/sass/**"
+      - "static/js/src/**"
+      - "navigation.yaml"
+      - "secondary-navigation.yaml"
+      - "snapshots.js"
+      - "test-links.yaml"
 
 permissions:
   contents: read
@@ -20,7 +28,9 @@ jobs:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
     # Ensure we only run for forks (internal PRs use a different workflow)
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: >
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      (github.event_name != 'labeled' || github.event.label.name == 'run-percy')
 
     # The environment "percy-testing" handles the approval gate
     environment: percy-testing

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event_name != 'labeled' || github.event.label.name == 'run-percy') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'run-percy') &&
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]'
     steps:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event_name != 'labeled' || github.event.label.name == 'run-percy')
+      (github.event_name != 'labeled' || github.event.label.name == 'run-percy') &&
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -9,15 +9,25 @@ on:
       - main
     types:
       - opened
-      - synchronize
       - reopened
       - ready_for_review
+      - labeled
+    paths:
+      - "templates/**"
+      - "static/sass/**"
+      - "static/js/src/**"
+      - "navigation.yaml"
+      - "secondary-navigation.yaml"
+      - "snapshots.js"
+      - "test-links.yaml"
 
 jobs:
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event_name != 'labeled' || github.event.label.name == 'run-percy')
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4


### PR DESCRIPTION
## Done

- only run snapshot comparison on initial push and manually after with the addition of the `run-percy` label
- add a list of paths that have to be touched for the action to trigger
- blocked from running on renovate or dependabot PRs

## QA

Please review the list of paths to see I have reasonably covered everything.

- See percy has run not run on this PR as it doesn't contain one of the validated paths
- Create a fork of this PR again main. make a html change
- See that the percy action runs
- Push another change, see it doesn't run again
- Add the label `run-percy`, see that it runs

## Issue / Card

Fixes [WD-36846](https://warthogs.atlassian.net/browse/WD-36846)



[WD-36846]: https://warthogs.atlassian.net/browse/WD-36846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ