### PR TITLE
feat: updated Landscape deployment and operations training information [WD-37171]

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -231,8 +231,7 @@
                 A highly modular training for SRE teams who need to manage Canonical OpenStack. The modules follow different levels, ranging from basics to pro tips, allowing you to tailor the full training program to your team's skills and needs. The peer training sessions are designed to ensure your team acquires experience on specific tasks in a controlled environment and with necessary supervision to correct any errors. Each module spans one to two weeks, depending on the topic.
               </p>
               <div class="p-cta-block u-hide--medium u-hide--small">
-                <a class="p-button--positive"
-                   href="/contact-us">Contact us to book</a>
+                <a class="p-button--positive" href="/contact-us">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
               </div>
             </div>
@@ -427,62 +426,40 @@
                        aria-labelledby="advanced-course-outline"
                        hidden="hidden">
                     <ol class="p-stepped-list">
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Virtualization with QEMU/KVM and libvirt
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        LXD System Containers
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        OpenSSH at Scale
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Boot and System Initialization
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Advanced Storage
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Advanced Filesystem Concepts
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        ZFS on Ubuntu
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Advanced Networking with Netplan
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Security: PAM, ACLs, AppArmor, and Ubuntu Pro
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Advanced Snap Packaging and Ubuntu Core
-                      </p>
-                    </li>
-                    <li class="p-stepped-list__item">
-                      <p class="p-stepped-list__title">
-                        Time Synchronization
-                      </p>
-                    </li>
-                  </ol>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Virtualization with QEMU/KVM and libvirt</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">LXD System Containers</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">OpenSSH at Scale</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Boot and System Initialization</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Advanced Storage</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Advanced Filesystem Concepts</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">ZFS on Ubuntu</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Advanced Networking with Netplan</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Security: PAM, ACLs, AppArmor, and Ubuntu Pro</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Advanced Snap Packaging and Ubuntu Core</p>
+                      </li>
+                      <li class="p-stepped-list__item">
+                        <p class="p-stepped-list__title">Time Synchronization</p>
+                      </li>
+                    </ol>
                   </div>
                 </div>
               </div>
@@ -519,8 +496,8 @@
             <div class="col-6">
               <p class="training-cta--stacked">
                 <a class="p-button--positive"
-                  href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
-                <a  href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
+                   href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
+                <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>
@@ -739,21 +716,20 @@
             <div class="col-6" itemscope itemtype="https://schema.org/Product">
               <h3 class="p-heading--2" itemprop="name">Deployment and operations training</h3>
               <p itemprop="description" class="u-sv3">
-                A two-day hands-on course for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.
+                A three-day hands-on course for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.
               </p>
               <p class="u-hide--medium u-hide--small">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/d55c5afe-Landscape+Deployment+and+Operations+Canonical+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
+                <a class="p-button--positive" href="https://ubuntu.com/contact-us">Contact us to book</a>
+                <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>
             <div class="col-3">
               <ul class="p-list">
                 <li class="p-list__item">
-                  <strong>Duration:</strong> 2 days
+                  <strong>Duration:</strong> 3 days
                 </li>
                 <li class="p-list__item">
-                  <strong>Cost:</strong> USD $17,500 up to 15 attendees, remote delivery
+                  <strong>Cost:</strong> USD $23,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
                   <strong>Location:</strong> Remote or at your premises at extra cost
@@ -767,9 +743,8 @@
           <div class="row u-hide--large">
             <div class="col-6">
               <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/d55c5afe-Landscape+Deployment+and+Operations+Canonical+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
+                <a class="p-button--positive" href="https://ubuntu.com/contact-us">Contact us to book</a>
+                <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -719,7 +719,7 @@
                 A three-day hands-on course for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.
               </p>
               <p class="u-hide--medium u-hide--small">
-                <a class="p-button--positive" href="https://ubuntu.com/contact-us">Contact us to book</a>
+                <a class="p-button--positive" href="/contact-us">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -743,7 +743,7 @@
           <div class="row u-hide--large">
             <div class="col-6">
               <p class="training-cta--stacked">
-                <a class="p-button--positive" href="https://ubuntu.com/contact-us">Contact us to book</a>
+                <a class="p-button--positive" href="/contact-us">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -719,7 +719,8 @@
                 A three-day hands-on course for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.
               </p>
               <p class="u-hide--medium u-hide--small">
-                <a class="p-button--positive" href="/contact-us">Contact us to book</a>
+                <a class="p-button--positive"
+                   href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>
@@ -743,7 +744,8 @@
           <div class="row u-hide--large">
             <div class="col-6">
               <p class="training-cta--stacked">
-                <a class="p-button--positive" href="/contact-us">Contact us to book</a>
+                <a class="p-button--positive"
+                   href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
               </p>
             </div>


### PR DESCRIPTION
## Done

- Updated Landscape deployment and operations training information to reflect changes to the program. 
- Updated "Read the course outline" link to refer to a new updated training pdf.
- Updated "contact us to book" link to refer to the new contact page.

## QA

- Open the [DEMO](http://127.0.0.1:8001/training#landscape)
- Alternatively, check out this feature branch
- Run the site using the command `task` 
- View the site locally in your web browser at: http://127.0.0.1:8001/training#landscape


## Copy Doc
- https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?tab=t.0 
- https://warthogs.atlassian.net/browse/WD-37171?focusedCommentId=1122275 