### PR TITLE
fix: remove inline styles from marketing and content templates

### DIFF
--- a/templates/ai/data-science.html
+++ b/templates/ai/data-science.html
@@ -35,8 +35,7 @@
       <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
            alt=""
            fetchpriority="high"
-           style="aspect-ratio: 5.1775700934579;
-                  width: 100%" />
+           class="p-suru-banner-image" />
     </div>
   </section>
 

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -39,8 +39,7 @@
       <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
            alt=""
            fetchpriority="high"
-           style="aspect-ratio: 5.1775700934579;
-                  width: 100%" />
+           class="p-suru-banner-image" />
     </div>
   </section>
 
@@ -334,9 +333,7 @@
         </div>
       </div>
       <div class="col">
-        <div style="background:rgba(0, 0, 0, 0.03);
-                    margin-top: 0.5rem"
-             class="u-align--center">
+        <div class="u-align--center u-background--shade u-margin-top--small">
           {{ image (
           url="https://assets.ubuntu.com/v1/3289e116-7f76ac3a-hp-laptop-studio-jammy 5.png",
           alt="",

--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -59,10 +59,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/blender/thank-you.html
+++ b/templates/blender/thank-you.html
@@ -44,8 +44,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/blog/archives.html
+++ b/templates/blog/archives.html
@@ -3,7 +3,7 @@
 {% block title %}Archives{% endblock %}
 
 {% block content %}
-  <section class="p-strip--accent is-dark is-deep" style="background-color: #333;">
+  <section class="p-strip--accent is-dark is-deep u-background--dark">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-10">
         <h1>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -62,8 +62,7 @@
 
 {% block content %}
   <article>
-    <header class="p-strip--image is-shallow"
-            style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png)">
+    <header class="p-strip--image is-shallow p-strip--blog-paper">
       <div class="row">
         <div class="col-8">
           <h1>{{ article.title.rendered|safe }}</h1>
@@ -149,7 +148,7 @@
       {% endif %}
     </header>
 
-    <section class="p-strip is-shallow" style="overflow-x: initial;">
+    <section class="p-strip is-shallow u-overflow-x--visible">
       <div class="row u-equal-height">
         <div class="col-8">
           {% if 'difference_in_years' in blog_notice %}
@@ -184,8 +183,7 @@
 
       {% for tag in tags %}
         {% if tag.name == 'robotics' %}
-          <section class="p-strip--image is-dark"
-                   style="background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%)">
+          <section class="p-strip--image is-dark p-strip--blog-robotics">
             <div class="row">
               <div class="col-8">
                 <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>

--- a/templates/blog/author.html
+++ b/templates/blog/author.html
@@ -39,11 +39,11 @@
               {% endif %}
 
               {% if author.id == 217 %}
-                <p class="p-media-object__content" style="margin-top: 1rem;">
+                <p class="p-media-object__content u-margin-top--medium">
                   Canonical produces Ubuntu, provides commercial services for Ubuntu's users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.
                 </p>
               {% elif author.description %}
-                <p class="p-media-object__content" style="margin-top: 1rem;">{{ author.description | safe }}</p>
+                <p class="p-media-object__content u-margin-top--medium">{{ author.description | safe }}</p>
               {% endif %}
 
               <ul class="p-inline-list u-no-margin--bottom">

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -22,7 +22,7 @@
     </p>
 
       {% if summary_visible or not article.image.source_url %}
-      <p class="{% if summary_visible %}u-hide--small{% endif %}" style="padding-top:1rem;">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
+      <p class="{% if summary_visible %}u-hide--small{% endif %} u-padding-top--medium">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
       {% endif %}
   </div>
 

--- a/templates/blog/draft-blogs.html
+++ b/templates/blog/draft-blogs.html
@@ -43,8 +43,7 @@
           {% if summary_visible or not article.image.source_url %}
             <p class="{% if summary_visible %}
                         u-hide--small
-                      {% endif %}"
-               style="padding-top:1rem">{{ article.excerpt.raw.replace('[…]', '') |truncate(162) }}</p>
+                      {% endif %} u-padding-top--medium">{{ article.excerpt.raw.replace('[…]', '') |truncate(162) }}</p>
           {% endif %}
         </div>
 

--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -2,7 +2,7 @@
   <form action="" method="get" class="p-form p-form--inline">
     <div class="p-form__group">
       <label for="filter" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
-      <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
+      <select class="js-submit-on-change p-form__control p-blog-filters" id="filter" name="content" aria-label="Filter by content type">
         <option {% if not category %}selected="selected"{% endif %} value="/blog/{{topic}}#posts-list">All content types</option>
         <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=articles#posts-list">Articles</option>
         <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=case-studies#posts-list">Case studies</option>

--- a/templates/contact-us/thank-you.html
+++ b/templates/contact-us/thank-you.html
@@ -394,7 +394,7 @@
                         name="UbuntuDesktopPlannedUsage"
                         maxlength="2000"></textarea>
                     <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage_label">How do you plan to use Ubuntu Desktop?</label>
-                    <div class="p-section--shallow" id="ubuntu_desktop_usage_fields" style="display: flex; align-items: center; gap: 24px;">
+                    <div class="p-section--shallow p-inline-options" id="ubuntu_desktop_usage_fields">
                         <label class="p-checkbox js-checkbox u-no-margin">
                         <input type="checkbox" aria-labelledby="work" class="p-checkbox__input" />
                         <span class="p-checkbox__label" id="work">Work</span>
@@ -529,10 +529,10 @@
         </div>
     </div>
 
-    <template style="display: none" id="articles-template">
+    <template id="articles-template">
         <div class="col-3 col-medium-2 u-equal-height-items">
             <div class="article-image"></div>
-            <h3 class="p-heading--5" style="font-weight: normal">
+            <h3 class="p-heading--5 u-font-weight--normal">
                 <a class="article-link article-title"></a>
             </h3>
         </div>
@@ -589,8 +589,8 @@ var google_conversion_value = 0;
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-<div style="display:inline;">
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+<div>
+<img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
 </div>
 </noscript>
 {{ marketo }}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -84,7 +84,7 @@
           for Ubuntu releases
         </h2>
       </div>
-      <div class="col u-hide--small" id="server-desktop-eol-key" style="padding-top:1rem;"></div>
+      <div class="col u-hide--small u-padding-top--medium" id="server-desktop-eol-key"></div>
     </div>
     <div class="u-fixed-width">
       <div class="u-hide--small" id="server-desktop-eol"></div>
@@ -461,7 +461,7 @@
       <div class="col-6">
         <p>
           <strong>Operating systems IoT developers prefer –
-            <span style="font-weight: 400">Multiple choice poll</span>
+            <span class="u-font-weight--normal">Multiple choice poll</span>
           </strong>
         </p>
         <br />

--- a/templates/desktop/partial/_desktop-latest-news.html
+++ b/templates/desktop/partial/_desktop-latest-news.html
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <template style="display:none" id="desktop-articles-template">
+  <template id="desktop-articles-template">
     <div class="col-3">
       <div class="u-crop--16-9">
         <div class="article-image p-image-wrapper"></div>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -77,10 +77,7 @@
             </div>
           </div>
         {% endif %}
-        <div class="col-3"
-             style="display: flex;
-                    align-items: flex-end;
-                    justify-content: flex-end">
+        <div class="col-3 p-flex--end">
           <div class="u-hide u-show--small">
             <br />
             <br />

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Kontaktinformationen</legend>
     <ul class="p-list u-no-margin--bottom">
       <li>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Información del contacto</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Informazioni sui contatti</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_kr_engage_form.html
+++ b/templates/engage/shared/_kr_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">연락처 정보</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Informações de contato</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-    <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <fieldset class="u-no-padding--top p-engage-form__fieldset">
         <legend class="u-off-screen">Контактная информация</legend>
         <ul class="p-list">
         <li>

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">İletişim bilgileri</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_webinar-embed.html
+++ b/templates/engage/shared/_webinar-embed.html
@@ -7,7 +7,7 @@
   <!-- webinar -->
   <section class="p-strip is-shallow" id="register-section">
     <div class="row" id="brighttalk-webinar">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
+      <div class="jsBrightTALKEmbedWrapper p-webinar-embed">
         <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "en-US", "commId" : {{ metadata["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li>

--- a/templates/hpc/thank-you.html
+++ b/templates/hpc/thank-you.html
@@ -43,8 +43,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -145,7 +145,7 @@
           <li class="p-list__item has-bullet">Detailed snap metrics</li>
         </ul>
         <div class="p-cta-block">
-          <p style="margin-right: 1rem">Ready to find out more?</p>
+          <p class="u-margin-right--medium">Ready to find out more?</p>
           <a href="/internet-of-things/contact-us?product=appstore"
              class="p-button--positive js-invoke-modal"
              aria-controls="iot-modal">Get in touch</a>
@@ -412,10 +412,7 @@
     <div class="row">
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>Commercial support</h3>
           </div>
@@ -434,10 +431,7 @@
       </div>
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>IoT Professional Services</h3>
           </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -185,8 +185,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.screenly.io/">
             {{ image(url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",
                         alt="Screenly",
@@ -204,8 +203,7 @@
            title="View Screenly webinar">View webinar&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.4yousee.com.br/">
             {{ image(url="https://assets.ubuntu.com/v1/391ea778-logo-4yousee.png",
                         alt="4YouSee",
@@ -225,8 +223,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html">
             {{
             image (
@@ -249,8 +246,7 @@
         </p>
       </div>
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.risevision.com/">
             {{ image(url="https://assets.ubuntu.com/v1/f2396b21-logo-risevision.png",
                         alt="Rise Vision",
@@ -279,8 +275,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.boldmind.co.uk/">
             {{ image(url="https://assets.ubuntu.com/v1/d4e5daf4-logo-boldmind.png",
                         alt="Boldmind",
@@ -298,8 +293,7 @@
            title="View Boldmind webinar">View webinar</a>
       </div>
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.limemicro.com/">
             {{ image(url="https://assets.ubuntu.com/v1/5e68dad7-logo-lime-microsystems.png",
                         alt="Lime Micro",
@@ -319,8 +313,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.hoxtonanalytics.com/">
             {{ image(url="https://assets.ubuntu.com/v1/d4ae60aa-logo-hoxton-analytics.svg",
                         alt="Hoxton Analytics",

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -351,10 +351,7 @@
       <div class="row">
         <div class="col-6">
           <hr class="p-rule--highlight u-no-margin--bottom" />
-          <div class="p-card--overlay u-no-padding--top"
-               style="padding: 1.5rem;
-                      height: 95%;
-                      overflow: hidden">
+          <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
             <div class="p-section--shallow">
               <h3 class="u-no-margin--bottom">Ubuntu</h3>
             </div>
@@ -374,10 +371,7 @@
         </div>
         <div class="col-6">
           <hr class="p-rule--highlight u-no-margin--bottom" />
-          <div class="p-card--overlay u-no-padding--top"
-               style="padding: 1.5rem;
-                      height: 95%;
-                      overflow: hidden">
+          <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
             <div class="p-section--shallow">
               <h3 class="u-no-margin--bottom">Ubuntu Core</h3>
             </div>

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -45,8 +45,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -23,9 +23,7 @@
     </div>
   </section>
   <section class="p-strip--light u-no-padding--top">
-    <div class="row u-vertically-center"
-         style="position: relative;
-                top: -2rem">
+    <div class="row u-vertically-center p-strip--pulled-up">
       <div class="col-12">
         <h5 class="p-muted-heading u-align--center">Watch Ubuntu's original KubeCon demos on multi-cloud Kubernetes</h5>
         <div class="u-embedded-media">
@@ -36,7 +34,7 @@
                   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                   allowfullscreen></iframe>
         </div>
-        <div style="padding-top: 2rem;">
+        <div class="u-padding-top--x-large">
           <p class="p-button--positive p-button--inline"
              onclick="LC_API.open_chat_window();return false">Private Livechat</p>
           <p class="p-button p-button--inline js-invoke-modal"

--- a/templates/landscape/compare.html
+++ b/templates/landscape/compare.html
@@ -47,9 +47,8 @@
       <div class="p-section--shallow">
         <h2>Compare Landscape options</h2>
       </div>
-      <div style="overflow-x: auto;">
-        <table aria-label="Pricing comparison table"
-               style="table-layout: unset">
+      <div class="u-overflow-x--auto">
+        <table class="u-table-layout--auto" aria-label="Pricing comparison table">
           <thead>
             <tr>
               <th>Feature</th>

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -32,7 +32,7 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="SQL server on Kubernetes" width="560" height="315" src="https://www.youtube.com/embed/sRuVBMclM_k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -54,7 +54,7 @@
       <a href="/core">Find out more about Ubuntu Core&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Industry 4.0 needs a complete automation solution" width="560" height="315" src="https://www.youtube.com/embed/Rv54iqchy5M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -64,7 +64,7 @@
 <section class="p-strip is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Plugging the Boothole" width="560" height="315" src="https://www.youtube.com/embed/2DOcm4yMvMw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -107,18 +107,18 @@
       </p>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Mastering multicloud for HPC systems" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/SGrRqCuiT90" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
   {# Domotz #}
   <div class="row u-equal-height">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Streamlined provisioning of IoT devices" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/8u-sM4xpfZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -143,7 +143,7 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
   {# Plus One Robotics #}
   <div class="row u-equal-height">
@@ -167,7 +167,7 @@
       </p>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="The open (source) road to smarter robots" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/Ma1hzMf6YO0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -183,7 +183,7 @@
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Scaling Years of Growth in One Week" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/WvZB3xn1bWg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -202,7 +202,7 @@
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
 
   <div class="row u-equal-height">
@@ -215,19 +215,19 @@
       <p>This is an introductory look at how distributed and edge computing has enhanced computer vision and sensor fusion workloads. Hear about system architecture design choices and practical examples for deployment.</p>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="An introudction to edge computing for computer vision and robotics" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/txNszs1AJf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Building the data centre" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/dSZqax12Q7A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -251,7 +251,7 @@
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Netflix talks about Extended BPF" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/7pmXdG8-7WU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -277,7 +277,7 @@
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
@@ -300,19 +300,19 @@
     </div>
 
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Adobe meets huge demand with a lean approach" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/IUgODRm9Soc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="How Roblox went from Windows to Ubuntu in 7 days for edge compute nodes" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/SwlU4U-BWRo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -85,7 +85,7 @@
           integrity and continuous
           production.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/007d3fe1-Industrial@3x.png",
                     alt="",
                     width="284",
@@ -102,7 +102,7 @@
           critical
           infrastructure they run on.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/04c896e6-Telco@3x.png",
                     alt="",
                     width="284",
@@ -118,7 +118,7 @@
           must complete tasks within
           specified deadlines.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/9969e00e-Healthcare@3x.png",
                     alt="",
                     width="284",
@@ -134,7 +134,7 @@
           infotainment systems, HMIs and
           latency-sensitive scenarios.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/4ffd9127-Automotive@3x.png",
                     alt="",
                     width="284",

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -8,8 +8,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1OA_Eg1200fHpt7YYkE4qubiWfxL_U5fnlA0OObRe2n8/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'
-); background-position: 77% 0%;">
+<section class="p-strip--image is-dark is-deep p-strip--rfp-hero">
 <div class="row">
   <div class="col-7">
     <div class="p-card--overlay">

--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -351,10 +351,10 @@
           <table aria-label="ESM for ROS &ndsah; Ubuntu Pro subscriptions">
             <thead>
               <tr>
-                <th class="u-no-padding--left" style="width: 39%">&nbsp;</th>
-                <th style="width: 25%">Ubuntu LTS</th>
-                <th style="width: 25%">Ubuntu Pro (Infra-only)</th>
-                <th style="width: 25%">Ubuntu Pro</th>
+                <th class="u-no-padding--left u-width--39">&nbsp;</th>
+                <th class="u-table-col--quarter">Ubuntu LTS</th>
+                <th class="u-table-col--quarter">Ubuntu Pro (Infra-only)</th>
+                <th class="u-table-col--quarter">Ubuntu Pro</th>
               </tr>
             </thead>
             <tbody>
@@ -424,7 +424,7 @@
       <div class="grid-row">
         <div class="grid-col-start-large-5 grid-col-4">
           <hr class="p-rule--muted is-fixed-width" />
-          <span style="margin-right: 1rem;">Want to know more?</span>
+          <span class="u-margin-right--medium">Want to know more?</span>
           <a href="/internet-of-things/contact-us?product=robotics"
             class="p-button js-invoke-modal"
             aria-controls="robotics-modal"

--- a/templates/robotics/thank-you.html
+++ b/templates/robotics/thank-you.html
@@ -28,8 +28,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -199,15 +199,13 @@
       <div class="u-align--right u-sv1">
         <a href="#"
            id="carousel-previous"
-           class="p-carousel__previous"
-           style="text-decoration: unset">
+           class="p-carousel__previous u-text-decoration--none">
           <i class="p-icon--chevron-left">Previous image</i>
         </a>
         &nbsp;
         <a href="#"
            id="carousel-next"
-           class="p-carousel__next"
-           style="text-decoration: unset">
+           class="p-carousel__next u-text-decoration--none">
           <i class="p-icon--chevron-right">Next image</i>
         </a>
       </div>
@@ -407,7 +405,7 @@
         <div class="p-equal-height-row">
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/fed38b56-new-linux.png",
                                 alt="",
                                 width="566",
@@ -426,7 +424,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/ec34b48a-new-app-ecosystem.png",
                                 alt="",
                                 width="566",
@@ -445,7 +443,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/8a92eed1-new-content-design.png",
                                 alt="",
                                 width="566",
@@ -464,7 +462,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/c71d8fa6-new-community.png",
                                 alt="",
                                 width="566",
@@ -483,7 +481,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/359e01a1-new-infrastructure.png",
                                 alt="",
                                 width="566",
@@ -503,7 +501,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/5fba2c50-new-devices.png",
                                 alt="",
                                 width="566",
@@ -523,7 +521,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/70b56649-new-data.png",
                                 alt="",
                                 width="566",
@@ -542,7 +540,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/5c5e4abc-new-gaming.png",
                                 alt="",
                                 width="566",
@@ -562,7 +560,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/e298d421-new-security.png",
                                 alt="",
                                 width="566",

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -941,12 +941,12 @@
   <noscript>
     <img height="1"
          width="1"
-         style="display:none"
+         class="u-hide"
          alt=""
          src="https://analytics.twitter.com/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
     <img height="1"
          width="1"
-         style="display:none"
+         class="u-hide"
          alt=""
          src="https://t.co/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
   </noscript>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -47,8 +47,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -141,15 +141,13 @@
               </div>
               <div class="l-tutorial__pagination">
                 {% if loop.first %}
-                  <button class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom"
-                          disabled
-                          style="margin-right: 1rem">
+                  <button class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom u-margin-right--medium"
+                          disabled>
                     <i class="p-icon--chevron-down">Previous step</i>
                   </button>
                 {% else %}
                   <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}"
-                     class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom"
-                     style="margin-right: 1rem">
+                     class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom u-margin-right--medium">
                     <i class="p-icon--chevron-down">Previous step</i>
                   </a>
                 {% endif %}

--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -204,7 +204,7 @@
                 <div class="row p-section--shallow" id="ubuntu-latest"></div>
             </div>
         </div>
-        <template style="display:none" id="blog-template">
+        <template id="blog-template">
             <div class="col-3 col-medium-2">
                 <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
                 <h3 class="p-heading--5">

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -349,7 +349,7 @@
           <div class="row p-section--shallow" id="ubuntu-wsl-latest"></div>
         </div>
       </div>
-      <template style="display:none" id="blog-template">
+      <template id="blog-template">
         <div class="col-3 col-medium-2">
           <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
           <h3 class="p-heading--5">

--- a/templates/wsl/thank-you.html
+++ b/templates/wsl/thank-you.html
@@ -42,10 +42,9 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>


### PR DESCRIPTION
## Done
- Chunk of https://github.com/canonical/ubuntu.com/pull/16476
- Removed inline style= attributes.
- Added static/sass/_utilities.scss atomic properties

## QA
- Open demo
- Navigate to pages that are modified by `Files changed`
- Ensure there are no breaking CSS changes (eg. buttons work as expected and things don't look strange)
- Open console and ensure there are no errors caused by removing inline styles.
