### PR TITLE
Update ubuntu.com/security/fips

### DIFF
--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -3,7 +3,7 @@
 {% block title %}Ubuntu FIPS certifications | Security{% endblock %}
 
 {% block meta_description %}
-  Meet FIPS compliance with Ubuntu Pro. Get easy access to FIPS 140-2 and FIPS 140-3 certified modules on any cloud, on prem, and at the edge.
+  Meet FIPS compliance with Ubuntu Pro. Get easy access to FIPS 140-3 certified modules on any cloud, on prem, and at the edge.
 {% endblock %}
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
@@ -31,7 +31,7 @@
     ) -%}
     {%- if slot == 'description' -%}
       <p>
-        Get easy access to FIPS 140-2 and FIPS 140-3 certified modules, required by US federal standards. Run Ubuntu workloads in high-security environments on-prem, in the cloud, and at the edge. Enjoy 1-step access with an Ubuntu Pro subscription.
+        Get easy access to FIPS 140-3 certified modules, required by US federal standards. Run Ubuntu workloads in high-security environments on-prem, in the cloud, and at the edge. Enjoy 1-step access with an Ubuntu Pro subscription.
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
@@ -152,7 +152,7 @@
             </div>
             <h3>Ubuntu Pro helps Lucid Software meet FedRAMP compliance for government contracts</h3>
             <p>
-              By deploying Ubuntu Pro, Lucid acquired AWS-compatible and FIPS 140-2 certified packages and became FedRAMP compliant.
+              By deploying Ubuntu Pro, Lucid acquired AWS-compatible and FIPS certified packages and became FedRAMP compliant.
             </p>
             <hr class="p-rule--muted" />
             <a href="https://canonical.com/case-study/lucid-aws-fedramp-compliance-case-study"
@@ -294,14 +294,14 @@
       <hr class="p-rule" />
       <div class="col">
         <h2>
-          What you need to know
+          What is going to happen to
           <br />
-          about FIPS 140-3
+          FIPS 140-2
         </h2>
       </div>
       <div class="col">
         <p>
-          FIPS 140-3 came into effect in 2020 and supersedes 140-2, which will be sunsetted in September 2026. From Ubuntu 22.04 onwards, we will enable compliance for FIPS 140-3. However, for previous Ubuntu LTS versions, certified for 140-2, it is acceptable to continue using them in existing installations. At Canonical, we are committed to continuing the security maintenance for those LTS versions for the lifetime of their support, with additional years offered with Ubuntu Pro. For more details, explore the release cycle details <a href="/about/release-cycle">here</a>.
+          FIPS 140-2 will be sunsetted in September 2026. From Ubuntu 22.04 LTS onwards, we have enabled compliance for FIPS 140-3. However, existing installations using FIPS 140-2, will still be supported and security maintained for the lifetime of those releases. The NIST CMVP guidelines suggest that it is acceptable to continue using sunset certificates for existing deployments. Any new systems must use valid FIPS 140-3 modules. Starting with Ubuntu 22.04 LTS, Canonical will maintain active FIPS 140-3 certificates for the lifetime of each release as long as the FIPS standard doesn’t change. For more details, explore the release cycle details <a href="/about/release-cycle">here</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done
As specified in [this copydoc](https://docs.google.com/document/d/1moTJCAtFXKD7ZXrxB-EB7GPVyZRTSIdkP-0BhPZl69M/edit?tab=t.0):

- Removed references to FIPS 140-2 from the page description, hero section, and the tabbed section under the Lucid tab.
- Renamed the section "What you need to know about FIPS 140-3" to "What is going to happen to FIPS 140-2".
- Updated the "What is going to happen to FIPS 140-2" section to highlight that FIPS 140-2 will be sunset in September 2026. Existing installations will continue to be supported and receive security maintenance for the lifetime of their respective releases. Starting with Ubuntu 22.04 LTS, FIPS compliance is enabled through FIPS 140-3.

## QA

- Open the [DEMO](https://ubuntu-com-16477.demos.haus/security/fips)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
Fixes [WD-37208](https://warthogs.atlassian.net/browse/WD-37208)

## Screenshots
N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37208]: https://warthogs.atlassian.net/browse/WD-37208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ