### PR TITLE
fix(WD-36936): Copy update replace download links for Nvidia Jetson

### DIFF
--- a/templates/download/nvidia-jetson/tab-1-jetson-agx-orin.html
+++ b/templates/download/nvidia-jetson/tab-1-jetson-agx-orin.html
@@ -67,7 +67,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button"
-               href="https://cdimage.ubuntu.com/nvidia-tegra/ubuntu-core/22/stable/manual/ubuntu-core-22-arm64+tegra-jetson.img.xz"
+               href="https://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-core-22-arm64+tegra-jetson.img.xz"
                aria-label="Download Ubuntu Core 22 for Jetson AGX Orin">
               Download
             </a>

--- a/templates/download/nvidia-jetson/tab-2-jetson-orin-nano.html
+++ b/templates/download/nvidia-jetson/tab-2-jetson-orin-nano.html
@@ -68,7 +68,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button"
-               href="https://cdimage.ubuntu.com/nvidia-tegra/ubuntu-core/22/stable/manual/ubuntu-core-22-arm64+tegra-jetson.img.xz"
+               href="https://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-core-22-arm64+tegra-jetson.img.xz"
                aria-label="Download Ubuntu Core 22 for Jetson Orin Nano">
               Download
             </a>

--- a/templates/download/nvidia-jetson/tab-3-jetson-orin-nx.html
+++ b/templates/download/nvidia-jetson/tab-3-jetson-orin-nx.html
@@ -69,7 +69,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button"
-               href="https://cdimage.ubuntu.com/nvidia-tegra/ubuntu-core/22/stable/manual/ubuntu-core-22-arm64+tegra-jetson.img.xz"
+               href="https://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-core-22-arm64+tegra-jetson.img.xz"
                aria-label="Download Ubuntu Core 22 for Jetson Orin NX">
               Download
             </a>


### PR DESCRIPTION
## Done

- Replaced links as per [copydoc](https://docs.google.com/document/d/1DHLqBbo6xIHDp-Uc8ngo1t5-GJgeTdTVwBvZRIKyZ0Y/edit?tab=t.0).

## QA

- Open the [DEMO](https://ubuntu-com-16413.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/nvidia-jetson
- Confirm the Ubuntu Core download links are replaced

## Issue / Card

Fixes [WD-36936](https://warthogs.atlassian.net/browse/WD-36936) [WD-36936](https://warthogs.atlassian.net/browse/WD-36936)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36936]: https://warthogs.atlassian.net/browse/WD-36936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
