### PR TITLE
chore: gate Percy workflows on visual-affecting changes

### DIFF
--- a/.github/PERCY.md
+++ b/.github/PERCY.md
@@ -1,0 +1,78 @@
+# Percy snapshots
+
+This repo runs visual regression tests via [Percy](https://percy.io/). Three workflows orchestrate it:
+
+- `.github/workflows/percy.yml` — PRs from this repo targeting `main`
+- `.github/workflows/percy-fork-pr.yml` — PRs from forks targeting `main` (uses `pull_request_target` with an approval gate)
+- `.github/workflows/percy-baseline.yaml` — pushes to `main` (refreshes the baseline that PRs compare against)
+
+The shared gate logic lives in `.github/actions/percy-gate/action.yml`.
+
+## When Percy runs
+
+For PRs (both internal and fork) the `decide` job evaluates, in order:
+
+1. **`run-percy` label present on the PR?** → RUN.
+2. **Author is `dependabot[bot]` or `renovate[bot]`?** → SKIP (bots must use the label to opt in).
+3. **Diff touches a watched path?** → RUN.
+4. **Otherwise** → SKIP.
+
+For pushes to `main` (baseline):
+
+1. **Workflow manually dispatched?** → RUN.
+2. **Push diff touches a watched path?** → RUN.
+3. **Otherwise** → SKIP.
+
+When the gate decides to skip, the `snapshot` job is skipped but the workflow exits successfully — branch protection (which treats `skipped` as `success` for required checks) is unaffected.
+
+## Watched paths
+
+Defined once in `.github/actions/percy-gate/action.yml`:
+
+- `static/sass/**`
+- `static/js/src/**`
+- `templates/**`
+- `navigation.yaml`
+- `secondary-navigation.yaml`
+- `snapshots.js`
+- `test-links.yaml`
+- `package.json`
+- `yarn.lock`
+
+To extend the list, edit the `filters:` block in `.github/actions/percy-gate/action.yml`. The change applies to all three workflows automatically.
+
+## How to force a Percy run
+
+### On a PR
+
+Add the `run-percy` label. Adding the label fires a `labeled` event, the gate re-evaluates, and the snapshot job runs.
+
+Reach for this when:
+
+- The PR changes visuals via a path we don't watch (e.g. a Python view that swaps template variables).
+- A Renovate or Dependabot PR bumps a visual-affecting dependency (e.g. `vanilla-framework`) and you want a snapshot.
+- You want a one-off sanity-check snapshot on any PR.
+
+### On `main` (refresh the baseline manually)
+
+Go to **Actions → Update Percy Baseline → Run workflow**, select `main`, click Run.
+
+Reach for this when:
+
+- A merged PR's change wasn't caught by the path filter and visual drift later surfaces in production.
+- You want a fresh baseline before a release.
+
+## Rapid pushes are de-duplicated
+
+PR workflows declare a `concurrency` group with `cancel-in-progress: true`, so pushing several commits in quick succession only completes the latest run — earlier in-flight Percy runs for the same PR are cancelled. The baseline workflow does not cancel itself (every `main` push completes its baseline independently).
+
+## Troubleshooting
+
+**"Percy didn't run on my PR with a CSS change."**
+Check the watched-paths list above. If the path is genuinely visual-affecting and not covered, add it to `.github/actions/percy-gate/action.yml`. For a one-off run, add the `run-percy` label.
+
+**"The `Take Percy snapshots` check shows as skipped."**
+Expected when the gate decided to skip. The `Decide whether to run Percy` job ran to completion and reported success — branch protection is satisfied.
+
+**"Percy ran on a PR that didn't change visuals."**
+Check whether the diff touches any watched path — `package.json` and `yarn.lock` will match any dependency bump. Bots are blocked by default, but a human PR touching these triggers a run.

--- a/.github/actions/percy-gate/action.yml
+++ b/.github/actions/percy-gate/action.yml
@@ -1,0 +1,80 @@
+name: Percy Gate
+description: >
+  Decides whether a Percy snapshot run should proceed. Combines a path filter
+  with a label override and a bot-author skip for PR contexts, and a
+  workflow_dispatch override for baseline (push) contexts.
+
+inputs:
+  mode:
+    description: >
+      'pr' for PR workflows (checks label, bot author, then paths). 'baseline'
+      for the main-push workflow (checks workflow_dispatch, then paths).
+    required: true
+
+outputs:
+  should_run:
+    description: 'true if the calling workflow should proceed to take snapshots'
+    value: ${{ steps.evaluate.outputs.should_run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Filter changed paths
+      id: filter
+      uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      with:
+        filters: |
+          visual:
+            - 'static/sass/**'
+            - 'static/js/src/**'
+            - 'templates/**'
+            - 'navigation.yaml'
+            - 'secondary-navigation.yaml'
+            - 'snapshots.js'
+            - 'test-links.yaml'
+            - 'package.json'
+            - 'yarn.lock'
+
+    - name: Evaluate gate
+      id: evaluate
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-percy') }}
+        ACTOR: ${{ github.event.pull_request.user.login }}
+        VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
+        DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        set -e
+        if [ "$MODE" = "baseline" ]; then
+          if [ "$DISPATCHED" = "true" ]; then
+            echo "RUN: manually dispatched"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$VISUAL_CHANGED" = "true" ]; then
+            echo "RUN: visual-affecting files changed on this push"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "SKIP: no visual-affecting changes on this push"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$HAS_LABEL" = "true" ]; then
+          echo "RUN: run-percy label present"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "renovate[bot]" ]; then
+          echo "SKIP: bot author ($ACTOR) without run-percy label"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$VISUAL_CHANGED" = "true" ]; then
+          echo "RUN: visual-affecting files changed"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "SKIP: no visual-affecting changes and no run-percy label"
+        echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/actions/percy-gate/action.yml
+++ b/.github/actions/percy-gate/action.yml
@@ -27,6 +27,7 @@ runs:
           visual:
             - 'static/sass/**'
             - 'static/js/src/**'
+            - 'static/js/data/**'
             - 'templates/**'
             - 'navigation.yaml'
             - 'secondary-navigation.yaml'

--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -23,7 +23,12 @@ jobs:
           filters: |
             visual:
               - 'static/sass/**'
-              - 'templates/**/*.html'
+              - 'static/js/src/**'
+              - 'templates/**'
+              - 'navigation.yaml'
+              - 'secondary-navigation.yaml'
+              - 'snapshots.js'
+              - 'test-links.yaml'
               - 'package.json'
               - 'yarn.lock'
 

--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -13,12 +13,14 @@ jobs:
   decide:
     name: Decide whether to update baseline
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.evaluate.outputs.should_run }}
     steps:
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             visual:
@@ -57,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: decide
     if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -16,43 +16,18 @@ jobs:
     permissions:
       contents: read
     outputs:
-      should_run: ${{ steps.evaluate.outputs.should_run }}
+      should_run: ${{ steps.gate.outputs.should_run }}
     steps:
-      - name: Filter changed paths
-        id: filter
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          filters: |
-            visual:
-              - 'static/sass/**'
-              - 'static/js/src/**'
-              - 'templates/**'
-              - 'navigation.yaml'
-              - 'secondary-navigation.yaml'
-              - 'snapshots.js'
-              - 'test-links.yaml'
-              - 'package.json'
-              - 'yarn.lock'
+          sparse-checkout: .github/actions/percy-gate
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
 
-      - name: Evaluate gate
-        id: evaluate
-        env:
-          DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
-          VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
-        run: |
-          set -e
-          if [ "$DISPATCHED" = "true" ]; then
-            echo "RUN: manually dispatched"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$VISUAL_CHANGED" = "true" ]; then
-            echo "RUN: visual-affecting files changed on this push"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "SKIP: no visual-affecting changes on this push"
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
+      - id: gate
+        uses: ./.github/actions/percy-gate
+        with:
+          mode: baseline
 
   snapshot:
     name: Take Percy snapshots

--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -1,5 +1,5 @@
-# This workflow updates the Percy baseline on every push to main.
-# This allows pull requests to be compared against baseline test results.
+# Updates the Percy baseline on pushes to main that touch visual-affecting files.
+# See .github/PERCY.md for when this runs, the watched-paths list, and how to refresh manually.
 
 name: Update Percy Baseline
 

--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -7,11 +7,51 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
+  decide:
+    name: Decide whether to update baseline
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+    steps:
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            visual:
+              - 'static/sass/**'
+              - 'templates/**/*.html'
+              - 'package.json'
+              - 'yarn.lock'
+
+      - name: Evaluate gate
+        id: evaluate
+        env:
+          DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
+          VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
+        run: |
+          set -e
+          if [ "$DISPATCHED" = "true" ]; then
+            echo "RUN: manually dispatched"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$VISUAL_CHANGED" = "true" ]; then
+            echo "RUN: visual-affecting files changed on this push"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "SKIP: no visual-affecting changes on this push"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
+    needs: decide
+    if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -1,3 +1,5 @@
+# See .github/PERCY.md for when Percy runs, the watched-paths list, and how to force a run.
+
 name: Percy testing on PRs from forks
 run-name: "Testing Percy on fork PR #${{ github.event.pull_request.number }}"
 

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -10,17 +10,68 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: percy-fork-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
+  decide:
+    name: Decide whether to run Percy
+    runs-on: ubuntu-latest
+    # Only run for forks; internal PRs use percy.yml
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+    steps:
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            visual:
+              - 'static/sass/**'
+              - 'templates/**/*.html'
+              - 'package.json'
+              - 'yarn.lock'
+
+      - name: Evaluate gate
+        id: evaluate
+        env:
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-percy') }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
+        run: |
+          set -e
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "RUN: run-percy label present"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "renovate[bot]" ]; then
+            echo "SKIP: bot author ($ACTOR) without run-percy label"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$VISUAL_CHANGED" = "true" ]; then
+            echo "RUN: visual-affecting files changed"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "SKIP: no visual-affecting changes and no run-percy label"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
-    # Ensure we only run for forks (internal PRs use a different workflow)
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    needs: decide
+    if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
 
     # The environment "percy-testing" handles the approval gate
     environment: percy-testing

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -37,7 +37,12 @@ jobs:
           filters: |
             visual:
               - 'static/sass/**'
-              - 'templates/**/*.html'
+              - 'static/js/src/**'
+              - 'templates/**'
+              - 'navigation.yaml'
+              - 'secondary-navigation.yaml'
+              - 'snapshots.js'
+              - 'test-links.yaml'
               - 'package.json'
               - 'yarn.lock'
 

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             visual:

--- a/.github/workflows/percy-fork-pr.yml
+++ b/.github/workflows/percy-fork-pr.yml
@@ -28,49 +28,18 @@ jobs:
     # Only run for forks; internal PRs use percy.yml
     if: github.event.pull_request.head.repo.full_name != github.repository
     outputs:
-      should_run: ${{ steps.evaluate.outputs.should_run }}
+      should_run: ${{ steps.gate.outputs.should_run }}
     steps:
-      - name: Filter changed paths
-        id: filter
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          filters: |
-            visual:
-              - 'static/sass/**'
-              - 'static/js/src/**'
-              - 'templates/**'
-              - 'navigation.yaml'
-              - 'secondary-navigation.yaml'
-              - 'snapshots.js'
-              - 'test-links.yaml'
-              - 'package.json'
-              - 'yarn.lock'
+          sparse-checkout: .github/actions/percy-gate
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
 
-      - name: Evaluate gate
-        id: evaluate
-        env:
-          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-percy') }}
-          ACTOR: ${{ github.event.pull_request.user.login }}
-          VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
-        run: |
-          set -e
-          if [ "$HAS_LABEL" = "true" ]; then
-            echo "RUN: run-percy label present"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "renovate[bot]" ]; then
-            echo "SKIP: bot author ($ACTOR) without run-percy label"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$VISUAL_CHANGED" = "true" ]; then
-            echo "RUN: visual-affecting files changed"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "SKIP: no visual-affecting changes and no run-percy label"
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
+      - id: gate
+        uses: ./.github/actions/percy-gate
+        with:
+          mode: pr
 
   snapshot:
     name: Take Percy snapshots

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,4 +1,3 @@
-
 name: Percy testing on PRs targeting main
 run-name: Testing Percy on branch ${{ github.head_ref }}
 
@@ -12,12 +11,63 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: percy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
+  decide:
+    name: Decide whether to run Percy
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+    steps:
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            visual:
+              - 'static/sass/**'
+              - 'templates/**/*.html'
+              - 'package.json'
+              - 'yarn.lock'
+
+      - name: Evaluate gate
+        id: evaluate
+        env:
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-percy') }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
+        run: |
+          set -e
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "RUN: run-percy label present"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "renovate[bot]" ]; then
+            echo "SKIP: bot author ($ACTOR) without run-percy label"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$VISUAL_CHANGED" = "true" ]; then
+            echo "RUN: visual-affecting files changed"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "SKIP: no visual-affecting changes and no run-percy label"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: decide
+    if: needs.decide.outputs.should_run == 'true'
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -67,7 +67,7 @@ jobs:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
     needs: decide
-    if: needs.decide.outputs.should_run == 'true'
+    if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,3 +1,5 @@
+# See .github/PERCY.md for when Percy runs, the watched-paths list, and how to force a run.
+
 name: Percy testing on PRs targeting main
 run-name: Testing Percy on branch ${{ github.head_ref }}
 

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -27,49 +27,18 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      should_run: ${{ steps.evaluate.outputs.should_run }}
+      should_run: ${{ steps.gate.outputs.should_run }}
     steps:
-      - name: Filter changed paths
-        id: filter
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          filters: |
-            visual:
-              - 'static/sass/**'
-              - 'static/js/src/**'
-              - 'templates/**'
-              - 'navigation.yaml'
-              - 'secondary-navigation.yaml'
-              - 'snapshots.js'
-              - 'test-links.yaml'
-              - 'package.json'
-              - 'yarn.lock'
+          sparse-checkout: .github/actions/percy-gate
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
 
-      - name: Evaluate gate
-        id: evaluate
-        env:
-          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-percy') }}
-          ACTOR: ${{ github.event.pull_request.user.login }}
-          VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
-        run: |
-          set -e
-          if [ "$HAS_LABEL" = "true" ]; then
-            echo "RUN: run-percy label present"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "renovate[bot]" ]; then
-            echo "SKIP: bot author ($ACTOR) without run-percy label"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$VISUAL_CHANGED" = "true" ]; then
-            echo "RUN: visual-affecting files changed"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "SKIP: no visual-affecting changes and no run-percy label"
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
+      - id: gate
+        uses: ./.github/actions/percy-gate
+        with:
+          mode: pr
 
   snapshot:
     name: Take Percy snapshots

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -33,7 +33,12 @@ jobs:
           filters: |
             visual:
               - 'static/sass/**'
-              - 'templates/**/*.html'
+              - 'static/js/src/**'
+              - 'templates/**'
+              - 'navigation.yaml'
+              - 'secondary-navigation.yaml'
+              - 'snapshots.js'
+              - 'test-links.yaml'
               - 'package.json'
               - 'yarn.lock'
 

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -23,12 +23,15 @@ jobs:
     name: Decide whether to run Percy
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should_run: ${{ steps.evaluate.outputs.should_run }}
     steps:
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             visual:
@@ -73,6 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: decide
     if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/HACKING.md
+++ b/HACKING.md
@@ -138,6 +138,10 @@ Parts of this site use [React Query](https://react-query.tanstack.com/overview) 
 
 To enable the React Query devtools you need to add `NODE_ENV="development"` to your `.env.local` file or run: `dotrun -e NODE_ENV="development"`.
 
+### Visual regression testing (Percy)
+
+Percy runs visual regression snapshots on PRs and on every merge to `main`, but only when the diff touches files that can affect rendered output (SCSS, JS source, templates, nav YAMLs, snapshot config, `package.json`/`yarn.lock`). See [.github/PERCY.md](.github/PERCY.md) for the full behaviour, watched-paths list, and how to force a run via the `run-percy` label.
+
 ## Linting / formatting
 
 When making changes to the codebase please make sure it's properly formatted and linted.


### PR DESCRIPTION
## Done

- Gate the three Percy workflows so snapshots only run when the diff touches a watched path (`static/sass/**`, `static/js/src/**`, `templates/**`, `navigation.yaml`, `secondary-navigation.yaml`, `snapshots.js`, `test-links.yaml`, `package.json`, `yarn.lock`)
- Bot PRs (Renovate/Dependabot) skip by default; `run-percy` label force-runs any PR
- Add per-PR concurrency cancellation; add `workflow_dispatch` to the baseline workflow so a maintainer can force a baseline refresh
- Extract the gate (path filter + decision tree) into a shared composite action at `.github/actions/percy-gate`
- Pin newly-introduced `actions/checkout` and `dorny/paths-filter` to commit SHAs; scope per-job permissions to `contents: read` (+ `pull-requests: read` on PR decide jobs)

## QA

- See that Percy is skipped on this PR (no watched paths touched)
- On a separate branch, edit a SCSS file or template and confirm Percy runs
- On a Renovate/Dependabot PR, confirm Percy is skipped; add the `run-percy` label and confirm a fresh run starts
- After merge, trigger `Update Percy Baseline` from the Actions UI and confirm it runs regardless of paths

### Manual follow-ups before merge

- [x] Create the `run-percy` label in the repo
- [x] Confirm branch protection still passes for skipped PRs (GitHub treats `skipped` as `success` for required checks); if not, switch the required check from `Take Percy snapshots` to `Decide whether to run Percy`

## Issue / Card

https://warthogs.atlassian.net/browse/WD-36846