### PR TITLE
chore: update text and links on /download/qualcomm-iot/tabs

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -2,7 +2,7 @@
   <div class="p-section--shallow">
     <div class="row">
       <div class="col-3">
-        <h2 class="u-hide--small">Qualcomm Dragonwing™ Evaluation Kit IQ-9075 (EVK)</h2>
+        <h2 class="u-hide--small">Qualcomm Dragonwing™ IQ-9075 Evaluation Kit (EVK)</h2>
       </div>
       <div class="col-6">
         <div class="p-image-container is-highlighted">

--- a/templates/download/qualcomm-iot/tabs/evaluation-kit3-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit3-tab.html
@@ -21,10 +21,10 @@
   <hr class="p-rule--muted" />
   <div class="row">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu 25.10</h3>
+      <h3 class="p-heading--5">Ubuntu 26.04</h3>
     </div>
     <div class="col-6">
-      <p>This is an early availability (EA) release of the Ubuntu 25.10 image on the Qualcomm Dragonwing™ IQ-X7181 Evaluation Kit (EVK).
+      <p>This is an early availability (EA) release of the Ubuntu 26.04 image on the Qualcomm Dragonwing™ IQ-X7181 Evaluation Kit (EVK).
       </p>
       <div class="p-section--shallow">
         <div class="row">
@@ -36,8 +36,8 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-25.10/ubuntu-25.10-x01/ubuntu-desktop-25.10/"
-               title="Download Ubuntu Desktop 25.10">Download</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-26.04/ubuntu-26.04-x02/ubuntu-desktop-26.04/"
+               title="Download Ubuntu Desktop 26.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
@@ -47,8 +47,8 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-25.10/ubuntu-25.10-x01/ubuntu-server-25.10/"
-               title="Download Ubuntu Server 25.10">Download</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-26.04/ubuntu-26.04-x02/ubuntu-server-26.04/"
+               title="Download Ubuntu Server 26.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
@@ -58,7 +58,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button"
-               href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/X1E80100/IQ-X.1.3-Ver.1.1/IQ-X.1.3-Ver.1.1-ubuntu-X1E80100-nhlos-bins.tar.gz"
+               href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/X1E80100/IQ-X.1.6-Ver.1.1/IQ-X.1.6-Ver.1.1-ubuntu-X1E80100-nhlos-bins.tar.gz"
                title=" Download boot firmware">Download</a>
           </div>
         </div>
@@ -66,19 +66,19 @@
 
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu 25.10 for Qualcomm Dragonwing <a
+          Get started with Ubuntu 26.04 for Qualcomm Dragonwing <a
           href="https://www.qualcomm.com/internet-of-things/products/iq-x-series"
           title="Read more about IQ-X">IQ-X</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 25.10 for Qualcomm Dragonwing IQ-X7181 Evaluation Kit (EVK) <a
+          Ubuntu 26.04 for Qualcomm Dragonwing IQ-X7181 Evaluation Kit (EVK) <a
           href="https://docs.qualcomm.com/doc/80-77183-266/80-77183-266.pdf"
-          title="Read image installation instructions of Ubuntu 25.10 for IQ-X7181">image installation instructions</a>
+          title="Read image installation instructions of Ubuntu 26.04 for IQ-X7181">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 25.10 for Qualcomm Dragonwing IQ-X7181 Evaluation Kit (EVK) <a
-          href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-25.10/ubuntu-25.10-x01/Ubuntu_25.10_Qualcomm_Dragonwing_IQ-X7181_Evaluation_Kit_Release_Notes_v1.0.pdf"
-          title="Read full release notes of Ubuntu 25.10 for IQ-X7181">release
+          Ubuntu 26.04 for Qualcomm Dragonwing IQ-X7181 Evaluation Kit (EVK) <a
+          href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-26.04/ubuntu-26.04-x02/Ubuntu_26.04_Qualcomm_Dragonwing_IQ-X7181_Evaluation_Kit_Release_Notes.pdf"
+          title="Read full release notes of Ubuntu 26.04 for IQ-X7181">release
           notes</a>
         </li>
       </ul>


### PR DESCRIPTION

## Done

- Updated ` /download/qualcomm-iot/tabs` as requested by this [copy doc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0)

## QA

- Open the [DEMO](https://ubuntu-com-16416.demos.haus/download/qualcomm-iot#evaluation-kit3)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/qualcomm-iot#rb3-gen2
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes # [WD-36942](https://warthogs.atlassian.net/browse/WD-36942) 

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36942]: https://warthogs.atlassian.net/browse/WD-36942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ