### PR TITLE
chore: upgrade global-nav version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@axe-core/playwright": "^4.8.5",
     "@canonical/cookie-policy": "^3.8.3",
-    "@canonical/global-nav": "3.8.0",
+    "@canonical/global-nav": "3.9.0",
     "@canonical/latest-news": "2.2.1",
     "@canonical/react-components": "^0.60.0",
     "@fullhuman/postcss-purgecss": "6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.4.tgz#38fd82f35d98ab0476bc106b0d813a2719bae26c"
   integrity sha512-mCPcaqscSt/6gbT9Pmf/VDhTmyGC192xz7N+xLs18hpJuFSrNK44vT9jGwnOS5WsdDW2B7tRc78KioTtATPk2g==
 
-"@canonical/global-nav@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.8.0.tgz#3f016b337f93a2b50fccb0cbf8f13c9a10dcee5a"
-  integrity sha512-ioJE4tUENS2L8ubD/lUAA+CvIrtqXB1RTv89vyAW/6eDJWRW8U9Fks+SdKoeoa/IwOtzSC02AOWTPo7rxgj+Mw==
+"@canonical/global-nav@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.9.0.tgz#00708ea529e85f25f217d2da3c2891328847813d"
+  integrity sha512-dFE9ioSSh5BZkG/s9o1HVNUB23HFbkfD4VWPFFxR+YRNNgHjtY5c3WdEMcsHnSL+OnYj0xv5ZqSl/rppI9hdCQ==
   dependencies:
     vanilla-framework "4.35.0"
 


### PR DESCRIPTION
## Done

- Upgrade global-nav version

## QA

- Open the [DEMO](https://ubuntu-com-16454.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-36464](https://warthogs.atlassian.net/browse/WD-36464)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-36464]: https://warthogs.atlassian.net/browse/WD-36464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ