### PR TITLE
Update OpenJDK releases table for Ubuntu 26.04

### DIFF
--- a/templates/toolchains/java.html
+++ b/templates/toolchains/java.html
@@ -89,8 +89,14 @@
             <tr>
               <td>21 (LTS)</td>
               <td>2023</td>
-              <td>24.04, 22.04, 20.04</td>
+              <td>26.04, 24.04, 22.04, 20.04</td>
               <td>Up to 2034</td>
+            </tr>
+            <tr>
+              <td>25 (LTS)</td>
+              <td>2025</td>
+              <td>26.04</td>
+              <td>Up to 2036</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary

Update the `/toolchains/java` releases table to reflect Ubuntu 26.04 LTS and OpenJDK 25 availability.

## Changes

- Add OpenJDK 25 (LTS) row
- Add Ubuntu 26.04 to the OpenJDK 21 availability row

## Notes

Keeping this PR scoped to the releases table only, following the issue discussion.

Closes #16316