### PR TITLE
Update Summit pages after Summit 26.04

### DIFF
--- a/templates/summit/call-for-collaboration.html
+++ b/templates/summit/call-for-collaboration.html
@@ -26,7 +26,7 @@
       </p>
       <div class="p-cta-block">
         <a class="p-button--positive"
-           href="https://ubu.link/ubuntusummit-extended">Organize an Ubuntu Summit Extended</a>
+           href="https://ubu.link/ubuntusummit-cfp">Submit your abstract</a>
       </div>
     {%- endif -%}
   {% endcall -%}
@@ -37,9 +37,9 @@
         <hr class="p-rule" />
         <div class="col">
           <h2>
-            Ubuntu Summit 26.04
+            Ubuntu Summit 26.10
             <br />
-            May 27-28
+            Nov 12-13
             <br />
             Online
           </h2>

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <section class="p-strip u-fixed-width">
-    <h1 class="p-heading--display">Ubuntu Summit 26.04</h1>
+    <h1 class="p-heading--display">Ubuntu Summit 26.10</h1>
   </section>
   <section class="p-section">
     <div class="p-section--shallow">

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -20,7 +20,7 @@
       <div class="row--50-50">
         <hr class="p-rule" />
         <div class="col">
-          <h2 class="p-heading--1">May 27-28</h2>
+          <h2 class="p-heading--1">Nov 12-13</h2>
           <h3 class="p-heading--2">Online</h3>
         </div>
         <div class="col">
@@ -33,7 +33,7 @@
           </p>
           <div class="p-cta-block">
             <a href="https://discourse.ubuntu.com/t/register-for-ubuntu-summit/65270" class="p-button--positive">Register for the Summit</a>
-            <a href="https://discourse.ubuntu.com/t/ubuntu-summit-26-04-timetable/81507" class="p-button">View the timetable</a>
+            <a href="/summit/call-for-collaboration" class="p-button">Find out how you can contribute</a>
           </div>
         </div>
       </div>
@@ -44,8 +44,8 @@
           <iframe width="560" 
                   height="315" 
                   class="u-embedded-media__element"
-                  src="https://www.youtube.com/embed/gKMz7FVPJjo?si=2PPT29IJJ6KV59Ja&autoplay=1&mute=1&loop=1" 
-                  title="Ubuntu Summit 25.10 Highlights" 
+                  src="https://www.youtube.com/embed/tErujp4RAWQ?si=lXQgGMoO8JA0dlZB&autoplay=1&mute=1&loop=1" 
+                  title="Ubuntu Summit 26.04 Highlights" 
                   frameborder="0" 
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                   referrerpolicy="strict-origin-when-cross-origin" 

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -44,7 +44,7 @@
           <iframe width="560" 
                   height="315" 
                   class="u-embedded-media__element"
-                  src="https://www.youtube.com/embed/tErujp4RAWQ?si=lXQgGMoO8JA0dlZB&autoplay=1&mute=1&loop=1" 
+                  src="https://www.youtube.com/embed/tErujp4RAWQ?si=lXQgGMoO8JA0dlZB&autoplay=1&mute=1&loop=1&playlist=tErujp4RAWQ" 
                   title="Ubuntu Summit 26.04 Highlights" 
                   frameborder="0" 
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 


### PR DESCRIPTION
## Done

- On /summit: updated event dates, replaced timetable link with collaboration call link, and changed video source for highlights. 
- On /call-for-collaboration: updated event dates

## QA

- Open the [DEMO](https://ubuntu-com-16418.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check against the copydocs below
- [/summit copydoc](https://docs.google.com/document/d/1lj-xPVQjWqo2J_eZ-3ldKhJHj6RQ0Cwmk_Mr4QA4UTY/edit?tab=t.drdrmoltf7ot#heading=h.hcdudj91eqh4)
- [/summit/call-for-collaboration](https://docs.google.com/document/d/1pjIpFWL7yu6Jc2gZGqCRvckd4clPVrLtGpRwTaw9-CY/edit?tab=t.dxdptoffij7w)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

