### PR TITLE
feat(qualcomm): update installation link

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit3-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit3-tab.html
@@ -72,7 +72,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 26.04 for Qualcomm Dragonwing IQ-X7181 Evaluation Kit (EVK) <a
-          href="https://docs.qualcomm.com/doc/80-77183-266/80-77183-266.pdf"
+          href="https://docs.qualcomm.com/doc/80-77183-262/topic/ubuntu-qsg-landing-page-1.html"
           title="Read image installation instructions of Ubuntu 26.04 for IQ-X7181">image installation instructions</a>
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

- Updated Qualcomm Dragonwing IQ-X7181 Evaluation Kit (EVK) image installation instructions link.

https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0

## QA

- go to https://ubuntu-com-16472.demos.haus/download/qualcomm-iot#evaluation-kit3
- click on "image installation instructions" link
- verify the link is now https://docs.qualcomm.com/doc/80-77183-262/topic/ubuntu-qsg-landing-page-1.html

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37196


