### PR TITLE
chore: add authd docs sitemap to index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -57,4 +57,7 @@
   <sitemap>
     <loc>https://ubuntu.com/hpc/docs/page/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/authd/page/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Added https://ubuntu.com/docs/authd to the sitemap index as suggested in [Migrating documentation](https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/#adding-sitemaps).