### PR TITLE
fix: update takeover image to a new asset with adjusted dimensions

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -87,10 +87,10 @@
           <picture>
             <source srcset="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
                     media="(max-width: 1036px)" />
-            {{ image(url="https://assets.ubuntu.com/v1/33b5133c-Noble-Numbat-optimised.svg",
+            {{ image(url="https://assets.ubuntu.com/v1/21bcdd1e-resolute_raccoon_white.png",
                         alt="",
-                        width="197",
-                        height="150",
+                        width=197,
+                        height=197,
                         hi_def=True,
                         loading="auto",
                         attrs={"id": "takeover-image"}) | safe


### PR DESCRIPTION
## Done

- Updates to 26.04 mascot

## QA

- Open the [DEMO](https://ubuntu-com-16410.demos.haus/)
- Disable JS and refresh
- see the 26.04 mascot https://assets.ubuntu.com/v1/21bcdd1e-resolute_raccoon_white.png

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36933

