### PR TITLE
Add CSP nonce attribute to inline scripts cont.

### DIFF
--- a/templates/account/checkout.html
+++ b/templates/account/checkout.html
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     </script>
     <script src="{{ versioned_static('js/dist/shopCheckout.js') }}" type="module"></script>

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -102,7 +102,7 @@
   </section>
   {% include "account/invoices/_edit_billing_modal.html" %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const prices = document.querySelectorAll('.js-format-price');
     prices.forEach(price => {
       const amount = price.innerText.split(' ')[0];
@@ -125,7 +125,7 @@
     })
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.accountId = "{{ account_id }}";
   </script>
   <script src="{{ versioned_static('js/dist/account-billing.js') }}"></script>

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -88,14 +88,14 @@
   {% include "account/payment-methods/_confirm-remove-modal.html" %}
 
   <script src="https://js.stripe.com/v3/"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     window.accountId = "{{ account_id }}";
     window.pendingPurchaseId = "{{ pending_purchase_id }}";
     window.hasPaymentMethod = {% if default_payment_method.id %}true{% else %}false{% endif %};
   </script>
   <script src="/static/js/src/modal.js"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     initModals('#remove-payment-modal', '[aria-controls=remove-payment-modal]', false)
   </script>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -298,7 +298,7 @@
 </div>
 
 <script src="https://js.stripe.com/v3/"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
 </script>
 <script src="{{ versioned_static('js/dist/ua-payment-modal.js') }}" type="module" defer></script>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -31,7 +31,7 @@ endblock meta_copydoc %}
   </section>
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     dataLayer.push({
       event: "GAEvent",
       eventCategory: "Advantage",
@@ -52,7 +52,7 @@ endblock meta_copydoc %}
   </div>
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
   localStorage.setItem("isTechnical", {{ is_technical|lower }});
   localStorage.setItem("isInMaintenance", {{ is_in_maintenance|lower }});

--- a/templates/advantage/offers/index.html
+++ b/templates/advantage/offers/index.html
@@ -16,7 +16,7 @@
 
 <script src="/static/js/dist/advantageOffers.js" type="module"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = '{{ get_stripe_publishable_key }}';
 </script>
 

--- a/templates/advantage/subscribe/blender/index.html
+++ b/templates/advantage/subscribe/blender/index.html
@@ -19,7 +19,7 @@
   defer
 ></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   window.blenderProductList = {
     {% for listing_id, listing in product_listings.items() %}
       "{{ listing.product.id }}-{{ listing.period }}": {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -35,7 +35,7 @@ endblock meta_copydoc %} {% block content %}
   defer
 ></script>
 
-<script defer>
+<script defer nonce="{{ csp_nonce }}">
   var productList = {
     {% for listing_id, listing in product_listings.items() %}
       "{{ listing.product.id }}-{{ listing.period }}": {

--- a/templates/credentials/base_cred.html
+++ b/templates/credentials/base_cred.html
@@ -16,7 +16,7 @@
         <p class="p-notification__message" id="cred-maintenance-message"></p>
       </div>
     </div>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       const dateTimeFormatter = (dateTime, locale = 'default') => {
         const date = new Date(dateTime);
         const options = {

--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -22,7 +22,7 @@
             src="{{ url }}"></iframe>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const setIframeHeight = () => {
       // TODO: Account for header height change
       const navHeight = document.getElementById("navigation").clientHeight;

--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -369,7 +369,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const anchorTags = document.querySelectorAll('.custom-link');
     anchorTags.forEach(anchor => {
       anchor.removeAttribute('onclick');

--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -59,7 +59,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function disableButton(event) {
       document.getElementById('activate-button').disabled=true;
     }

--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -98,7 +98,7 @@ meta_copydoc %}
   </section>
 
   {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     let selectedTimezone;
     {% if timezone and timezone != "" %}
     selectedTimezone = "{{ timezone }}";

--- a/templates/credentials/self-study.html
+++ b/templates/credentials/self-study.html
@@ -339,7 +339,7 @@
       </div>
     </div>
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const setupTabs = () => {
       var keys = {
         left: 'ArrowLeft',

--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -132,7 +132,7 @@
     </section>
   </form>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     const exams = JSON.parse('{{ exams | tojson }}');
     const isStaging = JSON.parse('{{ is_staging | tojson }}');

--- a/templates/credentials/shop/keys.html
+++ b/templates/credentials/shop/keys.html
@@ -86,7 +86,7 @@ meta_copydoc %}
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const cueKeyProduct = JSON.parse('{{cue_key_product | tojson }}');
 
     function handleSubmit() {

--- a/templates/credentials/sign-up.html
+++ b/templates/credentials/sign-up.html
@@ -9,7 +9,7 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function getSubmitButton() {
       return document.getElementById('formSubmitButton');
     }

--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -81,7 +81,7 @@
       </div>
     </div>
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var keys = {
         left: 'ArrowLeft',

--- a/templates/credentials/thank-you.html
+++ b/templates/credentials/thank-you.html
@@ -40,7 +40,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/credentials/your-exams.html
+++ b/templates/credentials/your-exams.html
@@ -130,7 +130,7 @@
     {% endif %}
   {% endfor %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function setTooltipPosition(trigger, container) {
       const triggerRect = trigger.getBoundingClientRect();
       let tooltipX = triggerRect.x;

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -357,7 +357,7 @@ layout='50/50'
 
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   const personalTab = document.getElementById('personal');
   const enterpriseTab = document.getElementById('enterprise');
   const toggleEnterpriseSupport = ()=>{

--- a/templates/pro/attach/instructions.html
+++ b/templates/pro/attach/instructions.html
@@ -74,7 +74,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     (function () {
         var keys = {
             left: 'ArrowLeft',

--- a/templates/pro/distributor/index.html
+++ b/templates/pro/distributor/index.html
@@ -17,7 +17,7 @@
       </div>
     </div>
     <script src="{{ versioned_static('js/dist/distributor.js') }}" type="module" defer></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.channelProductList = {{ product_listings | tojson }};
       
       var accountId = "{% if account %}{{ account.id }}{% endif %}";

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -30,7 +30,7 @@
         integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
         crossorigin="anonymous"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   const ctx = document.getElementById('myChart');
   Chart.defaults.font.family = "Ubuntu";
   new Chart(ctx, {

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -19,7 +19,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/security/compliance-automation-value-calculator/index.html
+++ b/templates/security/compliance-automation-value-calculator/index.html
@@ -395,7 +395,7 @@
   {{ load_form("/security/compliance-automation-value-calculator") | safe }}
 
   <script src="{{ versioned_static('js/src/slider-base.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Profile definitions based on actual benchmark specifications
     const profiles = {
       1: {

--- a/templates/security/cves/about.html
+++ b/templates/security/cves/about.html
@@ -388,7 +388,7 @@
       </div>
     </div>
   </section>
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     function setUpTogglableSideNav() {
       var navigationDrawer = document.querySelector("#drawer");
       var navigationDrawerToggles = Array.prototype.slice.call(

--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -621,7 +621,7 @@
     </div>
 
     <script src="{{ versioned_static('js/src/resources.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       fetchAndRenderResources(tag = "vulnerability+patching", resource = "whitepaper");
     </script>
   </section>
@@ -630,7 +630,7 @@
   <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
   <script src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
   
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function handleHiddenReleasesSwitch() {
       const maintainedCount = {{ maintained_count | tojson | safe }};
       const isOnlyUpstream = {{ only_upstream | tojson | safe }};

--- a/templates/security/cves/index.html
+++ b/templates/security/cves/index.html
@@ -50,7 +50,7 @@
   {% endif %}
 
   {# djlint:off #}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     const maintainedReleasesObj = {{maintained_releases | tojson | safe}};
     const ltsReleasesObj = {{lts_releases | tojson | safe}};
     const unmaintainedReleasesObj = {{unmaintained_releases | tojson | safe}};

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -550,7 +550,7 @@
 
   <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       limit: "4",

--- a/templates/security/notices/_further-reading.html
+++ b/templates/security/notices/_further-reading.html
@@ -11,7 +11,7 @@
 </template>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",

--- a/templates/security/notices/index.html
+++ b/templates/security/notices/index.html
@@ -145,7 +145,7 @@
   </section>
 
 {# djlint:off #}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   const maintainedReleasesObj = {{maintained_releases | tojson | safe}};
   const ltsReleasesObj = {{lts_releases | tojson | safe}};
   const unmaintainedReleasesObj = {{unmaintained_releases | tojson | safe}};


### PR DESCRIPTION
## Done

- Continuation of https://github.com/canonical/ubuntu.com/pull/16402

## QA

- Pick a demo listed below and run the following: `curl -sI https://ubuntu-com-16411.demos.haus | grep -i content-security-policy | tr ';' '\n' | grep script-src`
- See that nonce-<id> shows up in the response
- Check the pages still load as expected
- Demo list:
  - https://ubuntu-com-16411.demos.haus/pricing/pro
  - https://ubuntu-com-16411.demos.haus/pricing/pro
  - https://ubuntu-com-16411.demos.haus/security/cves
  - https://ubuntu-com-16411.demos.haus/security/notices

## Issue / Card

Partial work towards completing WD-36594

