### PR TITLE
Fix typos in /about

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -57,7 +57,7 @@
       </div>
       <div class="col">
         <p>Linux was already established in 2004, but it was fragmented into proprietary and unsupported community editions, and free software was not a part of everyday life for most computer users. That's when Mark Shuttleworth gathered a small team of Debian developers who together founded Canonical and set out to create an easy-to-use Linux desktop called Ubuntu.</p>
-        <p>The <a href="/community/mission">mission for Ubuntu</a> is both social and economic. First, we deliver the worlds free software, freely, to everybody on the same terms. Whether you are a student in India or a global bank, you can download and use Ubuntu free of charge. Second, we aim to cut the cost of professional services - support, management, maintenance, operations - for people who use Ubuntu at scale, through a portfolio of services provided by Canonical which ultimately fund the improvement of the platform.</p>
+        <p>The <a href="/community/mission">mission for Ubuntu</a> is both social and economic. First, we deliver the world's free software, freely, to everybody on the same terms. Whether you are a student in India or a global bank, you can download and use Ubuntu free of charge. Second, we aim to cut the cost of professional services - support, management, maintenance, operations - for people who use Ubuntu at scale, through a portfolio of services provided by Canonical which ultimately fund the improvement of the platform.</p>
       </div>
     </div>
   </section>
@@ -133,7 +133,7 @@
           Ubuntu today has <a href="/desktop/flavours">many flavors</a> and <a href="https://wiki.ubuntu.com/DerivativeTeam/Derivatives">dozens of specialized derivatives</a>. There are also special editions for servers, OpenStack clouds, and connected devices. All editions share common infrastructure and software, making Ubuntu a unique single platform that scales from consumer electronics to the desktop and up into the cloud for enterprise computing.
         </p>
         <p>
-          The Ubuntu desktop is by far the world's most widely used Linux workstation platform, powering the work of engineers across the globe. Ubuntu Core sets the standard for tiny, transactional operating systems for highly secure connected devices. Ubuntu Server is the reference operating system for the OpenStack project, and a hugely popular guest OS on AWS, Azure and Google Cloud. Ubuntu is pre-installed on computers from Dell, HP, Asus, Lenovo and other global vendors.
+          Ubuntu Desktop is by far the world's most widely used Linux workstation platform, powering the work of engineers across the globe. Ubuntu Core sets the standard for tiny, transactional operating systems for highly secure connected devices. Ubuntu Server is the reference operating system for the OpenStack project, and a hugely popular guest OS on AWS, Azure and Google Cloud. Ubuntu is pre-installed on computers from Dell, HP, Asus, Lenovo and other global vendors.
         </p>
         <p>
           We hope Ubuntu will bring something wonderful to your computing &ndash; and we hope that you'll join us in helping to shape and build the future of free software together.


### PR DESCRIPTION
## Done

- Found some typos in the /about page that were in the copydoc but hadn't been acted on yet.

## QA

- Open the [DEMO](https://ubuntu-com-16407.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]
- [Copy doc](https://docs.google.com/document/d/1NvYOhOJzdY5ypifTPs73vH5Nb7rFABRWMzjXyDUQt_U/edit?tab=t.0)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

