### PR TITLE
chore: add ADSys docs sitemap to index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -66,4 +66,7 @@
   <sitemap>
     <loc>https://ubuntu.com/project/docs/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/adsys/page/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Added https://ubuntu.com/docs/adsys to the sitemap index as suggested in [Migrating documentation](https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/#adding-sitemaps).