### PR TITLE
feat: add nonce to styles and add CI check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -137,6 +137,14 @@ jobs:
             exit 1
           fi
 
+      - name: Check inline styles have CSP nonce attribute
+        run: |
+          if grep -rn '<style\b[^>]*>' templates/ \
+            | grep -v 'nonce='; then
+            echo "Found inline <style> tags without nonce attribute"
+            exit 1
+          fi
+
   validate-deploy:
     runs-on: ubuntu-latest
 

--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -13,7 +13,7 @@
   {{ load_form("/appliance/contact-us",formId=3231, isModal=true) | safe }}
   <script src="{{ versioned_static('js/dist/appliance.js') }}" defer></script>
 
-  <style>
+  <style nonce="{{ csp_nonce }}">
     .p-stepped-list--detailed ol li {
       margin-bottom: 1rem;
     }

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -96,7 +96,7 @@
   </div>
 </section>
 
-<style>
+<style nonce="{{ csp_nonce }}">
   .p-stepped-list--detailed>.p-stepped-list__item:first-child {
     &::after {
       display: none;

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -26,7 +26,7 @@
   {% block content %}
 
     <noscript>
-      <style>
+      <style nonce="{{ csp_nonce }}">
         .p-takeover-animation {
           animation: none;
         }

--- a/templates/certified/platforms/platform-details.html
+++ b/templates/certified/platforms/platform-details.html
@@ -10,7 +10,7 @@
 
 {% block outer_content %}
 
-<style>
+<style nonce="{{ csp_nonce }}">
   .hidden {
     display: none;
   }

--- a/templates/community/events.html
+++ b/templates/community/events.html
@@ -19,7 +19,7 @@
 {% block content %}
   <!-- This is a temporary implementation of has-divider-0 for the specific design requirements.
   An issue has been created here: https://github.com/canonical/vanilla-framework/issues/5580 once it is merged this can be removed -->
-  <style>
+  <style nonce="{{ csp_nonce }}">
     /* Custom has-divider-0 implementation for events page */
     .p-equal-height-row.has-divider-0::before,
     .p-equal-height-row--wrap.has-divider-0::before {

--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -12,7 +12,7 @@
 {% endblock body_class %}
 
 {% block content %}
-  <style>
+  <style nonce="{{ csp_nonce }}">
     .dimmed-text {
       color: #666666;
     }

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -12,7 +12,7 @@
 
 {% block head_extra %}
   <meta name="robots" content="noindex" />
-  <style>
+  <style nonce="{{ csp_nonce }}">
     .async-hide {
       opacity: 0 !important
     }

--- a/templates/engage/shared/_header-case-study.html
+++ b/templates/engage/shared/_header-case-study.html
@@ -11,7 +11,7 @@
   </div>
 </section>
 
-<style media="screen">
+<style media="screen" nonce="{{ csp_nonce }}">
   .test-class {
     background-color: lightblue;
   }

--- a/templates/engage/shared/_kr_thank-you.html
+++ b/templates/engage/shared/_kr_thank-you.html
@@ -5,7 +5,7 @@
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-  <style>
+  <style nonce="{{ csp_nonce }}">
     .global-nav .global-nav__header-logo-anchor {
       padding-left: 0 !important;
     }

--- a/templates/engage/shared/_zh-TW_thank-you.html
+++ b/templates/engage/shared/_zh-TW_thank-you.html
@@ -5,7 +5,7 @@
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-  <style>
+  <style nonce="{{ csp_nonce }}">
     .global-nav .global-nav__header-logo-anchor {
       padding-left: 0 !important;
     }

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -15,7 +15,7 @@ https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/
 
 {% block content %}
 
-<style>
+<style nonce="{{ csp_nonce }}">
   .p-logo-section--dense .p-logo-section__logo {
     height: 4.5rem;
     max-width: 6rem;

--- a/templates/pro/attach/confirmation.html
+++ b/templates/pro/attach/confirmation.html
@@ -28,7 +28,7 @@
     </div>
     {% endif %}
 </section>
-<style>
+<style nonce="{{ csp_nonce }}">
     .vh-75 {
         height: 75vh;
     }

--- a/templates/pro/attach/index.html
+++ b/templates/pro/attach/index.html
@@ -62,7 +62,7 @@
         </div>
     </div>
 </div>
-<style>
+<style nonce="{{ csp_nonce }}">
     .vh-75 {
         height: 75vh;
     }

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -1,4 +1,4 @@
-<style>
+<style nonce="{{ csp_nonce }}">
   .chart-legend-lts::before, .chart-legend-pro::before {
     content:"";
     display: inline-block;

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -400,7 +400,7 @@ pro enable realtime-kernel --variant=raspi</code></pre>
   <!-- Set default Marketo information for contact form below-->
  {{ load_form("/real-time") | safe }}
 
-  <style>
+  <style nonce="{{ csp_nonce }}">
     @media (min-width: 1032px) {
       .p-cases {
         min-height: 130px;

--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -502,7 +502,7 @@
     </div>
   </section>
 
-  <style>
+  <style nonce="{{ csp_nonce }}">
     .p-resources .p-article-block {
       row-gap: 0;
     }

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -1131,7 +1131,7 @@
       </form>
     </div>
 </section>
-<style>
+<style nonce="{{ csp_nonce }}">
   label {
     max-width: 100%;
   }

--- a/templates/shared/_device_animation.html
+++ b/templates/shared/_device_animation.html
@@ -1,4 +1,4 @@
-<style type="text/css">  
+<style type="text/css" nonce="{{ csp_nonce }}">
  
 @keyframes swooshWidth {
     0%,10% {

--- a/templates/shared/_list_fade_keyframes.html
+++ b/templates/shared/_list_fade_keyframes.html
@@ -1,4 +1,4 @@
-<style type="text/css">  
+<style type="text/css" nonce="{{ csp_nonce }}">
   /* keyframes for the intro animation - row--intro */
   @keyframes fadeIn { 0% { display: none; opacity: 0; } 100% { display: block; opacity: 1; } }
   @-moz-keyframes fadeIn { 0% { display: none; opacity: 0; } 100% { display: block; opacity: 1; } }

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -1,7 +1,7 @@
   <div class="col-4 p-divider__block">
   <div id="mc_embed_signup" class="box-digest">
       <!-- Begin MailChimp Signup Form -->
-      <style type="text/css">
+      <style type="text/css" nonce="{{ csp_nonce }}">
         .response { display: block; width: 100%; padding-top: 10px; }
         #mce-error-response { color: red; }
         #mce-success-response { position: absolute; background: #fff; height: 90%; top: 47px; padding-top: 14px; }

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -56,7 +56,7 @@
   </div>
 {% endif %}
 
-<style>
+<style nonce="{{ csp_nonce }}">
   .is-active::after {
     background: rgba(249, 155, 17, 0.5);
     content: "Active";

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -119,7 +119,7 @@
           {% endif %}
 
           {% block extra_metatags %}{% endblock %}
-          <style>
+          <style nonce="{{ csp_nonce }}">
             #rememberMe {
               display: none;
             }

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -227,7 +227,7 @@
   </script>
 
   <!-- These styles take care of the issue where the same page links for h2, h3 are cut-off from the top upon click and auto-scroll -->
-  <style>
+  <style nonce="{{ csp_nonce }}">
     h2,
     h3 {
       &[id] {

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -508,6 +508,31 @@ class TestRoutes(VCRTestCase):
         self.assertIn("'unsafe-inline'", directives.get("style-src", ""))
         self.assertNotRegex(directives.get("style-src", ""), r"'nonce-")
 
+    def test_csp_strict_styles_enforced_when_flag_on(self):
+        """Test that CSP_ENFORCE_STRICT_STYLES moves the strict style
+        directives into the enforced CSP and drops the report-only
+        header, while style-src stays as the legacy fallback
+        (WD-36638)"""
+        with patch("webapp.handlers.CSP_ENFORCE_STRICT_STYLES", True):
+            response = self.client.get("/")
+        self.assertNotIn(
+            "Content-Security-Policy-Report-Only", response.headers
+        )
+        csp = response.headers.get("Content-Security-Policy", "")
+        directives = {
+            d.split()[0]: d for d in csp.rstrip(";").split(";") if d.strip()
+        }
+        self.assertRegex(
+            directives.get("style-src-elem", ""), r"'nonce-[a-f0-9]+'"
+        )
+        self.assertNotIn(
+            "'unsafe-inline'", directives.get("style-src-elem", "")
+        )
+        self.assertIn("'unsafe-inline'", directives.get("style-src-attr", ""))
+        # the fallback style-src must stay exactly as before
+        self.assertIn("'unsafe-inline'", directives.get("style-src", ""))
+        self.assertNotRegex(directives.get("style-src", ""), r"'nonce-")
+
     def test_csp_nonce_is_unique_per_request(self):
         """Test that a different nonce is generated for each request"""
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -477,6 +477,37 @@ class TestRoutes(VCRTestCase):
             directives.get("script-src", ""), r"'nonce-[a-f0-9]+'"
         )
 
+    def test_csp_report_only_style_directives(self):
+        """Test that the report-only CSP trials the strict style policy:
+        nonce'd style-src-elem without 'unsafe-inline', while style
+        attributes stay allowed (WD-36638)"""
+        response = self.client.get("/")
+        csp_ro = response.headers.get(
+            "Content-Security-Policy-Report-Only", ""
+        )
+        directives = {
+            d.split()[0]: d for d in csp_ro.rstrip(";").split(";") if d.strip()
+        }
+        self.assertRegex(
+            directives.get("style-src-elem", ""), r"'nonce-[a-f0-9]+'"
+        )
+        self.assertNotIn(
+            "'unsafe-inline'", directives.get("style-src-elem", "")
+        )
+        self.assertIn("'unsafe-inline'", directives.get("style-src-attr", ""))
+
+    def test_csp_enforced_style_src_keeps_unsafe_inline(self):
+        """Test that the enforced style-src keeps 'unsafe-inline' and has
+        no nonce: a nonce makes browsers ignore 'unsafe-inline', which
+        would break the inline styles still present (WD-36638)"""
+        response = self.client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        directives = {
+            d.split()[0]: d for d in csp.rstrip(";").split(";") if d.strip()
+        }
+        self.assertIn("'unsafe-inline'", directives.get("style-src", ""))
+        self.assertNotRegex(directives.get("style-src", ""), r"'nonce-")
+
     def test_csp_nonce_is_unique_per_request(self):
         """Test that a different nonce is generated for each request"""
 

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -199,3 +199,26 @@ CSP = {
         "https://support.stripe.com",
     ],
 }
+
+# Trial policy for removing 'unsafe-inline' from style-src (WD-36638).
+# Sent as Content-Security-Policy-Report-Only: violations are reported,
+# never enforced. Once reports confirm it is safe, these directives move
+# into CSP above.
+CSP_REPORT_ONLY = {
+    # Covers <style> elements and <link rel="stylesheet">. A per-request
+    # nonce is appended in add_headers; 'unsafe-inline' is deliberately
+    # absent so un-nonced <style> elements (e.g. injected by third-party
+    # scripts such as VWO or LiveChat) generate violation reports.
+    "style-src-elem": [
+        "'self'",
+        "*.cloudfront.net",
+        "cdn.jsdelivr.net",
+        "*.livechatinc.com",
+        "*.youtube.com",
+        "*.google.com",
+    ],
+    # style="..." attributes cannot carry a nonce, so they stay allowed
+    # here to keep reports focused on style elements. They are being
+    # removed from templates separately.
+    "style-src-attr": ["'unsafe-inline'"],
+}

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -200,11 +200,12 @@ CSP = {
     ],
 }
 
-# Trial policy for removing 'unsafe-inline' from style-src (WD-36638).
-# Sent as Content-Security-Policy-Report-Only: violations are reported,
-# never enforced. Once reports confirm it is safe, these directives move
-# into CSP above.
-CSP_REPORT_ONLY = {
+# Strict style policy for removing 'unsafe-inline' from style-src
+# (WD-36638). Sent as Content-Security-Policy-Report-Only by default;
+# merged into the enforced CSP when CSP_ENFORCE_STRICT_STYLES is set.
+# Either way, style-src above stays unchanged as the fallback for
+# browsers without style-src-elem/-attr support.
+CSP_STRICT_STYLE_DIRECTIVES = {
     # Covers <style> elements and <link rel="stylesheet">. A per-request
     # nonce is appended in add_headers; 'unsafe-inline' is deliberately
     # absent so un-nonced <style> elements (e.g. injected by third-party

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,3 +1,4 @@
+import random
 import secrets
 from typing import List
 
@@ -5,7 +6,7 @@ import flask
 from canonicalwebteam import image_template
 from slugify import slugify
 
-from webapp.constants import CSP
+from webapp.constants import CSP, CSP_REPORT_ONLY
 from webapp.context import (
     current_year,
     date_has_passed,
@@ -34,6 +35,17 @@ from webapp.shop.api.ua_contracts.api import (
 from webapp.shop.flaskparser import UAContractsValidationError
 from webapp.certified.helpers import convert_markdown_to_html
 from canonicalwebteam.flask_base.env import get_flask_env
+
+# CSP violation reporting endpoint (e.g. a Sentry security endpoint).
+# Reports are only sent on a sampled fraction of responses: every page
+# view can produce violations, which would flood the endpoint otherwise.
+CSP_REPORT_URI = get_flask_env("CSP_REPORT_URI", "")
+try:
+    CSP_REPORT_SAMPLE_RATE = float(
+        get_flask_env("CSP_REPORT_SAMPLE_RATE", "0.01")
+    )
+except ValueError:
+    CSP_REPORT_SAMPLE_RATE = 0.0
 
 
 def init_handlers(app):
@@ -231,6 +243,24 @@ def init_handlers(app):
             for key, values in CSP.items()
         }
         response.headers["Content-Security-Policy"] = get_csp_as_str(csp)
+
+        # Report-only trial of the strict style policy (WD-36638). The
+        # nonce must NOT be added to the enforced style-src above while
+        # it still needs 'unsafe-inline': browsers ignore 'unsafe-inline'
+        # in a directive that contains a nonce.
+        csp_report_only = {
+            key: (
+                values + [f"'nonce-{nonce}'"]
+                if key == "style-src-elem"
+                else values
+            )
+            for key, values in CSP_REPORT_ONLY.items()
+        }
+        if CSP_REPORT_URI and random.random() < CSP_REPORT_SAMPLE_RATE:
+            csp_report_only["report-uri"] = [CSP_REPORT_URI]
+        response.headers["Content-Security-Policy-Report-Only"] = (
+            get_csp_as_str(csp_report_only)
+        )
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -6,7 +6,7 @@ import flask
 from canonicalwebteam import image_template
 from slugify import slugify
 
-from webapp.constants import CSP, CSP_REPORT_ONLY
+from webapp.constants import CSP, CSP_STRICT_STYLE_DIRECTIVES
 from webapp.context import (
     current_year,
     date_has_passed,
@@ -46,6 +46,15 @@ try:
     )
 except ValueError:
     CSP_REPORT_SAMPLE_RATE = 0.0
+
+# WD-36638 Phase 3: when set, the strict style directives are enforced
+# instead of report-only. Only flip this on once report-only data has
+# confirmed the policy is safe (third-party tags such as VWO and
+# LiveChat inject <style> elements that a nonce'd style-src-elem will
+# block) and the inline-style nonce changes have shipped.
+CSP_ENFORCE_STRICT_STYLES = get_flask_env(
+    "CSP_ENFORCE_STRICT_STYLES", "false"
+).strip().lower() in ("1", "true", "yes", "on")
 
 
 def init_handlers(app):
@@ -242,25 +251,37 @@ def init_handlers(app):
             )
             for key, values in CSP.items()
         }
-        response.headers["Content-Security-Policy"] = get_csp_as_str(csp)
-
-        # Report-only trial of the strict style policy (WD-36638). The
-        # nonce must NOT be added to the enforced style-src above while
-        # it still needs 'unsafe-inline': browsers ignore 'unsafe-inline'
-        # in a directive that contains a nonce.
-        csp_report_only = {
+        # Strict style policy (WD-36638): enforced when
+        # CSP_ENFORCE_STRICT_STYLES is set, trialled via the report-only
+        # header otherwise. style-src stays unchanged in both modes: it
+        # is the fallback for browsers without style-src-elem support,
+        # and it must keep 'unsafe-inline' and never gain a nonce
+        # (browsers ignore 'unsafe-inline' in a directive containing a
+        # nonce).
+        strict_styles = {
             key: (
                 values + [f"'nonce-{nonce}'"]
                 if key == "style-src-elem"
                 else values
             )
-            for key, values in CSP_REPORT_ONLY.items()
+            for key, values in CSP_STRICT_STYLE_DIRECTIVES.items()
         }
-        if CSP_REPORT_URI and random.random() < CSP_REPORT_SAMPLE_RATE:
-            csp_report_only["report-uri"] = [CSP_REPORT_URI]
-        response.headers["Content-Security-Policy-Report-Only"] = (
-            get_csp_as_str(csp_report_only)
+        send_report = (
+            CSP_REPORT_URI and random.random() < CSP_REPORT_SAMPLE_RATE
         )
+
+        if CSP_ENFORCE_STRICT_STYLES:
+            csp.update(strict_styles)
+            if send_report:
+                csp["report-uri"] = [CSP_REPORT_URI]
+        response.headers["Content-Security-Policy"] = get_csp_as_str(csp)
+
+        if not CSP_ENFORCE_STRICT_STYLES:
+            if send_report:
+                strict_styles["report-uri"] = [CSP_REPORT_URI]
+            response.headers["Content-Security-Policy-Report-Only"] = (
+                get_csp_as_str(strict_styles)
+            )
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"


### PR DESCRIPTION
## Done
- Added nonce to `style` blocks
- Added CI check to ensure `style` blocks each have a corresponding `nonce` associated with them.

## QA
- Visit pages where nonces are implemented (see `Changed files`)
- Open browser console.
- Ensure there are no errors caused by the styles that have nonces.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-36639
