### PR TITLE
Update link for legal terms in s390x.html

### DIFF
--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -41,7 +41,7 @@
           Ubuntu Server for IBM Z and LinuxONE is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, Ubuntu Pro + Support (24/7) and regular security and reliability fixes from Canonical.
         </p>
         <p>
-          Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="https://canonical.com/legal/short-terms">acceptance of these terms</a>.
+          Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="https://canonical.com/legal">acceptance of these terms</a>.
         </p>
         <p>
           For questions about Ubuntu Pro for IBM Z and LinuxONE, please email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -170,7 +170,7 @@
             <p>
               All information provided will be handled in accordance with the Canonical <a href="https://canonical.com/legal"
     target="_blank"
-    rel="noopener noreferrer">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="https://canonical.com/legal/short-terms">acceptance of these terms</a>.
+    rel="noopener noreferrer">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="https://canonical.com/legal">acceptance of these terms</a>.
             </p>
 
             <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases_yaml.lts.short_version }}', 'eventValue' : undefined });"


### PR DESCRIPTION
## Done

- Replaced legal terms link with https://canonical.com/legal ([copydoc with change as suggestion](https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit?tab=t.0)).

## QA

- Open the [DEMO](https://ubuntu-com-16479.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

