### PR TITLE
fix: Hide unreleased release-cycle versions

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1926,54 +1926,6 @@ def build_github_data_access():
 def build_release_cycle_view():
     get_combined_products = build_github_data_access()
 
-    # For QA, to be deleted once PR is approved
-    def add_dummy_release_cycle_versions(raw_products):
-        """
-        Add test versions to validate release-date filtering.
-        """
-        ubuntu_product = raw_products.get("ubuntu")
-        if not ubuntu_product:
-            return
-
-        deployments = ubuntu_product.get("deployment", [])
-        if not deployments:
-            return
-
-        target_deployment = None
-        for deployment in deployments:
-            if deployment.get("name", "").lower() == "ubuntu":
-                target_deployment = deployment
-                break
-
-        if target_deployment is None:
-            target_deployment = deployments[0]
-
-        versions = target_deployment.setdefault("versions", [])
-        versions.extend(
-            [
-                {
-                    "release": "9.9-unreleased-dummy",
-                    "architecture": ["amd64"],
-                    "supported": "2099-12-01",
-                    "pro-supported": "2104-12-01",
-                    "legacy-supported": "2109-12-01",
-                    "release-date": "2099-01-01",
-                    "upgrade-path": [],
-                    "compatible-ubuntu-lts": [],
-                },
-                {
-                    "release": "9.8-released-dummy",
-                    "architecture": ["amd64"],
-                    "supported": "2032-12-01",
-                    "pro-supported": "2037-12-01",
-                    "legacy-supported": "2042-12-01",
-                    "release-date": "2024-01-01",
-                    "upgrade-path": [],
-                    "compatible-ubuntu-lts": [],
-                },
-            ]
-        )
-
     def format_date(value):
         """Convert YYYY-MM-DD or {date:..., notes:...} to a normalized dict."""
         raw = None
@@ -2149,8 +2101,6 @@ def build_release_cycle_view():
             ["products-data/25.10/products.json"]
         )
         raw_products = raw_files.get("products", {})
-
-        add_dummy_release_cycle_versions(raw_products)
 
         products_data = build_ui_products(raw_products)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1988,7 +1988,7 @@ def build_release_cycle_view():
                 try:
                     dt = datetime.strptime(raw, "%Y-%m-%d").date()
                     formatted = dt.strftime("%b %Y")  # Dec 2025
-                    is_past = dt < date.today()
+                    is_past = dt <= date.today()
                 except ValueError:
                     formatted = raw
 
@@ -2002,7 +2002,7 @@ def build_release_cycle_view():
             try:
                 dt = datetime.strptime(raw, "%Y-%m-%d").date()
                 formatted = dt.strftime("%b %Y")
-                is_past = dt < date.today()
+                is_past = dt <= date.today()
             except ValueError:
                 formatted = raw
             except Exception as e:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1926,7 +1926,7 @@ def build_github_data_access():
 def build_release_cycle_view():
     get_combined_products = build_github_data_access()
 
-    # For QA, to be deleted once PR is approved 
+    # For QA, to be deleted once PR is approved
     def add_dummy_release_cycle_versions(raw_products):
         """
         Add test versions to validate release-date filtering.
@@ -2078,9 +2078,13 @@ def build_release_cycle_view():
                 raw_versions = deployment.get("versions", [])
                 shaped_versions = [shape_version(v) for v in raw_versions]
                 visible_versions = [
-                    v for v in shaped_versions
+                    v
+                    for v in shaped_versions
                     if not version_is_expired(v)
-                    and (v["release_date"]["raw"] is None or v["release_date"]["is_past"])
+                    and (
+                        v["release_date"]["raw"] is None
+                        or v["release_date"]["is_past"]
+                    )
                 ]
 
                 deployments.append(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1926,6 +1926,54 @@ def build_github_data_access():
 def build_release_cycle_view():
     get_combined_products = build_github_data_access()
 
+    # For QA, to be deleted once PR is approved 
+    def add_dummy_release_cycle_versions(raw_products):
+        """
+        Add test versions to validate release-date filtering.
+        """
+        ubuntu_product = raw_products.get("ubuntu")
+        if not ubuntu_product:
+            return
+
+        deployments = ubuntu_product.get("deployment", [])
+        if not deployments:
+            return
+
+        target_deployment = None
+        for deployment in deployments:
+            if deployment.get("name", "").lower() == "ubuntu":
+                target_deployment = deployment
+                break
+
+        if target_deployment is None:
+            target_deployment = deployments[0]
+
+        versions = target_deployment.setdefault("versions", [])
+        versions.extend(
+            [
+                {
+                    "release": "9.9-unreleased-dummy",
+                    "architecture": ["amd64"],
+                    "supported": "2099-12-01",
+                    "pro-supported": "2104-12-01",
+                    "legacy-supported": "2109-12-01",
+                    "release-date": "2099-01-01",
+                    "upgrade-path": [],
+                    "compatible-ubuntu-lts": [],
+                },
+                {
+                    "release": "9.8-released-dummy",
+                    "architecture": ["amd64"],
+                    "supported": "2032-12-01",
+                    "pro-supported": "2037-12-01",
+                    "legacy-supported": "2042-12-01",
+                    "release-date": "2024-01-01",
+                    "upgrade-path": [],
+                    "compatible-ubuntu-lts": [],
+                },
+            ]
+        )
+
     def format_date(value):
         """Convert YYYY-MM-DD or {date:..., notes:...} to a normalized dict."""
         raw = None
@@ -2030,7 +2078,9 @@ def build_release_cycle_view():
                 raw_versions = deployment.get("versions", [])
                 shaped_versions = [shape_version(v) for v in raw_versions]
                 visible_versions = [
-                    v for v in shaped_versions if not version_is_expired(v)
+                    v for v in shaped_versions
+                    if not version_is_expired(v)
+                    and (v["release_date"]["raw"] is None or v["release_date"]["is_past"])
                 ]
 
                 deployments.append(
@@ -2094,8 +2144,9 @@ def build_release_cycle_view():
         raw_files = get_combined_products(
             ["products-data/25.10/products.json"]
         )
-
         raw_products = raw_files.get("products", {})
+
+        add_dummy_release_cycle_versions(raw_products)
 
         products_data = build_ui_products(raw_products)
 


### PR DESCRIPTION
## Done

- Filtered out unreleased versions

## QA

- Open the [DEMO](https://ubuntu-com-16470.demos.haus/about/release-cycle)
- See that `9.8-released-dummy` is visible on both the table and the version drop down select for product Ubuntu, but `9.9-unreleased-dummy` is not

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37195


