### PR TITLE
feat: add new tabs to Renesas IoT page

### DIFF
--- a/templates/download/renesas-iot/index.html
+++ b/templates/download/renesas-iot/index.html
@@ -46,7 +46,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/download/contact-us"
+      <a href="/download/renesas-iot#get-in-touch"
          class="p-button--positive js-invoke-modal"
          aria-controls="renesas-contact-modal">Get in touch</a>
     {%- endif -%}

--- a/templates/download/renesas-iot/index.html
+++ b/templates/download/renesas-iot/index.html
@@ -88,6 +88,18 @@
                     role="tab"
                     aria-controls="renesas-rz-v2l-tab">RZ/V2L</button>
           </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="renesas-rz-g3e"
+                    role="tab"
+                    aria-controls="renesas-rz-g3e-tab">RZ/G3E</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="renesas-rz-g3s"
+                    role="tab"
+                    aria-controls="renesas-rz-g3s-tab">RZ/G3S</button>
+          </li>
         </ul>
         <!-- form dropdown for smaller screens -->
         <form class="u-hide--large u-hide--medium">
@@ -96,6 +108,8 @@
             <option value="renesas-rz-g2lc-tab" selected="">RZ/G2LC</option>
             <option value="renesas-rz-g2ul-tab" selected="">RZ/G2UL</option>
             <option value="renesas-rz-v2l-tab" selected="">RZ/V2L</option>
+            <option value="renesas-rz-g3e-tab" selected="">RZ/G3E</option>
+            <option value="renesas-rz-g3s-tab" selected="">RZ/G3S</option>
           </select>
         </form>
       </div>
@@ -104,6 +118,8 @@
         {% include "download/renesas-iot/tab-2-renesas-rz-g2lc.html" %}
         {% include "download/renesas-iot/tab-3-renesas-rz-g2ul.html" %}
         {% include "download/renesas-iot/tab-4-renesas-rz-v2l.html" %}
+        {% include "download/renesas-iot/tab-5-renesas-rz-g3e.html" %}
+        {% include "download/renesas-iot/tab-6-renesas-rz-g3s.html" %}
       </div>
     </div>
   </section>

--- a/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
+++ b/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
@@ -1,0 +1,110 @@
+<div
+  tabindex="3"
+  role="tabpanel"
+  id="renesas-rz-g3e-tab"
+  aria-labelledby="renesas-rz-g3e"
+  aria-hidden="true"
+>
+  <div class="p-section--shallow">
+    <div class="row">
+      <div class="col-6">
+        <h2 class="u-hide--small">Renesas RZ/G3E</h2>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Desktop 26.04</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is
+            coming soon.
+          </p>
+          <div>
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-desktop-2604-release-20260507.img.xz"
+              class="p-button--positive"
+              >Download Ubuntu 26.04</a
+            >
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3e.tar.gz"
+              class="p-button"
+              >Download boot assets</a
+            >
+          </div>
+          <div class="p-cta-block">
+            Ubuntu 26.04 for RZ/G3E&nbsp;<a
+              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
+              >image installation instructions</a
+            >
+          </div>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Server 26.04</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is
+            coming soon.
+          </p>
+          <div>
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-server-2604-release-20260507.img.xz"
+              class="p-button--positive"
+              >Download Ubuntu 26.04</a
+            >
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3e.tar.gz"
+              class="p-button"
+              >Download boot assets</a
+            >
+          </div>
+          <div class="p-cta-block">
+            Ubuntu 26.04 for RZ/G3E&nbsp;<a
+              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
+              >image installation instructions</a
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="p-rule--muted" />
+  <div class="row">
+    <div class="col-3">
+      <h3 class="p-heading--5">Get started</h3>
+    </div>
+    <div class="col-6">
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 26.04 for&nbsp;<a
+            href="https://www.renesas.com/en/products/rz-g3e"
+            >RZ/G3E</a
+          >
+        </li>
+        <li class="p-list__item">
+          Ubuntu for RZ/G3E
+          <a
+            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3E-G3S%20Release%20Notes-x02.pdf"
+            >release notes</a
+          >
+        </li>
+        <hr class="p-rule--muted" />
+      </ul>
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the
+            <a
+              href="https://www.renesas.com/en/design-resources/boards-kits/rz-g3e-evkit?part-status=Active"
+              >RZ/G3E-EVKIT</a
+            >
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
+++ b/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
@@ -1,0 +1,80 @@
+<div
+  tabindex="3"
+  role="tabpanel"
+  id="renesas-rz-g3s-tab"
+  aria-labelledby="renesas-rz-g3s"
+  aria-hidden="true"
+>
+  <div class="p-section--shallow">
+    <div class="row">
+      <div class="col-6">
+        <h2 class="u-hide--small">Renesas RZ/G3S</h2>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Server 26.04</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is
+            coming soon.
+          </p>
+          <div>
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-server-2604-release-20260507.img.xz"
+              class="p-button--positive"
+              >Download Ubuntu 26.04</a
+            >
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3s.tar.gz"
+              class="p-button"
+              >Download boot assets</a
+            >
+          </div>
+          <div class="p-cta-block">
+            Ubuntu 26.04 for RZ/G3S&nbsp;<a
+              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
+              >image installation instructions</a
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="p-rule--muted" />
+  <div class="row">
+    <div class="col-3">
+      <h3 class="p-heading--5">Get started</h3>
+    </div>
+    <div class="col-6">
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 26.04 for&nbsp;<a
+            href="https://www.renesas.com/en/products/rz-g3s"
+            >RZ/G3S</a
+          >
+        </li>
+        <li class="p-list__item">
+          Ubuntu for RZ/G3S
+          <a
+            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3E-G3S%20Release%20Notes-x02.pdf"
+            >release notes</a
+          >
+        </li>
+        <hr class="p-rule--muted" />
+      </ul>
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the
+            <a
+              href="https://www.renesas.com/en/design-resources/boards-kits/rz-g3s-evkit?part-status=Active"
+              >RZ/G3S-EVKIT</a
+            >
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Added Renesas RZ/G3E and Renesas RZ/G3S tabs to the Renesas IoT downloads page.

## QA

- Open [/download/renesas-iot](https://ubuntu-com-16427.demos.haus/download/renesas-iot)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the new Renesas RZ/G3E and Renesas RZ/G3S tabs have been added and match the [copydoc](https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?tab=t.0#heading=h.1kwjxh1f4up9).

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36853?focusedCommentId=1106898

