### PR TITLE
feat(WD-35810): add code syntax highlighting on blogs

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -58,6 +58,7 @@
       }
     }
   </script>
+  <script src="{{ versioned_static('js/dist/prism.js') }}" defer></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- Added prism.js on blog articles, for syntax highlighting available on Vanilla

## QA

- Checkout this pull request
- Make sure you have the following env variables in your local env.
  - `WORDPRESS_USERNAME`
  - `WORDPRESS_APPLICATION_PASSWORD`
  - Get them from bitwarden if you don't have them
- Run the site using the command using `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to [this draft blog](http://0.0.0.0:8001/blog/draft-blogs/code-syntax-highlighting)
- Verify the blog has syntax highlighting

## Issue / Card

Fixes [WD-35810](https://warthogs.atlassian.net/browse/WD-35810)

## Screenshots

<img width="786" height="1019" alt="image" src="https://github.com/user-attachments/assets/c4d5983c-8f27-4253-96aa-be8674c07aac" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-35810]: https://warthogs.atlassian.net/browse/WD-35810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
