### PR TITLE
Feat: remove `unsafe-inline` csp rule 

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -117,6 +117,22 @@ jobs:
           echo "The following files have changed: $CHANGED_FILES"
           djlint $CHANGED_FILES --lint --profile="jinja"
 
+  check-csp-nonce:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check inline scripts have CSP nonce attribute
+        run: |
+          if grep -rn '<script\b[^>]*>' templates/ \
+            | grep -v 'nonce=' \
+            | grep -v 'src=' \
+            | grep -v 'type="application/'; then
+            echo "Found inline <script> tags without nonce attribute"
+            exit 1
+          fi
+
   validate-deploy:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -119,9 +119,13 @@ jobs:
 
   check-csp-nonce:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check inline scripts have CSP nonce attribute
         run: |

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -555,7 +555,7 @@
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   {# djlint:off #}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     const productsData = {{ products_data | tojson | safe }};
   </script>
   {# djlint:off #}

--- a/templates/account/checkout.html
+++ b/templates/account/checkout.html
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     </script>
     <script src="{{ versioned_static('js/dist/shopCheckout.js') }}" type="module"></script>

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -102,7 +102,7 @@
   </section>
   {% include "account/invoices/_edit_billing_modal.html" %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const prices = document.querySelectorAll('.js-format-price');
     prices.forEach(price => {
       const amount = price.innerText.split(' ')[0];
@@ -125,7 +125,7 @@
     })
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.accountId = "{{ account_id }}";
   </script>
   <script src="{{ versioned_static('js/dist/account-billing.js') }}"></script>

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -88,14 +88,14 @@
   {% include "account/payment-methods/_confirm-remove-modal.html" %}
 
   <script src="https://js.stripe.com/v3/"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     window.accountId = "{{ account_id }}";
     window.pendingPurchaseId = "{{ pending_purchase_id }}";
     window.hasPaymentMethod = {% if default_payment_method.id %}true{% else %}false{% endif %};
   </script>
   <script src="/static/js/src/modal.js"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     initModals('#remove-payment-modal', '[aria-controls=remove-payment-modal]', false)
   </script>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -298,7 +298,7 @@
 </div>
 
 <script src="https://js.stripe.com/v3/"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
 </script>
 <script src="{{ versioned_static('js/dist/ua-payment-modal.js') }}" type="module" defer></script>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -31,7 +31,7 @@ endblock meta_copydoc %}
   </section>
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     dataLayer.push({
       event: "GAEvent",
       eventCategory: "Advantage",
@@ -52,7 +52,7 @@ endblock meta_copydoc %}
   </div>
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
   localStorage.setItem("isTechnical", {{ is_technical|lower }});
   localStorage.setItem("isInMaintenance", {{ is_in_maintenance|lower }});

--- a/templates/advantage/offers/index.html
+++ b/templates/advantage/offers/index.html
@@ -16,7 +16,7 @@
 
 <script src="/static/js/dist/advantageOffers.js" type="module"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = '{{ get_stripe_publishable_key }}';
 </script>
 

--- a/templates/advantage/subscribe/blender/index.html
+++ b/templates/advantage/subscribe/blender/index.html
@@ -19,7 +19,7 @@
   defer
 ></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   window.blenderProductList = {
     {% for listing_id, listing in product_listings.items() %}
       "{{ listing.product.id }}-{{ listing.period }}": {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -35,7 +35,7 @@ endblock meta_copydoc %} {% block content %}
   defer
 ></script>
 
-<script defer>
+<script defer nonce="{{ csp_nonce }}">
   var productList = {
     {% for listing_id, listing in product_listings.items() %}
       "{{ listing.product.id }}-{{ listing.period }}": {

--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -46,7 +46,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -259,7 +259,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var downloadForm = document.querySelector(".js-download");
       if (downloadForm) {

--- a/templates/appliance/shared/_download_widget.html
+++ b/templates/appliance/shared/_download_widget.html
@@ -11,7 +11,7 @@
     <a href="/appliance/{{app}}/raspberry-pi" class="p-button--positive p-form__control js-download-button">Download</a>
   </div>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
   (function () {
     var downloadForm = document.querySelector(".js-download");
     if (downloadForm) {

--- a/templates/appliance/shared/_verify-checksums-pc.html
+++ b/templates/appliance/shared/_verify-checksums-pc.html
@@ -13,7 +13,7 @@
   </span>
 </p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Closes dropdown when click is registered outside of the tooltip
   function toggleChecksumDropdown() {
     const toggleControl = document.querySelector(".js-checksum-toggle");

--- a/templates/appliance/shared/_verify-checksums.html
+++ b/templates/appliance/shared/_verify-checksums.html
@@ -13,7 +13,7 @@
   </span>
 </p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Closes dropdown when click is registered outside of the tooltip
   function toggleChecksumDropdown() {
     const toggleControl = document.querySelector(".js-checksum-toggle");

--- a/templates/aws/shared/_aws-pie-chart.html
+++ b/templates/aws/shared/_aws-pie-chart.html
@@ -5,7 +5,7 @@
 
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function drawChart() {
   'use strict';
   document.querySelector('#ubuntu-pie').innerHTML = "";

--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -32,7 +32,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -322,7 +322,7 @@
   </template>
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-posts",
       articleTemplateSelector: "#articles-template",

--- a/templates/azure/shared/_latest-blogs-azure.html
+++ b/templates/azure/shared/_latest-blogs-azure.html
@@ -28,7 +28,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#azure-latest",

--- a/templates/azure/thank-you.html
+++ b/templates/azure/thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1397,7 +1397,7 @@
       {# include "ubuntu/takeovers/_footer_homepage.html" #}
     {% endblock footer_content %}
 
-    <script type="module">
+    <script type="module" nonce="{{ csp_nonce }}">
       const testTakeover = document.getElementById('test-takeover');
       const mainTakeover = document.getElementById('takeover');
 

--- a/templates/blender/thank-you.html
+++ b/templates/blender/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -17,7 +17,7 @@
   </form>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   var select = document.querySelector('.js-submit-on-change');
   select.addEventListener('change', function(e) {
     var form = this.closest('form');

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -148,7 +148,7 @@
   {% endif %}
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Get all loaded cards
   var cards = document.getElementsByClassName('js-product-card');
   if (cards) {

--- a/templates/ceph/shared/_latest-news-ceph.html
+++ b/templates/ceph/shared/_latest-news-ceph.html
@@ -26,7 +26,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-<script>  
+<script nonce="{{ csp_nonce }}">  
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#ceph-install-latest",

--- a/templates/ceph/thank-you.html
+++ b/templates/ceph/thank-you.html
@@ -34,7 +34,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -56,7 +56,7 @@
     </div>
   </noscript>
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -194,7 +194,7 @@
     {% endwith %}
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const tabs = document.querySelectorAll('.p-tabs__link');
       const panels = document.querySelectorAll('[role="tabpanel"]');

--- a/templates/certified/platforms/platform-details.html
+++ b/templates/certified/platforms/platform-details.html
@@ -139,7 +139,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', () => {
     const table = document.getElementById('configTable');
     const upButton = document.getElementById('upButton');

--- a/templates/cloud/public-cloud-survey.html
+++ b/templates/cloud/public-cloud-survey.html
@@ -35,5 +35,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
+<script nonce="{{ csp_nonce }}">(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
 {% endblock %}

--- a/templates/community/circles.html
+++ b/templates/community/circles.html
@@ -170,7 +170,7 @@ meta_copydoc %}
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   <script src="{{ versioned_static('js/dist/leaflet.js') }}"></script>
   {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var mapMarker = {{ map_markers | tojson | e }}
 
     function initMap(mapSelector) {

--- a/templates/community/events.html
+++ b/templates/community/events.html
@@ -217,7 +217,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const sections = Array.from(document.querySelectorAll('.p-equal-height-row--wrap'));
       const perPage = 12;

--- a/templates/community/uwn.html
+++ b/templates/community/uwn.html
@@ -87,7 +87,7 @@
   </div>
 
   <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener("DOMContentLoaded", () => {
       document.querySelector(".js-drawer-toggle").classList.remove("u-hide");
     })

--- a/templates/contact-us/thank-you.html
+++ b/templates/contact-us/thank-you.html
@@ -541,7 +541,7 @@
     <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
 
     <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
         canonicalLatestNews.fetchLatestNews({
             imageClasses: ["p-image-container__image"],
             limit: "4",
@@ -553,7 +553,7 @@
         })
     </script>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
         function stringifyCustomFields() {
             const checkboxes = document.querySelectorAll(".js-checkbox");
             const textarea = document.getElementById("ubuntu_desktop_usage");
@@ -576,7 +576,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical - contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -17,7 +17,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -32,7 +32,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -459,7 +459,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function setUpDynamicSideNav() {
       const questions = Array.prototype.slice.call(
         document.querySelectorAll(".question-heading")

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/credentials/base_cred.html
+++ b/templates/credentials/base_cred.html
@@ -16,7 +16,7 @@
         <p class="p-notification__message" id="cred-maintenance-message"></p>
       </div>
     </div>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       const dateTimeFormatter = (dateTime, locale = 'default') => {
         const date = new Date(dateTime);
         const options = {

--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -22,7 +22,7 @@
             src="{{ url }}"></iframe>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const setIframeHeight = () => {
       // TODO: Account for header height change
       const navHeight = document.getElementById("navigation").clientHeight;

--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -369,7 +369,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const anchorTags = document.querySelectorAll('.custom-link');
     anchorTags.forEach(anchor => {
       anchor.removeAttribute('onclick');

--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -59,7 +59,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function disableButton(event) {
       document.getElementById('activate-button').disabled=true;
     }

--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -98,7 +98,7 @@ meta_copydoc %}
   </section>
 
   {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     let selectedTimezone;
     {% if timezone and timezone != "" %}
     selectedTimezone = "{{ timezone }}";

--- a/templates/credentials/self-study.html
+++ b/templates/credentials/self-study.html
@@ -339,7 +339,7 @@
       </div>
     </div>
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const setupTabs = () => {
       var keys = {
         left: 'ArrowLeft',

--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -132,7 +132,7 @@
     </section>
   </form>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     const exams = JSON.parse('{{ exams | tojson }}');
     const isStaging = JSON.parse('{{ is_staging | tojson }}');

--- a/templates/credentials/shop/keys.html
+++ b/templates/credentials/shop/keys.html
@@ -86,7 +86,7 @@ meta_copydoc %}
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const cueKeyProduct = JSON.parse('{{cue_key_product | tojson }}');
 
     function handleSubmit() {

--- a/templates/credentials/sign-up.html
+++ b/templates/credentials/sign-up.html
@@ -9,7 +9,7 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function getSubmitButton() {
       return document.getElementById('formSubmitButton');
     }

--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -81,7 +81,7 @@
       </div>
     </div>
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var keys = {
         left: 'ArrowLeft',

--- a/templates/credentials/thank-you.html
+++ b/templates/credentials/thank-you.html
@@ -40,7 +40,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/credentials/your-exams.html
+++ b/templates/credentials/your-exams.html
@@ -130,7 +130,7 @@
     {% endif %}
   {% endfor %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function setTooltipPosition(trigger, container) {
       const triggerRect = trigger.getBoundingClientRect();
       let tooltipX = triggerRect.x;

--- a/templates/dell/thank-you.html
+++ b/templates/dell/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/desktop/partial/_desktop-latest-news.html
+++ b/templates/desktop/partial/_desktop-latest-news.html
@@ -26,7 +26,7 @@
 </section>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#desktop-latest-articles",

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -218,7 +218,7 @@ meta_copydoc %}
 
   {% include "download/shared/_footer.html" %}
 
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     function setUpTogglableSideNav() {
       var navigationDrawer = document.querySelector("#drawer");
       var navigationDrawerToggles = Array.prototype.slice.call(

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -65,7 +65,7 @@
                 <span class="u-text--muted">{{ releases_yaml.lts.iso_download_size }}</span>
               {% endif %}
 
-              <script>
+              <script nonce="{{ csp_nonce }}">
                 performance.mark("Download (Desktop) button rendered")
               </script>
             </div>
@@ -84,7 +84,7 @@
                 <span class="u-text--muted">{{ releases_yaml.lts.arm_iso_download_size }}</span>
               {% endif %}
 
-              <script>
+              <script nonce="{{ csp_nonce }}">
                 performance.mark("Download (Desktop) button rendered")
               </script>
             </div>
@@ -228,7 +228,7 @@
                   <span class="u-text--muted">{{ releases_yaml.latest.iso_download_size }}</span>
                 {% endif %}
 
-                <script>
+                <script nonce="{{ csp_nonce }}">
                   performance.mark("Download (Desktop) button rendered")
                 </script>
               </div>
@@ -247,7 +247,7 @@
                   <span class="u-text--muted">{{ releases_yaml.latest.arm_iso_download_size }}</span>
                 {% endif %}
 
-                <script>
+                <script nonce="{{ csp_nonce }}">
                   performance.mark("Download (Desktop) button rendered")
                 </script>
               </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -17,7 +17,7 @@
       opacity: 0 !important
     }
   </style>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function(a, s, y, n, c, h, i, d, e) {
       s.className += ' ' + y;
       h.start = 1 * new Date;
@@ -314,7 +314,7 @@
 
   {% if version %}
     <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
+    <script defer nonce="{{ csp_nonce }}">
       var architecture = '{{ architecture }}';
       var version = '{{ version }}';
 

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -318,7 +318,7 @@
     </template>
   </section>
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -165,7 +165,7 @@
   </section>
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -482,7 +482,7 @@
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -237,7 +237,7 @@
   </section>
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",
@@ -252,7 +252,7 @@
 {% block footer_extra %}
   <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
-  <script defer>
+  <script defer nonce="{{ csp_nonce }}">
     var architecture = '{{ architecture }}';
     var version = '{{ version }}';
     if (version) {

--- a/templates/download/shared/_everywhere.html
+++ b/templates/download/shared/_everywhere.html
@@ -146,7 +146,7 @@
       </div>
     </section>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       var all = document.querySelectorAll('.js-everywhere');
       var linux = document.querySelectorAll('.js-linux');
       var macos = document.querySelectorAll('.js-macos');

--- a/templates/download/shared/_instructions-resources.html
+++ b/templates/download/shared/_instructions-resources.html
@@ -50,7 +50,7 @@
 </section>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/download/shared/_latest-blogs_download.html
+++ b/templates/download/shared/_latest-blogs_download.html
@@ -30,7 +30,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-<script>  
+<script nonce="{{ csp_nonce }}">  
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#ubuntu-desktop-latest",

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -29,7 +29,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   var multipassOScta = document.getElementById('multipass-os-cta');
   var baseInstallURL = multipassOScta.getAttribute('href');
   var ctaSpan = multipassOScta.querySelector('span')

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -133,7 +133,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   /**
     Toggles modal dialog.
     @param {HTMLElement} event modal Modal dialog to show or hide.

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -33,7 +33,7 @@ You can
 </div>
 
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   function verifyDownloadContent() {
     var targetControls = document.getElementById("menu-4");
     if (targetControls) {

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -24,7 +24,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -184,12 +184,12 @@
 
 {% block footer_extra %}
   {% if architecture == 'pro' %}
-    <script defer>
+    <script defer nonce="{{ csp_nonce }}">
       window.location.href = '{{ pro_download_url }}';
     </script>
   {% elif version %}
     <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
+    <script defer nonce="{{ csp_nonce }}">
       var architecture = '{{ architecture }}';
       var version = '{{ version }}';
 

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -126,7 +126,7 @@
       </div>
     {% endif %}
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function clearFilters() {
       const clearFiltersButton = document.querySelector(".js-clear-filters");
       window.location.assign("/engage");

--- a/templates/gcp/thank-you.html
+++ b/templates/gcp/thank-you.html
@@ -33,7 +33,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/hpc/thank-you.html
+++ b/templates/hpc/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/ibm/thank-you.html
+++ b/templates/ibm/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/internet-of-things/contact-us-hannover.html
+++ b/templates/internet-of-things/contact-us-hannover.html
@@ -139,7 +139,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   function createMessage() {
     var message = "";
     var formFields = document.querySelectorAll(".js-formfield");

--- a/templates/internet-of-things/shared/_latest-news-iot.html
+++ b/templates/internet-of-things/shared/_latest-news-iot.html
@@ -32,7 +32,7 @@
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 
 {# djlint:off #}
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#iot-latest",

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -32,7 +32,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/kubernetes/charmed-k8s/docs/base_docs.html
+++ b/templates/kubernetes/charmed-k8s/docs/base_docs.html
@@ -18,7 +18,7 @@
         </div>
       </aside>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
       // Select the active navigation item
       var navigation = document.getElementById('docs-navigation');
       var links = navigation.getElementsByTagName('a');
@@ -31,7 +31,7 @@
       };
       </script>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
       // Toggle mobile sidebar nav
       var toggle = document.querySelector('.p-sidebar__toggle');
       var sidebarContent = document.querySelector('.p-sidebar__content');

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -612,7 +612,7 @@
 
   {{ load_form("/kubernetes") | safe }}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const switchElement = document.querySelector('.js-discoverer-switch');
       const discovererText = document.querySelector('.js-discoverer-text');

--- a/templates/macros/_vf-latest-news.jinja
+++ b/templates/macros/_vf-latest-news.jinja
@@ -81,7 +81,7 @@
 
     {# djlint: off #}
     <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews(
         {
           articlesContainerSelector: "#latest-articles-container",

--- a/templates/managed-infrastructure/thank-you.html
+++ b/templates/managed-infrastructure/thank-you.html
@@ -14,7 +14,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/managed/thank-you.html
+++ b/templates/managed/thank-you.html
@@ -14,7 +14,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -982,7 +982,7 @@
   {{ load_form('/openstack') | safe }}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#latest-articles",
       articleTemplateSelector: "#article-template",

--- a/templates/openstack/shared/_openstack-aws-pie-chart.html
+++ b/templates/openstack/shared/_openstack-aws-pie-chart.html
@@ -2,7 +2,7 @@
 
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 // FF/Opera does not support offsetWidth for tspan's. If undefined
 // use the getBoundingClientRect method.
 function getObjWidth(obj) {

--- a/templates/openstack/shared/_openstack-pie-chart.html
+++ b/templates/openstack/shared/_openstack-pie-chart.html
@@ -5,7 +5,7 @@
 
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function drawChart() {
   'use strict';
   document.querySelector('#ubuntu-pie').innerHTML = "";

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -54,7 +54,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -357,7 +357,7 @@ layout='50/50'
 
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   const personalTab = document.getElementById('personal');
   const enterpriseTab = document.getElementById('enterprise');
   const toggleEnterpriseSupport = ()=>{

--- a/templates/pro/attach/instructions.html
+++ b/templates/pro/attach/instructions.html
@@ -74,7 +74,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     (function () {
         var keys = {
             left: 'ArrowLeft',

--- a/templates/pro/distributor/index.html
+++ b/templates/pro/distributor/index.html
@@ -17,7 +17,7 @@
       </div>
     </div>
     <script src="{{ versioned_static('js/dist/distributor.js') }}" type="module" defer></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.channelProductList = {{ product_listings | tojson }};
       
       var accountId = "{% if account %}{{ account.id }}{% endif %}";

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -30,7 +30,7 @@
         integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
         crossorigin="anonymous"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   const ctx = document.getElementById('myChart');
   Chart.defaults.font.family = "Ubuntu";
   new Chart(ctx, {

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -19,7 +19,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -666,7 +666,7 @@
     attrs={"class": "p-image-container__image",}) | safe
   }}
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   function rotateRoboticsHeroImage() {
     const roboticsImages = [
       "https://assets.ubuntu.com/v1/b4316d3f-hero-drone.png",

--- a/templates/robotics/thank-you.html
+++ b/templates/robotics/thank-you.html
@@ -15,7 +15,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";

--- a/templates/security/compliance-automation-value-calculator/index.html
+++ b/templates/security/compliance-automation-value-calculator/index.html
@@ -395,7 +395,7 @@
   {{ load_form("/security/compliance-automation-value-calculator") | safe }}
 
   <script src="{{ versioned_static('js/src/slider-base.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Profile definitions based on actual benchmark specifications
     const profiles = {
       1: {

--- a/templates/security/cves/about.html
+++ b/templates/security/cves/about.html
@@ -388,7 +388,7 @@
       </div>
     </div>
   </section>
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     function setUpTogglableSideNav() {
       var navigationDrawer = document.querySelector("#drawer");
       var navigationDrawerToggles = Array.prototype.slice.call(

--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -567,7 +567,7 @@
     </div>
 
     <script src="{{ versioned_static('js/src/resources.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       fetchAndRenderResources(tag = "vulnerability+patching", resource = "whitepaper");
     </script>
   </section>
@@ -577,7 +577,7 @@
   <script src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
   <script src="{{ versioned_static('js/dist/cve-detail.js') }}" defer></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function handleHiddenReleasesSwitch() {
       const maintainedCount = {{ maintained_count | tojson | safe }};
       const isOnlyUpstream = {{ only_upstream | tojson | safe }};

--- a/templates/security/cves/index.html
+++ b/templates/security/cves/index.html
@@ -50,7 +50,7 @@
   {% endif %}
 
   {# djlint:off #}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ csp_nonce }}">
     const maintainedReleasesObj = {{maintained_releases | tojson | safe}};
     const ltsReleasesObj = {{lts_releases | tojson | safe}};
     const unmaintainedReleasesObj = {{unmaintained_releases | tojson | safe}};

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -550,7 +550,7 @@
 
   <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       limit: "4",

--- a/templates/security/notices/_further-reading.html
+++ b/templates/security/notices/_further-reading.html
@@ -11,7 +11,7 @@
 </template>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",

--- a/templates/security/notices/index.html
+++ b/templates/security/notices/index.html
@@ -145,7 +145,7 @@
   </section>
 
 {# djlint:off #}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   const maintainedReleasesObj = {{maintained_releases | tojson | safe}};
   const ltsReleasesObj = {{lts_releases | tojson | safe}};
   const unmaintainedReleasesObj = {{unmaintained_releases | tojson | safe}};

--- a/templates/server/maas/thank-you.html
+++ b/templates/server/maas/thank-you.html
@@ -9,7 +9,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/server/partial/_latest-blogs-server.html
+++ b/templates/server/partial/_latest-blogs-server.html
@@ -28,7 +28,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#server-latest",

--- a/templates/server/partial/_server-footer.html
+++ b/templates/server/partial/_server-footer.html
@@ -52,7 +52,7 @@
 </div>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -274,7 +274,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -1136,7 +1136,7 @@
     max-width: 100%;
   }
 </style>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 

--- a/templates/shared/_credentials-signup-sme-form.html
+++ b/templates/shared/_credentials-signup-sme-form.html
@@ -737,7 +737,7 @@
     </div>
   {% endif %}
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
   var PROGRESS_COLOUR = '#E95420';

--- a/templates/shared/_credentials-signup-tester-form.html
+++ b/templates/shared/_credentials-signup-tester-form.html
@@ -710,7 +710,7 @@
     </div>
   {% endif %}
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
   var PROGRESS_COLOUR = '#E95420';

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -599,7 +599,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -104,7 +104,7 @@
     </div>
   </form>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function stringifyCustomFields() {
       const checkboxes = document.querySelectorAll(".js-checkbox");
       const textarea = document.getElementById("ubuntu_desktop_usage");

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -83,7 +83,7 @@
   {% endif %}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#horizontal-latest-articles",

--- a/templates/shared/_share_this.html
+++ b/templates/shared/_share_this.html
@@ -1,7 +1,7 @@
 <div class="share-this">
 	<iframe title="Share on Facebook" src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20" style="border:none; overflow:hidden; height:21px; padding-right:23px;"></iframe>
 	<div class="g-plusone" data-size="medium"></div>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.___gcfg = {lang: 'en-GB'};
 
       (function() {

--- a/templates/shared/contextual_footers/_ai_further_reading.html
+++ b/templates/shared/contextual_footers/_ai_further_reading.html
@@ -12,7 +12,7 @@
 </template>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -40,7 +40,7 @@
           </div>
       </form>
       <script src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
-      <script>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+      <script nonce="{{ csp_nonce }}">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
       <!--End mc_embed_signup-->
   </div>
 </div>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -14,7 +14,7 @@
 </template>
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -65,7 +65,7 @@
   {% include "/shared/forms/form-fields.html" %}
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form[id^="mktoForm_"]').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -166,12 +166,12 @@
   </div>
 
   <script src="/static/js/src/modal.js"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       initModals('#modal', '[aria-controls=modal]', false)
     })();
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Handles form submissions
     (function() {
       const form = document.querySelector("#subscription-centre");
@@ -209,7 +209,7 @@
       });
     })()
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Setup search
     (function() {
       const subsContainer = document.querySelector("#subscriptions-list");

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -602,7 +602,7 @@
 
   <script src="{{ versioned_static('js/dist/flickity.pkgd.min.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     initCarousel('#carousel_target', '#carousel-next', '#carousel-previous');
 
     function initCarousel(carouselSelector, nextSelector, previousSelector) {

--- a/templates/summit/shared/_latest-blogs_summit.html
+++ b/templates/summit/shared/_latest-blogs_summit.html
@@ -24,7 +24,7 @@
 
 <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>  
+  <script nonce="{{ csp_nonce }}">  
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#ubuntu-summit-latest",

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -26,7 +26,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/templates/_getfeedback.html
+++ b/templates/templates/_getfeedback.html
@@ -1,5 +1,5 @@
 <!-- begin usabilla live embed code -->
-<script>
+<script nonce="{{ csp_nonce }}">
   window.lightningjs || function(n) {
     var e = "lightningjs";
 

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{ csp_nonce }}">
   const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
   if (userIDCookie !== null) {
     let idValue = userIDCookie[2];
@@ -10,7 +10,7 @@
   }
 </script>
 <!-- Google Tag Manager -->
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener('DOMContentLoaded', () => {
     /** init gtm after 2 seconds - can be adjusted */
     setTimeout(initGTM, 2000);

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -34,7 +34,7 @@
           type="text/css"
           media="print"
           href="{{ versioned_static('css/print.css') }}" />
-    <script>
+    <script nonce="{{ csp_nonce }}">
       performance.mark("Stylesheets finished");
     </script>
 

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -48,7 +48,7 @@
         <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
         <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
 
-        <script>
+        <script nonce="{{ csp_nonce }}">
           var html = document.documentElement
           html.classList.replace("no-js", "js");
         </script>

--- a/templates/templates/docs/markdown.html
+++ b/templates/templates/docs/markdown.html
@@ -55,7 +55,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
     var currentPath = window.location.pathname;
 

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -175,7 +175,7 @@
 
   <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Allows the 'onchange' listener to be used on a select field, while still being accessible.
     (function initSelect() {
       var selectField = document.querySelector("#version-select");

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -271,7 +271,7 @@
         <a href="#">Back to top</a>
       </p>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
         /* Add the page to the report a bug link */
         var bugLink = document.querySelector('#report-a-bug');
         bugLink.href += '&reported_from=' + location.href;

--- a/templates/templates/markdown/base.html
+++ b/templates/templates/markdown/base.html
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
     var currentPath = window.location.pathname;
 

--- a/templates/tests/_thank-you.html
+++ b/templates/tests/_thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -904,7 +904,7 @@
   <!-- twitter tracking code -->
   <script src="https://platform.twitter.com/oct.js"></script>
   <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const tabGroups = document.querySelectorAll('.p-tabs');
 
@@ -935,7 +935,7 @@
       });
     });
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     twttr.conversion.trackPid('l4pwm');
   </script>
   <noscript>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -35,7 +35,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -175,13 +175,13 @@
 
   <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     if (window.location.hash == "#0") {
       window.location.hash == "#welcome";
     }
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var polls = document.querySelectorAll('.poll');
 

--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -216,7 +216,7 @@
     </section>
 
     <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         articlesContainerSelector: "#ubuntu-latest",
         articleTemplateSelector: "#blog-template",

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -361,7 +361,7 @@
     </section>
   
     <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         articlesContainerSelector: "#ubuntu-wsl-latest",
         articleTemplateSelector: "#blog-template",
@@ -373,7 +373,7 @@
     </script>
   
     <script src="/static/js/src/render-tutorials.js" type="text/javascript"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       document.addEventListener("DOMContentLoaded", function() {
         renderTutorials('wsl');
       });

--- a/templates/wsl/organizations.html
+++ b/templates/wsl/organizations.html
@@ -219,7 +219,7 @@
   ) }}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       /*

--- a/templates/wsl/thank-you.html
+++ b/templates/wsl/thank-you.html
@@ -30,7 +30,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -456,20 +456,26 @@ class TestRoutes(VCRTestCase):
         )
 
     def test_csp_header_contains_nonce(self):
-        """Test that CSP header includes a non-empty nonce in script directives"""
+        """Test that CSP header includes a non-empty nonce in script
+        directives"""
         response = self.client.get("/")
         csp = response.headers.get("Content-Security-Policy", "")
         self.assertRegex(csp, r"'nonce-[a-f0-9]+'")
 
     def test_csp_nonce_in_script_directives(self):
-        """Test that nonce appears in both script-src and script-src-elem"""
+        """Test that nonce appears in both script-src and
+        script-src-elem"""
         response = self.client.get("/")
         csp = response.headers.get("Content-Security-Policy", "")
         directives = {
             d.split()[0]: d for d in csp.rstrip(";").split(";") if d.strip()
         }
-        self.assertRegex(directives.get("script-src-elem", ""), r"'nonce-[a-f0-9]+'")
-        self.assertRegex(directives.get("script-src", ""), r"'nonce-[a-f0-9]+'")
+        self.assertRegex(
+            directives.get("script-src-elem", ""), r"'nonce-[a-f0-9]+'"
+        )
+        self.assertRegex(
+            directives.get("script-src", ""), r"'nonce-[a-f0-9]+'"
+        )
 
     def test_csp_nonce_is_unique_per_request(self):
         """Test that a different nonce is generated for each request"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -456,10 +456,10 @@ class TestRoutes(VCRTestCase):
         )
 
     def test_csp_header_contains_nonce(self):
-        """Test that CSP header includes a nonce in script directives"""
+        """Test that CSP header includes a non-empty nonce in script directives"""
         response = self.client.get("/")
         csp = response.headers.get("Content-Security-Policy", "")
-        self.assertIn("nonce-", csp)
+        self.assertRegex(csp, r"'nonce-[a-f0-9]+'")
 
     def test_csp_nonce_in_script_directives(self):
         """Test that nonce appears in both script-src and script-src-elem"""
@@ -468,8 +468,8 @@ class TestRoutes(VCRTestCase):
         directives = {
             d.split()[0]: d for d in csp.rstrip(";").split(";") if d.strip()
         }
-        self.assertIn("nonce-", directives.get("script-src-elem", ""))
-        self.assertIn("nonce-", directives.get("script-src", ""))
+        self.assertRegex(directives.get("script-src-elem", ""), r"'nonce-[a-f0-9]+'")
+        self.assertRegex(directives.get("script-src", ""), r"'nonce-[a-f0-9]+'")
 
     def test_csp_nonce_is_unique_per_request(self):
         """Test that a different nonce is generated for each request"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -456,5 +456,34 @@ class TestRoutes(VCRTestCase):
         )
 
 
+    def test_csp_header_contains_nonce(self):
+        """Test that CSP header includes a nonce in script directives"""
+        response = self.client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        self.assertIn("nonce-", csp)
+
+    def test_csp_nonce_in_script_directives(self):
+        """Test that nonce appears in both script-src and script-src-elem"""
+        response = self.client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        directives = {
+            d.split()[0]: d for d in csp.rstrip(";").split(";") if d.strip()
+        }
+        self.assertIn("nonce-", directives.get("script-src-elem", ""))
+        self.assertIn("nonce-", directives.get("script-src", ""))
+
+    def test_csp_nonce_is_unique_per_request(self):
+        """Test that a different nonce is generated for each request"""
+        def get_nonce(csp):
+            for part in csp.split():
+                if part.startswith("'nonce-"):
+                    return part
+            return None
+
+        csp1 = self.client.get("/").headers.get("Content-Security-Policy", "")
+        csp2 = self.client.get("/").headers.get("Content-Security-Policy", "")
+        self.assertNotEqual(get_nonce(csp1), get_nonce(csp2))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -455,7 +455,6 @@ class TestRoutes(VCRTestCase):
             response.location,
         )
 
-
     def test_csp_header_contains_nonce(self):
         """Test that CSP header includes a nonce in script directives"""
         response = self.client.get("/")
@@ -474,6 +473,7 @@ class TestRoutes(VCRTestCase):
 
     def test_csp_nonce_is_unique_per_request(self):
         """Test that a different nonce is generated for each request"""
+
         def get_nonce(csp):
             for part in csp.split():
                 if part.startswith("'nonce-"):

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -63,7 +63,6 @@ CSP = {
         "*.g.doubleclick.net",
         "extend.vimeocdn.com",
         "tracking-api.g2.com",
-        "'unsafe-inline'",
     ],
     "font-src": [
         "'self'",
@@ -81,7 +80,6 @@ CSP = {
         "*.livechat-static.com",
         "'unsafe-eval'",
         "'unsafe-hashes'",
-        "'unsafe-inline'",
     ],
     "connect-src": [
         "'self'",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,3 +1,4 @@
+import secrets
 from typing import List
 
 import flask
@@ -36,6 +37,10 @@ from canonicalwebteam.flask_base.env import get_flask_env
 
 
 def init_handlers(app):
+    @app.before_request
+    def generate_csp_nonce():
+        flask.g.csp_nonce = secrets.token_urlsafe(16)
+
     @app.after_request
     def cache_headers(response):
         """
@@ -165,6 +170,7 @@ def init_handlers(app):
             "get_navigation": get_navigation,
             "split_list": split_list,
             "format_to_id": format_to_id,
+            "csp_nonce": flask.g.get("csp_nonce", ""),
         }
 
     def get_countries_list() -> List[dict]:
@@ -215,7 +221,14 @@ def init_handlers(app):
                 csp_str += f"{key} {csp_value}; "
             return csp_str.strip()
 
-        response.headers["Content-Security-Policy"] = get_csp_as_str(CSP)
+        nonce = flask.g.get("csp_nonce", "")
+        csp = {
+            key: values + [f"'nonce-{nonce}'"]
+            if key in ("script-src-elem", "script-src")
+            else values
+            for key, values in CSP.items()
+        }
+        response.headers["Content-Security-Policy"] = get_csp_as_str(csp)
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -223,9 +223,11 @@ def init_handlers(app):
 
         nonce = flask.g.get("csp_nonce", "")
         csp = {
-            key: values + [f"'nonce-{nonce}'"]
-            if key in ("script-src-elem", "script-src")
-            else values
+            key: (
+                values + [f"'nonce-{nonce}'"]
+                if key in ("script-src-elem", "script-src")
+                else values
+            )
             for key, values in CSP.items()
         }
         response.headers["Content-Security-Policy"] = get_csp_as_str(csp)

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -39,7 +39,7 @@ from canonicalwebteam.flask_base.env import get_flask_env
 def init_handlers(app):
     @app.before_request
     def generate_csp_nonce():
-        flask.g.csp_nonce = secrets.token_urlsafe(16)
+        flask.g.csp_nonce = secrets.token_hex(16)
 
     @app.after_request
     def cache_headers(response):


### PR DESCRIPTION
## Done

- Feat branch for removing unsafe-inline csp rule, includes the following sub PR's:
  - https://github.com/canonical/ubuntu.com/pull/16402
  - https://github.com/canonical/ubuntu.com/pull/16411
  - https://github.com/canonical/ubuntu.com/pull/16412
  - https://github.com/canonical/ubuntu.com/pull/16414
- Added CI check for inline scripts missing  

## QA

- One template was missed in the above prs and should be qa'd:
  - Run  `curl -sI https://ubuntu-com-16419.demos.haus/workshop | grep -i content-security-policy | tr ';' '\n' | grep script-src`
  - See that nonce- shows up in the response
  - Check https://ubuntu-com-16419.demos.haus/workshop still loads as expected
- For the CI check:
  - See that the action on this test branch where the attribute was deleted from an inline script does indeed fail https://github.com/canonical/ubuntu.com/actions/runs/26923808974/job/79429673356?pr=16421 


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36594
