### PR TITLE
feat: add CSP nonce to inline scripts and remove unsafe-inline from script directive 

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -555,7 +555,7 @@
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   {# djlint:off #}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     const productsData = {{ products_data | tojson | safe }};
   </script>
   {# djlint:off #}

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -259,7 +259,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var downloadForm = document.querySelector(".js-download");
       if (downloadForm) {

--- a/templates/appliance/shared/_download_widget.html
+++ b/templates/appliance/shared/_download_widget.html
@@ -11,7 +11,7 @@
     <a href="/appliance/{{app}}/raspberry-pi" class="p-button--positive p-form__control js-download-button">Download</a>
   </div>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
   (function () {
     var downloadForm = document.querySelector(".js-download");
     if (downloadForm) {

--- a/templates/appliance/shared/_verify-checksums-pc.html
+++ b/templates/appliance/shared/_verify-checksums-pc.html
@@ -13,7 +13,7 @@
   </span>
 </p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Closes dropdown when click is registered outside of the tooltip
   function toggleChecksumDropdown() {
     const toggleControl = document.querySelector(".js-checksum-toggle");

--- a/templates/appliance/shared/_verify-checksums.html
+++ b/templates/appliance/shared/_verify-checksums.html
@@ -13,7 +13,7 @@
   </span>
 </p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Closes dropdown when click is registered outside of the tooltip
   function toggleChecksumDropdown() {
     const toggleControl = document.querySelector(".js-checksum-toggle");

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1397,7 +1397,7 @@
       {# include "ubuntu/takeovers/_footer_homepage.html" #}
     {% endblock footer_content %}
 
-    <script type="module">
+    <script type="module" nonce="{{ csp_nonce }}">
       const testTakeover = document.getElementById('test-takeover');
       const mainTakeover = document.getElementById('takeover');
 

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -194,7 +194,7 @@
     {% endwith %}
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const tabs = document.querySelectorAll('.p-tabs__link');
       const panels = document.querySelectorAll('[role="tabpanel"]');

--- a/templates/certified/platforms/platform-details.html
+++ b/templates/certified/platforms/platform-details.html
@@ -139,7 +139,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', () => {
     const table = document.getElementById('configTable');
     const upButton = document.getElementById('upButton');

--- a/templates/cloud/public-cloud-survey.html
+++ b/templates/cloud/public-cloud-survey.html
@@ -35,5 +35,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
+<script nonce="{{ csp_nonce }}">(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
 {% endblock %}

--- a/templates/community/circles.html
+++ b/templates/community/circles.html
@@ -170,7 +170,7 @@ meta_copydoc %}
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   <script src="{{ versioned_static('js/dist/leaflet.js') }}"></script>
   {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var mapMarker = {{ map_markers | tojson | e }}
 
     function initMap(mapSelector) {

--- a/templates/community/events.html
+++ b/templates/community/events.html
@@ -217,7 +217,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const sections = Array.from(document.querySelectorAll('.p-equal-height-row--wrap'));
       const perPage = 12;

--- a/templates/community/uwn.html
+++ b/templates/community/uwn.html
@@ -87,7 +87,7 @@
   </div>
 
   <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener("DOMContentLoaded", () => {
       document.querySelector(".js-drawer-toggle").classList.remove("u-hide");
     })

--- a/templates/desktop/partial/_desktop-latest-news.html
+++ b/templates/desktop/partial/_desktop-latest-news.html
@@ -26,7 +26,7 @@
 </section>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#desktop-latest-articles",

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -126,7 +126,7 @@
       </div>
     {% endif %}
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function clearFilters() {
       const clearFiltersButton = document.querySelector(".js-clear-filters");
       window.location.assign("/engage");

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -666,7 +666,7 @@
     attrs={"class": "p-image-container__image",}) | safe
   }}
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   function rotateRoboticsHeroImage() {
     const roboticsImages = [
       "https://assets.ubuntu.com/v1/b4316d3f-hero-drone.png",

--- a/templates/robotics/thank-you.html
+++ b/templates/robotics/thank-you.html
@@ -15,7 +15,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -166,12 +166,12 @@
   </div>
 
   <script src="/static/js/src/modal.js"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       initModals('#modal', '[aria-controls=modal]', false)
     })();
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Handles form submissions
     (function() {
       const form = document.querySelector("#subscription-centre");
@@ -209,7 +209,7 @@
       });
     })()
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Setup search
     (function() {
       const subsContainer = document.querySelector("#subscriptions-list");

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -602,7 +602,7 @@
 
   <script src="{{ versioned_static('js/dist/flickity.pkgd.min.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     initCarousel('#carousel_target', '#carousel-next', '#carousel-previous');
 
     function initCarousel(carouselSelector, nextSelector, previousSelector) {

--- a/templates/summit/shared/_latest-blogs_summit.html
+++ b/templates/summit/shared/_latest-blogs_summit.html
@@ -24,7 +24,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>  
+  <script nonce="{{ csp_nonce }}">  
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#ubuntu-summit-latest",

--- a/templates/tests/_thank-you.html
+++ b/templates/tests/_thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -904,7 +904,7 @@
   <!-- twitter tracking code -->
   <script src="https://platform.twitter.com/oct.js"></script>
   <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const tabGroups = document.querySelectorAll('.p-tabs');
 
@@ -935,7 +935,7 @@
       });
     });
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     twttr.conversion.trackPid('l4pwm');
   </script>
   <noscript>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -35,7 +35,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -175,13 +175,13 @@
 
   <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     if (window.location.hash == "#0") {
       window.location.hash == "#welcome";
     }
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var polls = document.querySelectorAll('.poll');
 

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -361,7 +361,7 @@
     </section>
   
     <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         articlesContainerSelector: "#ubuntu-wsl-latest",
         articleTemplateSelector: "#blog-template",
@@ -373,7 +373,7 @@
     </script>
   
     <script src="/static/js/src/render-tutorials.js" type="text/javascript"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       document.addEventListener("DOMContentLoaded", function() {
         renderTutorials('wsl');
       });

--- a/templates/wsl/organizations.html
+++ b/templates/wsl/organizations.html
@@ -219,7 +219,7 @@
   ) }}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       /*

--- a/templates/wsl/thank-you.html
+++ b/templates/wsl/thank-you.html
@@ -30,7 +30,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -63,7 +63,6 @@ CSP = {
         "*.g.doubleclick.net",
         "extend.vimeocdn.com",
         "tracking-api.g2.com",
-        "'unsafe-inline'",
     ],
     "font-src": [
         "'self'",
@@ -81,7 +80,6 @@ CSP = {
         "*.livechat-static.com",
         "'unsafe-eval'",
         "'unsafe-hashes'",
-        "'unsafe-inline'",
     ],
     "connect-src": [
         "'self'",


### PR DESCRIPTION
## Done

- Continuation of https://github.com/canonical/ubuntu.com/pull/16402, final pr

## QA

- Pick a demo listed below and run the following: `curl -sI https://ubuntu-com-16414.demos.haus/ | grep -i content-security-policy | tr ';' '\n' | grep script-src`
- See that nonce-<id> shows up in the response
- Check the pages still load as expected
- Demo list:
  - https://ubuntu-com-16414.demos.haus/about/release-cycle
  - https://ubuntu-com-16414.demos.haus/wsl
  - https://ubuntu-com-16414.demos.haus/certified
  - https://ubuntu-com-16414.demos.haus/engage
  - https://ubuntu-com-16414.demos.haus/tutorials

## Issue / Card

Partial work towards completing WD-36594


