### PR TITLE
fix: update RISC-V Cookbook link to point to the correct documentation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -974,7 +974,7 @@ download_ubuntu:
         - title: Quick links
           links:
             - title: RISC-V Cookbook for partners to build Ubuntu images
-              url: https://canonical-risc-v-cookbook.readthedocs-hosted.com/en/latest/
+              url: https://documentation.ubuntu.com/hardware-support/image-cookbook/overview/
             - title: Introduction to Canonical's RISC-V programs
               url: https://canonical.com/partners/silicon#risc-v
     - title: Develop on Ubuntu


### PR DESCRIPTION
## Done

- update RISC-V Cookbook link to point to the correct documentation per [copydoc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?tab=t.0) (search for "RISC-V Cookbook for partners to build Ubuntu Images")

## QA

- Open the [DEMO](https://ubuntu-com-16406.demos.haus/)
- Check the navbar: Download Ubuntu > Ubuntu for RISC-V > Quick links > RISC-V Cookbook for partners to build Ubuntu images
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
