### PR TITLE
Fix broken OpenSearch link on /ai page - Fixes #16435

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -433,7 +433,7 @@
         <div class="p-section--shallow">
           <hr class="p-rule" />
           <p>
-            <a href="/blog/what-is-opensearch">What is OpenSearch&nbsp;&rsaquo;</a>
+            <a href="https://canonical.com/data/opensearch/what-is-opensearch">What is OpenSearch&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Fixes #16435

Changed broken /blog/what-is-opensearch link to the correct URL: https://canonical.com/data/opensearch/what-is-opensearch