### PR TITLE
WD-37155: change centre to center spelling in footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -143,7 +143,7 @@
               <a href="/engage">Resources</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="/blog/press-centre">Press center</a>
+              <a href="https://canonical.com/press-center">Press center</a>
             </li>
           </ul>
         </div>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -143,7 +143,7 @@
               <a href="/engage">Resources</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="/blog/press-centre">Press centre</a>
+              <a href="/blog/press-centre">Press center</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

Changed `Press centre` to `Press center` (US spelling) in the footer of https://ubuntu.com/

## QA

- Open the [DEMO](https://ubuntu-com-16468.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

- [WD-37155](https://warthogs.atlassian.net/browse/WD-37155)
- [Copy doc](https://docs.google.com/document/d/1FeFQOztvyxnXP4Gp5nsTe0iV7mMNtY4PSfiKxvuPgWI/edit?tab=t.0)

The task also mentions updating https://ubuntu.com/#all-canonical, but the spelling is already correct there.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37155]: https://warthogs.atlassian.net/browse/WD-37155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
