### PR TITLE
chore: update Qualcomm IoT download links from x10 to x11

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -36,7 +36,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-desktop-24.04/"
+              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-desktop-24.04/"
               title="Download Ubuntu Desktop 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -47,7 +47,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-server-24.04/"
+              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-server-24.04/"
               title="Download Ubuntu Server 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -77,7 +77,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a
-            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
+            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
             title="Read full release notes of Ubuntu 24.04 for IQ-9075">release
             notes</a>
         </li>

--- a/templates/download/qualcomm-iot/tabs/evaluation-kit2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit2-tab.html
@@ -36,7 +36,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-desktop-24.04/"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-desktop-24.04/"
                title="Download Ubuntu Desktop 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -47,7 +47,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-server-24.04/"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-server-24.04/"
                title="Download Ubuntu Server 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -58,7 +58,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button"
-               href="https://artifacts.codelinaro.org/qli-ci/flashable-binaries/ubuntu-fw/QCS8300/QLI.1.7-Ver.1.1/QLI.1.7-Ver.1.1-ubuntu-QCS8300-nhlos-bins.tar.gz"
+               href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCS8300/QLI.1.7-Ver.1.2/QLI.1.7-Ver.1.2-ubuntu-QCS8300-nhlos-bins.tar.gz"
                title=" Download boot firmware">Download</a>
           </div>
         </div>
@@ -77,7 +77,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for Qualcomm IQ-8275 Evaluation Kit (EVK) <a
-          href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
+          href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
           title="Read full release notes of Ubuntu 24.04 for IQ-8275">release
           notes</a>
         </li>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -35,7 +35,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-desktop-24.04/"
+              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-desktop-24.04/"
               title=" Download Ubuntu Desktop 24.04 for QCS5430"> Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -46,7 +46,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-server-24.04/"
+              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-server-24.04/"
               title=" Download Ubuntu Server 24.04 for QCS5430">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -76,7 +76,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for QCS5430 <a
-            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
+            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
             title="Read full release notes of Ubuntu 24.04 for QCS5430">release notes</a>
         </li>
       </ul>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -35,7 +35,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-desktop-24.04/"
+              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-desktop-24.04/"
               title=" Download Ubuntu Desktop 24.04 for QCS6490">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -46,7 +46,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/ubuntu-server-24.04/"
+              href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/ubuntu-server-24.04/"
               title=" Download Ubuntu Server 24.04 for QCS6490">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -76,7 +76,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for QCS6490 <a
-            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x10/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
+            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x11/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
             title="Read full release notes of Ubuntu 24.04 for QCS6490">release notes</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- Update download and release notes URLs across all Qualcomm IoT tab templates from `ubuntu-24.04-x10` to `ubuntu-24.04-x11` to point to the latest image release.
- Also updates the boot firmware link for the IQ-8275 EVK from `QLI.1.7-Ver.1.1` to `QLI.1.7-Ver.1.2`.


[COPY DOC](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?usp=sharing)

## QA

- Open the [DEMO](https://ubuntu-com-16459.demos.haus/download/qualcomm-iot)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Navigate to `/download/qualcomm-iot` and verify each board tab (RB3 Gen2, RB3 Gen2 Lite, IQ-9075 EVK, IQ-8275 EVK) shows working download and release notes links pointing to the `x11` path.


## Issue / Card

Fixes [WD-37122](https://warthogs.atlassian.net/browse/WD-37122)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-37122]: https://warthogs.atlassian.net/browse/WD-37122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ