### PR TITLE
feat: add per-request CSP nonce generation for inline scripts

### DIFF
--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -17,7 +17,7 @@
   </form>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   var select = document.querySelector('.js-submit-on-change');
   select.addEventListener('change', function(e) {
     var form = this.closest('form');

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -148,7 +148,7 @@
   {% endif %}
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Get all loaded cards
   var cards = document.getElementsByClassName('js-product-card');
   if (cards) {

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -218,7 +218,7 @@ meta_copydoc %}
 
   {% include "download/shared/_footer.html" %}
 
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     function setUpTogglableSideNav() {
       var navigationDrawer = document.querySelector("#drawer");
       var navigationDrawerToggles = Array.prototype.slice.call(

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -65,7 +65,7 @@
                 <span class="u-text--muted">{{ releases_yaml.lts.iso_download_size }}</span>
               {% endif %}
 
-              <script>
+              <script nonce="{{ csp_nonce }}">
                 performance.mark("Download (Desktop) button rendered")
               </script>
             </div>
@@ -84,7 +84,7 @@
                 <span class="u-text--muted">{{ releases_yaml.lts.arm_iso_download_size }}</span>
               {% endif %}
 
-              <script>
+              <script nonce="{{ csp_nonce }}">
                 performance.mark("Download (Desktop) button rendered")
               </script>
             </div>
@@ -228,7 +228,7 @@
                   <span class="u-text--muted">{{ releases_yaml.latest.iso_download_size }}</span>
                 {% endif %}
 
-                <script>
+                <script nonce="{{ csp_nonce }}">
                   performance.mark("Download (Desktop) button rendered")
                 </script>
               </div>
@@ -247,7 +247,7 @@
                   <span class="u-text--muted">{{ releases_yaml.latest.arm_iso_download_size }}</span>
                 {% endif %}
 
-                <script>
+                <script nonce="{{ csp_nonce }}">
                   performance.mark("Download (Desktop) button rendered")
                 </script>
               </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -17,7 +17,7 @@
       opacity: 0 !important
     }
   </style>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function(a, s, y, n, c, h, i, d, e) {
       s.className += ' ' + y;
       h.start = 1 * new Date;
@@ -314,7 +314,7 @@
 
   {% if version %}
     <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
+    <script defer nonce="{{ csp_nonce }}">
       var architecture = '{{ architecture }}';
       var version = '{{ version }}';
 

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -318,7 +318,7 @@
     </template>
   </section>
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -165,7 +165,7 @@
   </section>
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -482,7 +482,7 @@
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -237,7 +237,7 @@
   </section>
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",
@@ -252,7 +252,7 @@
 {% block footer_extra %}
   <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
-  <script defer>
+  <script defer nonce="{{ csp_nonce }}">
     var architecture = '{{ architecture }}';
     var version = '{{ version }}';
     if (version) {

--- a/templates/download/shared/_everywhere.html
+++ b/templates/download/shared/_everywhere.html
@@ -146,7 +146,7 @@
       </div>
     </section>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       var all = document.querySelectorAll('.js-everywhere');
       var linux = document.querySelectorAll('.js-linux');
       var macos = document.querySelectorAll('.js-macos');

--- a/templates/download/shared/_instructions-resources.html
+++ b/templates/download/shared/_instructions-resources.html
@@ -50,7 +50,7 @@
 </section>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/download/shared/_latest-blogs_download.html
+++ b/templates/download/shared/_latest-blogs_download.html
@@ -30,7 +30,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-<script>  
+<script nonce="{{ csp_nonce }}">  
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#ubuntu-desktop-latest",

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -29,7 +29,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   var multipassOScta = document.getElementById('multipass-os-cta');
   var baseInstallURL = multipassOScta.getAttribute('href');
   var ctaSpan = multipassOScta.querySelector('span')

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -133,7 +133,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   /**
     Toggles modal dialog.
     @param {HTMLElement} event modal Modal dialog to show or hide.

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -33,7 +33,7 @@ You can
 </div>
 
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   function verifyDownloadContent() {
     var targetControls = document.getElementById("menu-4");
     if (targetControls) {

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -24,7 +24,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -184,12 +184,12 @@
 
 {% block footer_extra %}
   {% if architecture == 'pro' %}
-    <script defer>
+    <script defer nonce="{{ csp_nonce }}">
       window.location.href = '{{ pro_download_url }}';
     </script>
   {% elif version %}
     <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
+    <script defer nonce="{{ csp_nonce }}">
       var architecture = '{{ architecture }}';
       var version = '{{ version }}';
 

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -274,7 +274,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -1136,7 +1136,7 @@
     max-width: 100%;
   }
 </style>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 

--- a/templates/shared/_credentials-signup-sme-form.html
+++ b/templates/shared/_credentials-signup-sme-form.html
@@ -737,7 +737,7 @@
     </div>
   {% endif %}
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
   var PROGRESS_COLOUR = '#E95420';

--- a/templates/shared/_credentials-signup-tester-form.html
+++ b/templates/shared/_credentials-signup-tester-form.html
@@ -710,7 +710,7 @@
     </div>
   {% endif %}
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
   var PROGRESS_COLOUR = '#E95420';

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -599,7 +599,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -104,7 +104,7 @@
     </div>
   </form>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function stringifyCustomFields() {
       const checkboxes = document.querySelectorAll(".js-checkbox");
       const textarea = document.getElementById("ubuntu_desktop_usage");

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -83,7 +83,7 @@
   {% endif %}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#horizontal-latest-articles",

--- a/templates/shared/_share_this.html
+++ b/templates/shared/_share_this.html
@@ -1,7 +1,7 @@
 <div class="share-this">
 	<iframe title="Share on Facebook" src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20" style="border:none; overflow:hidden; height:21px; padding-right:23px;"></iframe>
 	<div class="g-plusone" data-size="medium"></div>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.___gcfg = {lang: 'en-GB'};
 
       (function() {

--- a/templates/shared/contextual_footers/_ai_further_reading.html
+++ b/templates/shared/contextual_footers/_ai_further_reading.html
@@ -12,7 +12,7 @@
 </template>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -40,7 +40,7 @@
           </div>
       </form>
       <script src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
-      <script>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+      <script nonce="{{ csp_nonce }}">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
       <!--End mc_embed_signup-->
   </div>
 </div>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -14,7 +14,7 @@
 </template>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -65,7 +65,7 @@
   {% include "/shared/forms/form-fields.html" %}
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form[id^="mktoForm_"]').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/templates/_getfeedback.html
+++ b/templates/templates/_getfeedback.html
@@ -1,5 +1,5 @@
 <!-- begin usabilla live embed code -->
-<script>
+<script nonce="{{ csp_nonce }}">
   window.lightningjs || function(n) {
     var e = "lightningjs";
 

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{ csp_nonce }}">
   const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
   if (userIDCookie !== null) {
     let idValue = userIDCookie[2];
@@ -10,7 +10,7 @@
   }
 </script>
 <!-- Google Tag Manager -->
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener('DOMContentLoaded', () => {
     /** init gtm after 2 seconds - can be adjusted */
     setTimeout(initGTM, 2000);

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -34,7 +34,7 @@
           type="text/css"
           media="print"
           href="{{ versioned_static('css/print.css') }}" />
-    <script>
+    <script nonce="{{ csp_nonce }}">
       performance.mark("Stylesheets finished");
     </script>
 

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -48,7 +48,7 @@
         <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
         <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
 
-        <script>
+        <script nonce="{{ csp_nonce }}">
           var html = document.documentElement
           html.classList.replace("no-js", "js");
         </script>

--- a/templates/templates/docs/markdown.html
+++ b/templates/templates/docs/markdown.html
@@ -55,7 +55,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
     var currentPath = window.location.pathname;
 

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -175,7 +175,7 @@
 
   <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Allows the 'onchange' listener to be used on a select field, while still being accessible.
     (function initSelect() {
       var selectField = document.querySelector("#version-select");

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -271,7 +271,7 @@
         <a href="#">Back to top</a>
       </p>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
         /* Add the page to the report a bug link */
         var bugLink = document.querySelector('#report-a-bug');
         bugLink.href += '&reported_from=' + location.href;

--- a/templates/templates/markdown/base.html
+++ b/templates/templates/markdown/base.html
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
     var currentPath = window.location.pathname;
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -456,5 +456,34 @@ class TestRoutes(VCRTestCase):
         )
 
 
+    def test_csp_header_contains_nonce(self):
+        """Test that CSP header includes a nonce in script directives"""
+        response = self.client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        self.assertIn("nonce-", csp)
+
+    def test_csp_nonce_in_script_directives(self):
+        """Test that nonce appears in both script-src and script-src-elem"""
+        response = self.client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        directives = {
+            d.split()[0]: d for d in csp.rstrip(";").split(";") if d.strip()
+        }
+        self.assertIn("nonce-", directives.get("script-src-elem", ""))
+        self.assertIn("nonce-", directives.get("script-src", ""))
+
+    def test_csp_nonce_is_unique_per_request(self):
+        """Test that a different nonce is generated for each request"""
+        def get_nonce(csp):
+            for part in csp.split():
+                if part.startswith("'nonce-"):
+                    return part
+            return None
+
+        csp1 = self.client.get("/").headers.get("Content-Security-Policy", "")
+        csp2 = self.client.get("/").headers.get("Content-Security-Policy", "")
+        self.assertNotEqual(get_nonce(csp1), get_nonce(csp2))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -455,7 +455,6 @@ class TestRoutes(VCRTestCase):
             response.location,
         )
 
-
     def test_csp_header_contains_nonce(self):
         """Test that CSP header includes a nonce in script directives"""
         response = self.client.get("/")
@@ -474,6 +473,7 @@ class TestRoutes(VCRTestCase):
 
     def test_csp_nonce_is_unique_per_request(self):
         """Test that a different nonce is generated for each request"""
+
         def get_nonce(csp):
             for part in csp.split():
                 if part.startswith("'nonce-"):

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,3 +1,4 @@
+import secrets
 from typing import List
 
 import flask
@@ -36,6 +37,10 @@ from canonicalwebteam.flask_base.env import get_flask_env
 
 
 def init_handlers(app):
+    @app.before_request
+    def generate_csp_nonce():
+        flask.g.csp_nonce = secrets.token_urlsafe(16)
+
     @app.after_request
     def cache_headers(response):
         """
@@ -165,6 +170,7 @@ def init_handlers(app):
             "get_navigation": get_navigation,
             "split_list": split_list,
             "format_to_id": format_to_id,
+            "csp_nonce": flask.g.get("csp_nonce", ""),
         }
 
     def get_countries_list() -> List[dict]:
@@ -215,7 +221,14 @@ def init_handlers(app):
                 csp_str += f"{key} {csp_value}; "
             return csp_str.strip()
 
-        response.headers["Content-Security-Policy"] = get_csp_as_str(CSP)
+        nonce = flask.g.get("csp_nonce", "")
+        csp = {
+            key: values + [f"'nonce-{nonce}'"]
+            if key in ("script-src-elem", "script-src")
+            else values
+            for key, values in CSP.items()
+        }
+        response.headers["Content-Security-Policy"] = get_csp_as_str(csp)
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -223,9 +223,11 @@ def init_handlers(app):
 
         nonce = flask.g.get("csp_nonce", "")
         csp = {
-            key: values + [f"'nonce-{nonce}'"]
-            if key in ("script-src-elem", "script-src")
-            else values
+            key: (
+                values + [f"'nonce-{nonce}'"]
+                if key in ("script-src-elem", "script-src")
+                else values
+            )
             for key, values in CSP.items()
         }
         response.headers["Content-Security-Policy"] = get_csp_as_str(csp)


### PR DESCRIPTION
## Done

- Added per-request CSP nonce generation to the Flask app as groundwork for removing `unsafe-inline` from script directive and related unit tests
- Added `nonce` attribute to first batch of inline scripts 

## QA

- Pick a demo listed below and run the following: `curl -sI https://ubuntu-com-16402.demos.haus | grep -i content-security-policy | tr ';' '\n' | grep script-src`
- See that `nonce-<id>` shows up in the response
- Check the pages still load as expected
- Demo list:
  - https://ubuntu-com-16402.demos.haus/
  - https://ubuntu-com-16402.demos.haus/download/desktop
  - https://ubuntu-com-16402.demos.haus/download/server
  - https://ubuntu-com-16402.demos.haus/downloads/alternative-downloads

## Issue / Card

Partial work towards completing WD-36594
