### PR TITLE
fix: move Chrome executable path to PUPPETEER_EXECUTABLE_PATH in CI

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Run a11y tests
         env:
           URL_LIST: ${{ needs.read-config.outputs.urls }}
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
         run: |
           yarn pa11y-ci $URL_LIST
 


### PR DESCRIPTION
The a11y workflow was failing on the ubuntu-24.04 runner because pa11y-ci's bundled Puppeteer couldn't auto-detect Chrome. Rather than hard-coding /usr/bin/google-chrome in the shared .pa11yci (which would break local runs on macOS/Windows), the executable path is now provided only in CI via PUPPETEER_EXECUTABLE_PATH, keeping .pa11yci portable.

## QA

- Check that the run [passes](https://github.com/canonical/ubuntu.com/actions/runs/26788404051/job/78969310088?pr=16408) compared to that of production that [failed](https://github.com/canonical/ubuntu.com/actions/runs/26745592297)
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-36893

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
