### PR TITLE
ci: post zizmor findings as PR comment for visibility

### DIFF
--- a/.github/workflows/zizmor-static-analysis.yaml
+++ b/.github/workflows/zizmor-static-analysis.yaml
@@ -29,8 +29,17 @@ jobs:
         with:
           online-audits: true
 
+      # The next three steps post a PR comment with findings scoped to the
+      # files changed in this PR. They are skipped on fork PRs because
+      # GITHUB_TOKEN is read-only on cross-repo PRs and the comment step
+      # would fail to authenticate.
+      - name: Install zizmor CLI
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        run: pipx install zizmor==1.25.2
+
       - name: Build zizmor PR report (changed files only)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         env:
           NO_COLOR: "1"
@@ -44,6 +53,8 @@ jobs:
             | grep -E '^\.github/(workflows|actions)/.*\.ya?ml$' \
             > changed_files.txt || true
 
+          # Always write the report file so the sticky-comment step has something
+          # to post even if a previous step failed.
           {
             echo '## :shield: zizmor findings on workflow/action files changed in this PR'
             echo ''
@@ -51,6 +62,8 @@ jobs:
             echo ''
             if [ ! -s changed_files.txt ]; then
               echo '_No workflow or action YAML files changed in this PR — nothing to scan._'
+            elif ! command -v zizmor >/dev/null 2>&1; then
+              echo '_zizmor CLI failed to install — see the workflow log. SARIF upload to Code Scanning is unaffected._'
             else
               echo 'Scanned:'
               while IFS= read -r file; do
@@ -58,14 +71,13 @@ jobs:
               done < changed_files.txt
               echo ''
               echo '```'
-              pipx install zizmor==1.25.2
               xargs zizmor --persona=auditor --format=plain < changed_files.txt 2>/dev/null || true
               echo '```'
             fi
           } > zizmor-report.md
 
       - name: Post zizmor findings as sticky PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: zizmor-findings

--- a/.github/workflows/zizmor-static-analysis.yaml
+++ b/.github/workflows/zizmor-static-analysis.yaml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: zizmor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest
@@ -54,7 +58,7 @@ jobs:
               done < changed_files.txt
               echo ''
               echo '```'
-              pipx install zizmor
+              pipx install zizmor==1.25.2
               xargs zizmor --persona=auditor --format=plain < changed_files.txt 2>/dev/null || true
               echo '```'
             fi

--- a/.github/workflows/zizmor-static-analysis.yaml
+++ b/.github/workflows/zizmor-static-analysis.yaml
@@ -13,13 +13,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Run zizmor
+      - name: Run zizmor (SARIF upload to code scanning)
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           online-audits: true
+
+      - name: Run zizmor (plain output for PR comment)
+        if: github.event_name == 'pull_request'
+        id: zizmor_plain
+        continue-on-error: true
+        run: |
+          pipx install zizmor
+          {
+            echo '## :shield: zizmor security findings'
+            echo ''
+            echo 'Rule descriptions and remediation guidance: <https://docs.zizmor.sh/audits/>'
+            echo ''
+            echo '```'
+            zizmor --persona=auditor --format=plain . 2>&1 || true
+            echo '```'
+          } > zizmor-report.md
+
+      - name: Post zizmor findings as sticky PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: zizmor-findings
+          path: zizmor-report.md

--- a/.github/workflows/zizmor-static-analysis.yaml
+++ b/.github/workflows/zizmor-static-analysis.yaml
@@ -25,20 +25,39 @@ jobs:
         with:
           online-audits: true
 
-      - name: Run zizmor (plain output for PR comment)
+      - name: Build zizmor PR report (changed files only)
         if: github.event_name == 'pull_request'
-        id: zizmor_plain
         continue-on-error: true
+        env:
+          NO_COLOR: "1"
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          pipx install zizmor
+          # List workflow/action YAML files changed in this PR (skip removed files).
+          gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+            --jq '.[] | select(.status != "removed") | .filename' \
+            | grep -E '^\.github/(workflows|actions)/.*\.ya?ml$' \
+            > changed_files.txt || true
+
           {
-            echo '## :shield: zizmor security findings'
+            echo '## :shield: zizmor findings on workflow/action files changed in this PR'
             echo ''
             echo 'Rule descriptions and remediation guidance: <https://docs.zizmor.sh/audits/>'
             echo ''
-            echo '```'
-            zizmor --persona=auditor --format=plain . 2>&1 || true
-            echo '```'
+            if [ ! -s changed_files.txt ]; then
+              echo '_No workflow or action YAML files changed in this PR — nothing to scan._'
+            else
+              echo 'Scanned:'
+              while IFS= read -r file; do
+                echo "- \`$file\`"
+              done < changed_files.txt
+              echo ''
+              echo '```'
+              pipx install zizmor
+              xargs zizmor --persona=auditor --format=plain < changed_files.txt 2>/dev/null || true
+              echo '```'
+            fi
           } > zizmor-report.md
 
       - name: Post zizmor findings as sticky PR comment


### PR DESCRIPTION
## Done

- Post zizmor findings as a single auto-updating sticky PR comment so reviewers can see all security findings (rule, file, line, fix suggestion) without clicking through to the Security tab
- Link to the upstream audit catalog at <https://docs.zizmor.sh/audits/> for each rule's full description and remediation guidance
- Keep the existing SARIF upload to Code Scanning unchanged (inline annotations still work as before)
- Grant `pull-requests: write` at the job level (workflow-level permissions stay `{}`)

## QA

- Open a PR (or push to any branch with an open PR)
- See the `GitHub Actions Security Analysis with zizmor` workflow run on the PR
- See a new comment from `github-actions[bot]` titled "zizmor security findings" with the readable list of findings; existing per-line annotations from the SARIF upload still appear in the Files changed view
- Push another commit; see the same comment update in place rather than a new one appearing

## Issue / Card

n/a
