### PR TITLE
New domain for Desktop docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -117,11 +117,11 @@ products:
         - title: Quick links
           links:
             - title: Upgrade Ubuntu
-              url: https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/how-to/upgrade-ubuntu-desktop/
             - title: Ubuntu documentation
               url: https://docs.ubuntu.com/
             - title: Desktop install
-              url: https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/
             - title: Server install
               url: /server/docs/installation
             - title: Server guide
@@ -693,11 +693,11 @@ community:
         - title: Quick links
           links:
             - title: Upgrade Ubuntu
-              url: https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/how-to/upgrade-ubuntu-desktop/
             - title: Official Ubuntu documentation
               url: https://docs.ubuntu.com/
             - title: Install guide
-              url: https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/
             - title: How to write a tutorial
               url: /tutorials/tutorial-guidelines
 
@@ -850,13 +850,13 @@ download_ubuntu:
         - title: Quick links
           links:
             - title: Upgrade Ubuntu Desktop
-              url: https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/how-to/upgrade-ubuntu-desktop/
             - title: Ubuntu Desktop guide
-              url: https://documentation.ubuntu.com/desktop/
+              url: https://ubuntu.com/desktop/docs/
             - title: Installation tutorial
-              url: https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/
             - title: Try before installing
-              url: https://documentation.ubuntu.com/desktop/en/latest/tutorial/try-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/tutorial/try-ubuntu-desktop/
             - title: Case studies, whitepapers & webinars
               url: /engage
             - title: All Ubuntu tutorials
@@ -912,7 +912,7 @@ download_ubuntu:
         - title: Quick links
           links:
             - title: Desktop installation tutorial
-              url: https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/
+              url: https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/
             - title: Server installation tutorial
               url: /tutorials/how-to-install-ubuntu-on-your-raspberry-pi
             - title: Core installation tutorial

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1296,7 +1296,7 @@ resolute/mini.iso: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/resolute
 AMI/MiniISO: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/ubuntu-mini-iso-24.04.4-mini-iso-amd64.iso"
 
 # Redirects for TPM/FDE documentation
-desktop/tpm-fde-requirements/?: "https://documentation.ubuntu.com/desktop/en/latest/reference/hardware-backed-disk-encryption-requirements/"
+desktop/tpm-fde-requirements/?: "https://ubuntu.com/desktop/docs/en/latest/reference/hardware-backed-disk-encryption-requirements/"
 
 # Hiring blog redirect
 blog/how-we-hire-at-canonical: https://canonical.com/careers/hiring-process

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -180,12 +180,12 @@
           <ol class="p-list--divided">
             <li class="p-list__item">Download the ISO image</li>
             <li class="p-list__item">
-              Create a bootable USB flash drive with <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
+              Create a bootable USB flash drive with <a href="https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
             </li>
             <li class="p-list__item">Boot your laptop or PC from the USB flash drive</li>
           </ol>
           <hr class="p-rule--muted" />
-          <a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+          <a href="https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>
@@ -338,13 +338,13 @@
             <ol class="p-list--divided">
               <li class="p-list__item">Download the ISO image</li>
               <li class="p-list__item">
-                Create a bootable USB flash drive with <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
+                Create a bootable USB flash drive with <a href="https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
               </li>
               <li class="p-list__item">Boot your laptop or PC from the USB flash drive</li>
             </ol>
             <hr class="p-rule--muted" />
             <p>
-              <a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+              <a href="https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -56,7 +56,7 @@ meta_copydoc %}
               <hr class="p-rule" />
               <div class="p-section--shallow">
                 <a href="/download/desktop" class="p-button--positive">Download Ubuntu Desktop</a>
-                <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/"
+                <a href="https://ubuntu.com/desktop/docs/en/latest/how-to/upgrade-ubuntu-desktop/"
                    class="p-button">Upgrade Ubuntu</a>
               </div>
             </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -184,7 +184,7 @@
           <ol class="p-list--divided">
             <li class="p-list__item">Download the ISO image</li>
             <li class="p-list__item">
-              Create a bootable USB flash drive with <a href="https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
+              Create a bootable USB flash drive with <a href="https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/">an image writer</a>
             </li>
             <li class="p-list__item">Boot from the USB flash drive</li>
           </ol>

--- a/templates/download/shared/_downloads-resources.html
+++ b/templates/download/shared/_downloads-resources.html
@@ -8,7 +8,7 @@
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">
-            <a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/">Install Ubuntu Desktop</a>
+            <a href="https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/">Install Ubuntu Desktop</a>
           </h3>
           <div>
             <p>Follow this tutorial to install Ubuntu Desktop on your laptop or PC.</p>
@@ -36,7 +36,7 @@
       </div>
       <ul class="p-list--divided">
         <li class="p-list__item">
-          <a href="https://documentation.ubuntu.com/desktop/">Ubuntu Desktop documentation</a>
+          <a href="https://ubuntu.com/desktop/docs/">Ubuntu Desktop documentation</a>
         </li>
         <li class="p-list__item">
           <a href="https://discourse.ubuntu.com/">Ubuntu Discourse</a>

--- a/templates/download/shared/_footer.html
+++ b/templates/download/shared/_footer.html
@@ -21,13 +21,13 @@
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Detailed documentation</h3>
           <p class="u-no-margin--bottom">
-            <a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/">Install Ubuntu Desktop</a>
+            <a href="https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/">Install Ubuntu Desktop</a>
           </p>
           <p class="u-no-margin--bottom">
             <a href="/server/docs/tutorial/basic-installation/">Install Ubuntu Server</a>
           </p>
-          <p class="u-no-margin--bottom">
-            <a href="https://documentation.ubuntu.com/desktop/">Ubuntu Desktop documentation</a>
+          p class="u-no-margin--bottom">
+            <a href="https://ubuntu.com/desktop/docs/">Ubuntu Desktop documentation</a>
           </p>
           <p class="u-no-margin--bottom">
             <a href="https://documentation.ubuntu.com/server/">Ubuntu Server documentation</a>

--- a/templates/download/shared/_footer.html
+++ b/templates/download/shared/_footer.html
@@ -26,7 +26,7 @@
           <p class="u-no-margin--bottom">
             <a href="/server/docs/tutorial/basic-installation/">Install Ubuntu Server</a>
           </p>
-          p class="u-no-margin--bottom">
+          <p class="u-no-margin--bottom">
             <a href="https://ubuntu.com/desktop/docs/">Ubuntu Desktop documentation</a>
           </p>
           <p class="u-no-margin--bottom">

--- a/templates/shared/contextual_footers/_download_all_installation.html
+++ b/templates/shared/contextual_footers/_download_all_installation.html
@@ -2,7 +2,7 @@
   <h3 class="p-heading--4">Installation guides</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
-      <li><a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/" data-ga-category="Contextual footer link" data-ga-action="install desktop guide" data-ga-label="Installation guides">Installing Ubuntu Desktop</a></li>
+      <li><a href="https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/" data-ga-category="Contextual footer link" data-ga-action="install desktop guide" data-ga-label="Installation guides">Installing Ubuntu Desktop</a></li>
       <li><a href="/server/docs/tutorial/basic-installation/" data-ga-category="Contextual footer link" data-ga-action="install server guide" data-ga-label="Installation guides">Installing Ubuntu Server</a></li>
       <li><a href="/download/cloud" data-ga-category="Contextual footer link" data-ga-action="install openstack" data-ga-label="Installation guides">Install OpenStack&nbsp;&rsaquo;</a></li>
   </ul>

--- a/templates/shared/contextual_footers/_download_desktop_guide.html
+++ b/templates/shared/contextual_footers/_download_desktop_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--4">Ubuntu Desktop documentation</h3>
   <p>Read the official Ubuntu Desktop documentation.</p>
-  <p><a href="https://documentation.ubuntu.com/desktop/en/lts/" data-ga-category="Contextual footer link" data-ga-action="help.u.c" data-ga-label="Ubuntu desktop guide">Ubuntu {{ releases_yaml.lts.short_version }} LTS documentation</a></p>
+  <p><a href="https://ubuntu.com/desktop/docs/en/lts/" data-ga-category="Contextual footer link" data-ga-action="help.u.c" data-ga-label="Ubuntu desktop guide">Ubuntu {{ releases_yaml.lts.short_version }} LTS documentation</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_desktop_installation.html
+++ b/templates/shared/contextual_footers/_download_desktop_installation.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--4">Installation guide</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guide.</p>
-  <p><a href="https://documentation.ubuntu.com/desktop/en/latest/tutorial/install-ubuntu-desktop/" data-ga-category="Contextual footer link" data-ga-action="install-ubuntu-desktop" data-ga-label="Installation guide">Read the installation instructions</a></p>
+  <p><a href="https://ubuntu.com/desktop/docs/en/latest/tutorial/install-ubuntu-desktop/" data-ga-category="Contextual footer link" data-ga-action="install-ubuntu-desktop" data-ga-label="Installation guide">Read the installation instructions</a></p>
 </div>

--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -46,6 +46,9 @@
     <loc>https://ubuntu.com/server/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://ubuntu.com/desktop/docs/en/latest/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://ubuntu.com/workshop/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/tests/cassettes/TestRoutes.test_tutorials_homepage.yaml
+++ b/tests/cassettes/TestRoutes.test_tutorials_homepage.yaml
@@ -609,7 +609,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/enable-smart-cards-in-snapped-browsers/\\\"\\u003eEnable
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/enable-smart-cards-in-snapped-browsers/\\\"\\u003eEnable
         smart cards in snapped browser\\u003c/a\\u003e guide in th\"],[46034,\"Use
         Sunbeam together with MAAS to deploy machines at scale\",\"use-sunbeam-together-with-maas-to-deploy-machines-at-scale\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploy
@@ -744,7 +744,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/log-in-using-a-smart-card/\\\"
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/log-in-using-a-smart-card/\\\"
         rel=\\\"noopener nofollow ugc\\\"\\u003eLo\"],[34463,\"Summarizing Security
         Status of Ubuntu Machines on Azure with Runbooks\",\"summarizing-security-status-of-ubuntu-machines-on-azure-with-runbooks\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eSummarizing
@@ -1694,7 +1694,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been updated
-        and replaced by \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/tutorial/the-linux-command-line-for-beginners/\\\"
+        and replaced by \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/tutorial/the-linux-command-line-for-beginners/\\\"
         rel=\\\"noopener nofollow ugc\\\"\\u003e The Linux command line for beginners\\u003c/a\\u003e
         in t\"],[14273,\"Create an Ubuntu image for a Raspberry Pi on MacOS\",\"create-an-ubuntu-image-for-a-raspberry-pi-on-macos\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
@@ -1757,7 +1757,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003eI\"],[14019,\"Install
         the Java Runtime Environment\",\"install-the-java-runtime-environment\",\"\\u003cdiv
@@ -1806,7 +1806,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003c\"],[14015,\"How
         to burn a DVD on macOS\",\"how-to-burn-a-dvd-on-macos\",\"\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eInstructions
@@ -1830,7 +1830,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/tutorial/try-ubuntu-desktop/\\\"\\u003eTry
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/tutorial/try-ubuntu-desktop/\\\"\\u003eTry
         Ubuntu Desktop\\u003c/a\\u003e guide in the product documentation.\"],[14013,\"Install
         Ubuntu 16.04 desktop\",\"install-ubuntu-16-04-desktop\",\"\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eInstall
         Ubuntu 16.04 (Xenial) onto your laptop or PC computer, from either a DVD or
@@ -1855,7 +1855,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/\"],[14011,\"Create
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/\"],[14011,\"Create
         a bootable USB stick on Ubuntu\",\"create-a-bootable-usb-stick-on-ubuntu\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eUse
         your Ubuntu desktop to create a bootable USB stick that can be used to run
@@ -1867,7 +1867,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB s\"],[14010,\"How to verify your Ubuntu download\",\"how-to-verify-your-ubuntu-download\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eVerifying
         your ISO helps insure the data integrity and authenticity of your download.\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCategories\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDifficulty\\u003c/td\\u003e\\n\\u003ctd\\u003e3\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAuthor\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
@@ -2116,7 +2116,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been updated
-        and replaced by \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/share-your-desktop-remotely/\\\"\\u003eShare
+        and replaced by \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/share-your-desktop-remotely/\\\"\\u003eShare
         your desktop remotely\\u003c/a\\u003e and \\u003ca href=\\\"https://do\"],[13964,\"Apply
         kernel patches without rebooting\",\"apply-kernel-patches-without-rebooting\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
@@ -2967,7 +2967,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/enable-smart-cards-in-snapped-browsers/\\\"\\u003eEnable
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/enable-smart-cards-in-snapped-browsers/\\\"\\u003eEnable
         smart cards in snapped browser\\u003c/a\\u003e guide in th\"],[46034,\"Use
         Sunbeam together with MAAS to deploy machines at scale\",\"use-sunbeam-together-with-maas-to-deploy-machines-at-scale\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploy
@@ -3102,7 +3102,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/log-in-using-a-smart-card/\\\"
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/log-in-using-a-smart-card/\\\"
         rel=\\\"noopener nofollow ugc\\\"\\u003eLo\"],[34463,\"Summarizing Security
         Status of Ubuntu Machines on Azure with Runbooks\",\"summarizing-security-status-of-ubuntu-machines-on-azure-with-runbooks\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eSummarizing
@@ -4052,7 +4052,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been updated
-        and replaced by \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/tutorial/the-linux-command-line-for-beginners/\\\"
+        and replaced by \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/tutorial/the-linux-command-line-for-beginners/\\\"
         rel=\\\"noopener nofollow ugc\\\"\\u003e The Linux command line for beginners\\u003c/a\\u003e
         in t\"],[14273,\"Create an Ubuntu image for a Raspberry Pi on MacOS\",\"create-an-ubuntu-image-for-a-raspberry-pi-on-macos\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
@@ -4115,7 +4115,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003eI\"],[14019,\"Install
         the Java Runtime Environment\",\"install-the-java-runtime-environment\",\"\\u003cdiv
@@ -4164,7 +4164,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003c\"],[14015,\"How
         to burn a DVD on macOS\",\"how-to-burn-a-dvd-on-macos\",\"\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eInstructions
@@ -4188,7 +4188,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/tutorial/try-ubuntu-desktop/\\\"\\u003eTry
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/tutorial/try-ubuntu-desktop/\\\"\\u003eTry
         Ubuntu Desktop\\u003c/a\\u003e guide in the product documentation.\"],[14013,\"Install
         Ubuntu 16.04 desktop\",\"install-ubuntu-16-04-desktop\",\"\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eInstall
         Ubuntu 16.04 (Xenial) onto your laptop or PC computer, from either a DVD or
@@ -4213,7 +4213,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/\"],[14011,\"Create
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/\"],[14011,\"Create
         a bootable USB stick on Ubuntu\",\"create-a-bootable-usb-stick-on-ubuntu\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eUse
         your Ubuntu desktop to create a bootable USB stick that can be used to run
@@ -4225,7 +4225,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB s\"],[14010,\"How to verify your Ubuntu download\",\"how-to-verify-your-ubuntu-download\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eVerifying
         your ISO helps insure the data integrity and authenticity of your download.\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCategories\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDifficulty\\u003c/td\\u003e\\n\\u003ctd\\u003e3\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAuthor\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
@@ -4474,7 +4474,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been updated
-        and replaced by \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/share-your-desktop-remotely/\\\"\\u003eShare
+        and replaced by \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/share-your-desktop-remotely/\\\"\\u003eShare
         your desktop remotely\\u003c/a\\u003e and \\u003ca href=\\\"https://do\"],[13964,\"Apply
         kernel patches without rebooting\",\"apply-kernel-patches-without-rebooting\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
@@ -5320,7 +5320,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003eInstall
         or upgrade Ubuntu\\u003c/li\\u003e\\n\\u003cli\\u003eTest out the Ubuntu desktop
@@ -5542,7 +5542,7 @@ interactions:
         Ubuntu\\u003c/a\\u003e\\u003c/li\\u003e\\n\\u003cli\\u003e\\u003ca href=\\\"https://wiki.ubuntu.com/IRC/ChannelList\\\"\\u003eIRC-based
         support\\u003c/a\\u003e\\u003c/li\\u003e\\n\\u003c/ul\\u003e\",\"post_number\":1,\"post_type\":1,\"posts_count\":36,\"updated_at\":\"2025-11-26T17:51:35.301Z\",\"reply_count\":0,\"reply_to_post_number\":null,\"quote_count\":0,\"incoming_link_count\":67540,\"reads\":125,\"readers_count\":124,\"score\":337185.0,\"yours\":false,\"topic_id\":14020,\"topic_slug\":\"create-a-bootable-usb-stick-with-rufus-on-windows\",\"display_username\":\"system\",\"primary_group_name\":null,\"flair_name\":null,\"flair_url\":null,\"flair_bg_color\":null,\"flair_color\":null,\"flair_group_id\":null,\"badges_granted\":[],\"version\":15,\"can_edit\":true,\"can_delete\":false,\"can_recover\":false,\"can_see_hidden_post\":true,\"can_wiki\":true,\"link_counts\":[{\"url\":\"https://rufus.ie/\",\"internal\":false,\"reflection\":false,\"clicks\":4006},{\"url\":\"https://www.ubuntu.com/download\",\"internal\":false,\"reflection\":false,\"clicks\":2142},{\"url\":\"https://ubuntu.com/tutorials/install-ubuntu-desktop#1-overview\",\"internal\":false,\"reflection\":false,\"title\":\"Install
         Ubuntu desktop | Ubuntu\",\"clicks\":814},{\"url\":\"https://www.balena.io/etcher/\",\"internal\":false,\"reflection\":false,\"clicks\":590},{\"url\":\"https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu\",\"internal\":false,\"reflection\":false,\"title\":\"Create
-        a bootable USB stick on Ubuntu | Ubuntu tutorials\",\"clicks\":483},{\"url\":\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\",\"internal\":false,\"reflection\":false,\"clicks\":111},{\"url\":\"https://askubuntu.com/\",\"internal\":false,\"reflection\":false,\"title\":\"Ask
+        a bootable USB stick on Ubuntu | Ubuntu tutorials\",\"clicks\":483},{\"url\":\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\",\"internal\":false,\"reflection\":false,\"clicks\":111},{\"url\":\"https://askubuntu.com/\",\"internal\":false,\"reflection\":false,\"title\":\"Ask
         Ubuntu\",\"clicks\":89},{\"url\":\"https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos\",\"internal\":false,\"reflection\":false,\"title\":\"Create
         a bootable USB stick on macOS | Ubuntu tutorials\",\"clicks\":79},{\"url\":\"https://wiki.ubuntu.com/IRC/ChannelList\",\"internal\":false,\"reflection\":false,\"title\":\"IRC/ChannelList
         - Ubuntu Wiki\",\"clicks\":20},{\"url\":\"https://discourse.ubuntu.com/\",\"internal\":true,\"reflection\":false,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/about-the-tutorials-category/13611\",\"internal\":true,\"reflection\":true,\"title\":\"About
@@ -5803,7 +5803,7 @@ interactions:
         Erdogmus\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/leterel/{size}/84745_2.png\",\"post_count\":1,\"primary_group_name\":null,\"flair_name\":null,\"flair_url\":null,\"flair_color\":null,\"flair_bg_color\":null,\"flair_group_id\":null,\"trust_level\":0}],\"created_by\":{\"id\":-1,\"username\":\"system\",\"name\":\"system\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/system/{size}/67752_2.png\"},\"last_poster\":{\"id\":34800,\"username\":\"marek-suchanek\",\"name\":\"Marek
         Such\xE1nek\",\"avatar_template\":\"/letter_avatar/marek-suchanek/{size}/5_341fea102a12413267ee9cca6a635b61.png\"},\"links\":[{\"url\":\"https://rufus.ie/\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":4006,\"user_id\":-1,\"domain\":\"rufus.ie\",\"root_domain\":\"rufus.ie\"},{\"url\":\"https://www.ubuntu.com/download\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":2142,\"user_id\":-1,\"domain\":\"www.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://ubuntu.com/tutorials/install-ubuntu-desktop#1-overview\",\"title\":\"Install
         Ubuntu desktop | Ubuntu\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":814,\"user_id\":-1,\"domain\":\"ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://www.balena.io/etcher/\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":602,\"user_id\":-1,\"domain\":\"www.balena.io\",\"root_domain\":\"balena.io\"},{\"url\":\"https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu\",\"title\":\"Create
-        a bootable USB stick on Ubuntu | Ubuntu tutorials\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":483,\"user_id\":-1,\"domain\":\"tutorials.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":114,\"user_id\":-1,\"domain\":\"documentation.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/install-ubuntu-desktop/25312\",\"title\":\"Install
+        a bootable USB stick on Ubuntu | Ubuntu tutorials\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":483,\"user_id\":-1,\"domain\":\"tutorials.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":114,\"user_id\":-1,\"domain\":\"documentation.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/install-ubuntu-desktop/25312\",\"title\":\"Install
         Ubuntu Desktop\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":107,\"user_id\":14438,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://askubuntu.com/\",\"title\":\"Ask
         Ubuntu\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":89,\"user_id\":-1,\"domain\":\"askubuntu.com\",\"root_domain\":\"askubuntu.com\"},{\"url\":\"https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos\",\"title\":\"Create
         a bootable USB stick on macOS | Ubuntu tutorials\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":79,\"user_id\":-1,\"domain\":\"tutorials.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://store.nskmultiservices.in/product/windows-10-bootable-usb-pendrive\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":64,\"user_id\":27638,\"domain\":\"store.nskmultiservices.in\",\"root_domain\":\"nskmultiservices.in\"},{\"url\":\"http://shorturl.at/qtRSU\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":28,\"user_id\":11392,\"domain\":\"shorturl.at\",\"root_domain\":\"shorturl.at\"},{\"url\":\"https://ubuntu-mate.org/faq/usb-image/\",\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":27,\"user_id\":193,\"domain\":\"ubuntu-mate.org\",\"root_domain\":\"ubuntu-mate.org\"},{\"url\":\"https://wiki.ubuntu.com/IRC/ChannelList\",\"title\":\"IRC/ChannelList

--- a/tests/cassettes/TestRoutes.test_tutorials_search.yaml
+++ b/tests/cassettes/TestRoutes.test_tutorials_search.yaml
@@ -969,7 +969,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/enable-smart-cards-in-snapped-browsers/\\\"\\u003eEnable
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/enable-smart-cards-in-snapped-browsers/\\\"\\u003eEnable
         smart cards in snapped browser\\u003c/a\\u003e guide in th\"],[46034,\"Use
         Sunbeam together with MAAS to deploy machines at scale\",\"use-sunbeam-together-with-maas-to-deploy-machines-at-scale\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploy
@@ -1104,7 +1104,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/log-in-using-a-smart-card/\\\"
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/log-in-using-a-smart-card/\\\"
         rel=\\\"noopener nofollow ugc\\\"\\u003eLo\"],[34463,\"Summarizing Security
         Status of Ubuntu Machines on Azure with Runbooks\",\"summarizing-security-status-of-ubuntu-machines-on-azure-with-runbooks\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eSummarizing
@@ -2054,7 +2054,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been updated
-        and replaced by \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/tutorial/the-linux-command-line-for-beginners/\\\"
+        and replaced by \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/tutorial/the-linux-command-line-for-beginners/\\\"
         rel=\\\"noopener nofollow ugc\\\"\\u003e The Linux command line for beginners\\u003c/a\\u003e
         in t\"],[14273,\"Create an Ubuntu image for a Raspberry Pi on MacOS\",\"create-an-ubuntu-image-for-a-raspberry-pi-on-macos\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
@@ -2117,7 +2117,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003eI\"],[14019,\"Install
         the Java Runtime Environment\",\"install-the-java-runtime-environment\",\"\\u003cdiv
@@ -2166,7 +2166,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB stick\\u003c/a\\u003e guide.\\u003c/p\\u003e\\n\\u003c/blockquote\\u003e\\n\\u003cp\\u003eWith
         a bootable Ubuntu USB stick, you can:\\u003c/p\\u003e\\n\\u003c\"],[14015,\"How
         to burn a DVD on macOS\",\"how-to-burn-a-dvd-on-macos\",\"\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eInstructions
@@ -2190,7 +2190,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/tutorial/try-ubuntu-desktop/\\\"\\u003eTry
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/tutorial/try-ubuntu-desktop/\\\"\\u003eTry
         Ubuntu Desktop\\u003c/a\\u003e guide in the product documentation.\"],[14013,\"Install
         Ubuntu 16.04 desktop\",\"install-ubuntu-16-04-desktop\",\"\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eInstall
         Ubuntu 16.04 (Xenial) onto your laptop or PC computer, from either a DVD or
@@ -2215,7 +2215,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/\"],[14011,\"Create
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/\"],[14011,\"Create
         a bootable USB stick on Ubuntu\",\"create-a-bootable-usb-stick-on-ubuntu\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eUse
         your Ubuntu desktop to create a bootable USB stick that can be used to run
@@ -2227,7 +2227,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been rewritten
-        and replaced by the \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
+        and replaced by the \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/\\\"\\u003eCreate
         a bootable USB s\"],[14010,\"How to verify your Ubuntu download\",\"how-to-verify-your-ubuntu-download\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eVerifying
         your ISO helps insure the data integrity and authenticity of your download.\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCategories\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDifficulty\\u003c/td\\u003e\\n\\u003ctd\\u003e3\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAuthor\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
@@ -2476,7 +2476,7 @@ interactions:
         title=\\\":warning:\\\" class=\\\"emoji\\\" alt=\\\":warning:\\\" loading=\\\"lazy\\\"
         width=\\\"20\\\" height=\\\"20\\\"\\u003e \\u003cstrong\\u003eNew version
         available\\u003c/strong\\u003e\\u003cbr\\u003e\\nThis tutorial has been updated
-        and replaced by \\u003ca href=\\\"https://documentation.ubuntu.com/desktop/en/latest/how-to/share-your-desktop-remotely/\\\"\\u003eShare
+        and replaced by \\u003ca href=\\\"https://ubuntu.com/desktop/docs/en/latest/how-to/share-your-desktop-remotely/\\\"\\u003eShare
         your desktop remotely\\u003c/a\\u003e and \\u003ca href=\\\"https://do\"],[13964,\"Apply
         kernel patches without rebooting\",\"apply-kernel-patches-without-rebooting\",\"\\u003cdiv
         class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSummary\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn


### PR DESCRIPTION
The Ubuntu Desktop documentation has moved to a new domain.

- Old: documentation.ubuntu.com/desktop
- New: ubuntu.com/desktop/docs

I'm making this change across the website:

- Mass-replace links
- Update redirects
- Add the sitemap of the migrated documentation