### PR TITLE
Copy update: Add CTA in ceph pricing calculator page

### DIFF
--- a/templates/ceph/form-data.json
+++ b/templates/ceph/form-data.json
@@ -6,7 +6,8 @@
         "/ceph/consulting",
         "/ceph/install",
         "/ceph/managed",
-        "/ceph/what-is-ceph"
+        "/ceph/what-is-ceph",
+        "/ceph/pricing-calculator"
       ],
       "isModal": true,
       "modalId": "contact-modal",

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -30,7 +30,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-label="contact-modal">Get in touch</a>
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-controls="contact-modal" aria-expanded="false">Get in touch</a>
       <a href="/engage/optimize-cloud-storage-costs">Learn how Ceph can reduce your storage costs&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}

--- a/templates/ceph/install.html
+++ b/templates/ceph/install.html
@@ -30,7 +30,7 @@
       <p>Looking for help running Ceph?</p>
     {%- endif -%}
     {%- if slot == "cta" -%}
-      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-label="contact-modal">Get in touch</a>
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-controls="contact-modal" aria-expanded="false">Get in touch</a>
     {%- endif -%}
     {%- if slot == "image" -%}
 

--- a/templates/ceph/pricing-calculator.html
+++ b/templates/ceph/pricing-calculator.html
@@ -1,5 +1,7 @@
 {% extends "ceph/base_ceph.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Pricing Calculator | Ceph{% endblock %}
 
 {% block body_class %}
@@ -11,22 +13,24 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
-  <section class="p-section--hero">
-    <div class="grid-row">
-      <div class="grid-col-4">
-        <h1>Calculate your storage costs</h1>
-      </div>
-      <div class="grid-col-4">
-        <p>
-          Cloud storage can make up a significant proportion of public cloud hosting costs, for some data sets it can be more cost effective to store them in a self-hosted storage system.
-        </p>
-        <p>
-          Learn more in our <a href="/engage/optimize-cloud-storage-costs">white paper</a>, <span class="u-hide js-show">and explore potential savings with the calculator below.</span>
-          <noscript>and <a href="/contact-us/form">get in touch with our team</a> for cost estimations.</noscript>
-        </p>
-      </div>
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text="Calculate your storage costs",
+    layout="50/50",
+    is_split_on_medium=true
+    ) -%}
+    {%- if slot == "description" -%}
+      <p>
+        Cloud storage can make up a significant proportion of public cloud hosting costs, for some data sets it can be more cost effective to store them in a self-hosted storage system.
+      </p>
+      <p>
+        Learn more in our <a href="/engage/optimize-cloud-storage-costs">white paper</a>, <span class="u-hide js-show">and explore potential savings with the calculator below.</span>
+        <noscript>and <a href="/contact-us/form">get in touch with our team</a> for cost estimations.</noscript>
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-label="contact-modal">Contact us</a>
+    {%- endif -%}
+  {% endcall -%}
 
   <noscript>
     <div class="u-fixed-width">
@@ -241,5 +245,7 @@
     </section>
   </div>
   <script src="{{ versioned_static('js/src/ceph-pricing-calculator.js') }}"></script>
+
+  {{ load_form("/ceph/pricing-calculator") | safe }}
 
 {% endblock content %}

--- a/templates/ceph/pricing-calculator.html
+++ b/templates/ceph/pricing-calculator.html
@@ -28,7 +28,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-label="contact-modal">Contact us</a>
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-controls="contact-modal" aria-expanded="false">Contact us</a>
     {%- endif -%}
   {% endcall -%}
 

--- a/templates/ceph/what-is-ceph.html
+++ b/templates/ceph/what-is-ceph.html
@@ -24,7 +24,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-label="contact-modal">Get in touch</a>
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" aria-controls="contact-modal" aria-expanded="false">Get in touch</a>
       <a href="https://www.brighttalk.com/webcast/6793/520582">Watch the webinar - Ceph for Enterprise&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}


### PR DESCRIPTION
## Done
Updated the Ceph pricing calculator page in line with the [copy sheet](https://docs.google.com/spreadsheets/d/1cn5daIlWGpKF5557ERFY4Ok4_0IlJKTDbZjRXcXyhjk/edit?gid=471278338#gid=471278338&range=A2).

## QA
- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph/pricing-calculator
- Ensure the page is line with the sheet

## Issue
https://warthogs.atlassian.net/browse/WD-36995