### PR TITLE
feat: add CSP nonce to inline scripts in continued

### DIFF
--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -46,7 +46,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/aws/shared/_aws-pie-chart.html
+++ b/templates/aws/shared/_aws-pie-chart.html
@@ -5,7 +5,7 @@
 
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function drawChart() {
   'use strict';
   document.querySelector('#ubuntu-pie').innerHTML = "";

--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -32,7 +32,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -322,7 +322,7 @@
   </template>
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-posts",
       articleTemplateSelector: "#articles-template",

--- a/templates/azure/shared/_latest-blogs-azure.html
+++ b/templates/azure/shared/_latest-blogs-azure.html
@@ -28,7 +28,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#azure-latest",

--- a/templates/azure/thank-you.html
+++ b/templates/azure/thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/blender/thank-you.html
+++ b/templates/blender/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/ceph/shared/_latest-news-ceph.html
+++ b/templates/ceph/shared/_latest-news-ceph.html
@@ -26,7 +26,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-<script>  
+<script nonce="{{ csp_nonce }}">  
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#ceph-install-latest",

--- a/templates/ceph/thank-you.html
+++ b/templates/ceph/thank-you.html
@@ -34,7 +34,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -56,7 +56,7 @@
     </div>
   </noscript>
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/contact-us/thank-you.html
+++ b/templates/contact-us/thank-you.html
@@ -541,7 +541,7 @@
     <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
 
     <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
         canonicalLatestNews.fetchLatestNews({
             imageClasses: ["p-image-container__image"],
             limit: "4",
@@ -553,7 +553,7 @@
         })
     </script>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
         function stringifyCustomFields() {
             const checkboxes = document.querySelectorAll(".js-checkbox");
             const textarea = document.getElementById("ubuntu_desktop_usage");
@@ -576,7 +576,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical - contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -17,7 +17,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -32,7 +32,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -459,7 +459,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function setUpDynamicSideNav() {
       const questions = Array.prototype.slice.call(
         document.querySelectorAll(".question-heading")

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/dell/thank-you.html
+++ b/templates/dell/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/gcp/thank-you.html
+++ b/templates/gcp/thank-you.html
@@ -33,7 +33,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/hpc/thank-you.html
+++ b/templates/hpc/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/ibm/thank-you.html
+++ b/templates/ibm/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/internet-of-things/contact-us-hannover.html
+++ b/templates/internet-of-things/contact-us-hannover.html
@@ -139,7 +139,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   function createMessage() {
     var message = "";
     var formFields = document.querySelectorAll(".js-formfield");

--- a/templates/internet-of-things/shared/_latest-news-iot.html
+++ b/templates/internet-of-things/shared/_latest-news-iot.html
@@ -32,7 +32,7 @@
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 
 {# djlint:off #}
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#iot-latest",

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -32,7 +32,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/kubernetes/charmed-k8s/docs/base_docs.html
+++ b/templates/kubernetes/charmed-k8s/docs/base_docs.html
@@ -18,7 +18,7 @@
         </div>
       </aside>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
       // Select the active navigation item
       var navigation = document.getElementById('docs-navigation');
       var links = navigation.getElementsByTagName('a');
@@ -31,7 +31,7 @@
       };
       </script>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
       // Toggle mobile sidebar nav
       var toggle = document.querySelector('.p-sidebar__toggle');
       var sidebarContent = document.querySelector('.p-sidebar__content');

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -612,7 +612,7 @@
 
   {{ load_form("/kubernetes") | safe }}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const switchElement = document.querySelector('.js-discoverer-switch');
       const discovererText = document.querySelector('.js-discoverer-text');

--- a/templates/managed-infrastructure/thank-you.html
+++ b/templates/managed-infrastructure/thank-you.html
@@ -14,7 +14,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/managed/thank-you.html
+++ b/templates/managed/thank-you.html
@@ -14,7 +14,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -982,7 +982,7 @@
   {{ load_form('/openstack') | safe }}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#latest-articles",
       articleTemplateSelector: "#article-template",

--- a/templates/openstack/shared/_openstack-aws-pie-chart.html
+++ b/templates/openstack/shared/_openstack-aws-pie-chart.html
@@ -2,7 +2,7 @@
 
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 // FF/Opera does not support offsetWidth for tspan's. If undefined
 // use the getBoundingClientRect method.
 function getObjWidth(obj) {

--- a/templates/openstack/shared/_openstack-pie-chart.html
+++ b/templates/openstack/shared/_openstack-pie-chart.html
@@ -5,7 +5,7 @@
 
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function drawChart() {
   'use strict';
   document.querySelector('#ubuntu-pie').innerHTML = "";

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -54,7 +54,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/server/maas/thank-you.html
+++ b/templates/server/maas/thank-you.html
@@ -9,7 +9,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/server/partial/_latest-blogs-server.html
+++ b/templates/server/partial/_latest-blogs-server.html
@@ -28,7 +28,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#server-latest",

--- a/templates/server/partial/_server-footer.html
+++ b/templates/server/partial/_server-footer.html
@@ -52,7 +52,7 @@
 </div>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -26,7 +26,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";


### PR DESCRIPTION
## Done

- Continuation of https://github.com/canonical/ubuntu.com/pull/16402

## QA

- Pick a demo listed below and run the following: `curl -sI https://ubuntu-com-16412.demos.haus/ | grep -i content-security-policy | tr ';' '\n' | grep script-src`
- See that nonce-<id> shows up in the response
- Check the pages still load as expected
- Demo list:
  - https://ubuntu-com-16412.demos.haus/ai
  - https://ubuntu-com-16412.demos.haus/azure
  - https://ubuntu-com-16412.demos.haus/core
  - https://ubuntu-com-16412.demos.haus/k8s

## Issue / Card

Partial work towards completing WD-36594
