### PR TITLE
fix: remove inline styles from commerce and account templates

### DIFF
--- a/templates/account/invoices/_edit_billing_modal.html
+++ b/templates/account/invoices/_edit_billing_modal.html
@@ -1,4 +1,4 @@
-<div style="display: none;" class="p-modal" id="edit-billing-modal">
+<div class="p-modal u-hide" id="edit-billing-modal">
   <section class="p-modal__dialog"
            role="dialog"
            aria-modal="true"

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -10,9 +10,7 @@
 
   <section class="p-strip--suru-topped p-strip-account-page">
     <div class="u-fixed-width">
-      <div style="display: flex;
-                  justify-content: space-between;
-                  align-items: baseline">
+      <div class="p-invoices__header">
         <h1>Billing</h1>
         <button id="edit-billing-btn"
                 class="p-button"
@@ -20,7 +18,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-3" style="padding: 0.75rem 0">
+      <div class="col-3 p-invoices__total">
         <select name="marketplace" id="marketplace-dropdown">
           <option value="">All invoices</option>
           <option value="blender" {% if marketplace == 'blender' %}selected{% endif %}>Blender Support</option>
@@ -37,7 +35,7 @@
               <th>Service</th>
               <th>Date</th>
               <th width="10%">Status</th>
-              <th class="u-align--right" style="padding-right: 5%">Total</th>
+              <th class="u-align--right p-invoices__cell">Total</th>
               <th>Invoice and receipt</th>
             </thead>
             <tbody>
@@ -69,7 +67,7 @@
                       <div class="p-chip is-readonly">Pending</div>
                     {% endif %}
                   </td>
-                  <td class="u-align--right" aria-label="Total" style="padding-right: 5%">
+                  <td class="u-align--right p-invoices__cell" aria-label="Total">
                     {% if invoice.invoice %}
                       <span class="js-format-price">{{ invoice.get_total() }}</span>
                     {% else %}

--- a/templates/account/payment-methods/_confirm-remove-modal.html
+++ b/templates/account/payment-methods/_confirm-remove-modal.html
@@ -1,4 +1,4 @@
-<div style="display: none;" class="p-modal" id="remove-payment-modal">
+<div class="p-modal u-hide" id="remove-payment-modal">
   <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Remove payment method</h2>

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -35,14 +35,13 @@
       <h1>Payment method</h1>
 
       <div id="default-payment-method-section"
-           class="row {% if not default_payment_method.id %}u-hide{% endif %}"
-           style="margin-top: 2rem">
+           class="row {% if not default_payment_method.id %}u-hide{% endif %} u-margin-top--x-large">
         <div class="col-4 current-payment-method">
           {% with brand=default_payment_method["brand"] %}
             {% include "account/payment-methods/_card-logo.html" %}
           {% endwith %}
           <p>
-            <span style="text-transform: capitalize;">{{ default_payment_method["brand"] }}</span> ending in {{ default_payment_method["last4"] }}
+            <span class="u-text-transform--capitalize">{{ default_payment_method["brand"] }}</span> ending in {{ default_payment_method["last4"] }}
           </p>
         </div>
         <p class="col-4 u-text--muted">Default payment method</p>
@@ -55,8 +54,7 @@
       </div>
 
       <div id="edit-payment-method-section"
-           class="row u-hide"
-           style="margin-top: 2rem">
+           class="row u-hide u-margin-top--x-large">
         <div class="col-8">
           <div id="card-element"></div>
           <span id="card-errors" class="p-form-validation__message u-hide"></span>
@@ -72,11 +70,10 @@
            class="p-strip {% if default_payment_method.id %}u-hide{% endif %}">
         <div class="row">
           <div class="u-align--right col-4">
-            <i style="width: 4rem; height: 4rem; margin-top: 0.4rem;" 
-               class="p-icon--credit-card u-hide--medium u-hide--small"></i>
+            <i class="p-icon--credit-card u-hide--medium u-hide--small p-icon--credit-card-large"></i>
           </div>
           <div class="u-align--left col-8 col-medium-4 col-small-3">
-            <p style="margin-bottom: 0;" class="p-heading--4">You have no payment method saved</p>
+            <p class="p-heading--4 u-no-margin--bottom">You have no payment method saved</p>
             <p>Add a card to resize and automatically renew your subscriptions.</p>
             <button class="p-button--positive" id="add-payment-method">Add card</button>
           </div>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -8,7 +8,7 @@
       <section id="order-info" class="p-strip is-shallow u-no-padding--top u-hide">
       </section>
 
-      <section class="p-strip is-shallow u-no-padding" style="overflow-x: visible;">
+      <section class="p-strip is-shallow u-no-padding u-overflow-x--visible">
         <div id="payment-errors" class="p-notification--negative u-hide">
           <div class="p-notification__content">
             <p class="p-notification__message"></p>
@@ -279,19 +279,19 @@
       </span>
 
       <div class="row u-no-padding">
-        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin" style="text-align: center;">
+        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin u-align--center">
           Cancel
         </button>
 
-        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive u-no-margin" style="text-align: center;" disabled type="submit">
+        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive u-no-margin u-align--center" disabled type="submit">
           Continue
         </button>
 
-        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive u-no-margin" style="text-align: center;" disabled type="submit">
+        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive u-no-margin u-align--center" disabled type="submit">
           Pay
         </button>
 
-        <button class="js-close-modal col-small-2 col-medium-2 col-3 p-button" style="text-align: center;">OK</button>
+        <button class="js-close-modal col-small-2 col-medium-2 col-3 p-button u-align--center">OK</button>
       </div>
     </footer>
   </div>

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-12 u-sv3" style="overflow-x: auto">
+  <div class="col-12 u-sv3 u-overflow-x--auto">
     <table class="p-table--mobile-card advantage-table">
       <thead>
         <tr>
@@ -10,7 +10,7 @@
           <th class="u-align--center">Advanced</th>
         </tr>
         <tr>
-          <th colspan="5" style="background-color: #f7f7f7; padding: 0.75rem">
+          <th class="p-table__cell--shaded" colspan="5">
             <strong>What's included</strong>
           </th>
         </tr>
@@ -337,10 +337,7 @@
       </tbody>
       <thead>
         <tr>
-          <th colspan="5"
-              style="background-color: #f7f7f7;
-                     border-top: 1px solid rgba(0, 0, 0, 0.1);
-                     padding: 0.75rem">
+          <th colspan="5" class="p-table__cell--shaded-bordered">
             <strong>Price per year</strong>
           </th>
         </tr>

--- a/templates/advantage/subscribe/_purchase-modal.html
+++ b/templates/advantage/subscribe/_purchase-modal.html
@@ -1,4 +1,4 @@
-<div class="p-modal p-modal--ua-payment is-details-mode" id="purchase-modal" style="display: none;">
+<div class="p-modal p-modal--ua-payment is-details-mode u-hide" id="purchase-modal">
   <div id="react-root" class="p-modal__dialog" role="dialog" aria-labelledby="modal-title">
   </div>
 </div>

--- a/templates/advantage/subscribe/form/_type_select.html
+++ b/templates/advantage/subscribe/form/_type_select.html
@@ -119,8 +119,7 @@
 
     <div
       id="aws-public-cloud"
-      class="col-12 subscribe-section u-hide"
-      style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem"
+      class="col-12 subscribe-section u-hide u-background--light u-margin-bottom--large u-padding--large"
     >
       <span>
         <strong>
@@ -149,8 +148,7 @@
 
     <div
       id="azure-public-cloud"
-      class="col-12 subscribe-section u-hide"
-      style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem"
+      class="col-12 subscribe-section u-hide u-background--light u-margin-bottom--large u-padding--large"
     >
       <span>
         <strong>
@@ -180,8 +178,7 @@
     </div>
     <div
       id="gcp-public-cloud"
-      class="col-12 subscribe-section u-hide"
-      style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem"
+      class="col-12 subscribe-section u-hide u-background--light u-margin-bottom--large u-padding--large"
     >
       <span>
         <strong>

--- a/templates/advantage/subscribe/form/_ubuntu_version_select.html
+++ b/templates/advantage/subscribe/form/_ubuntu_version_select.html
@@ -53,7 +53,7 @@
         </div>
       </div>
       <div class="col-12">
-        <div class="p-card" style="background-color: #f7f7f7">
+        <div class="p-card u-background--light">
           <h4 class="p-card__title">
             For Ubuntu <span id="version-number">18.04</span>, all UA plans
             include:
@@ -93,7 +93,7 @@
   </div>
 </li>
 
-<div class="p-modal" id="other-versions-modal" style="display: none;">
+<div class="p-modal u-hide" id="other-versions-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="other-versions-modal-title" aria-describedby="other-versions-modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="other-versions-modal-title">Other versions?</h2>
@@ -101,7 +101,7 @@
     </header>
     <div class="row">
         <span>Ubuntu Advantage is available only for Ubuntu 20.04 LTS, 18.04 LTS, 16.04 LTS, and 14.04 ESM.<br /><br />You can:</span>
-        <ul style="list-style-type: disc;">
+        <ul class="u-list-style--disc">
           <li>
             <a href="/tutorials/tutorial-upgrading-ubuntu-desktop#1-before-you-start">Upgrade to a supported version</a>
           </li>

--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -14,7 +14,7 @@
     
     {% if contract["renewal"] %}
       {% if contract["renewal"]["renewable"] or contract["renewal"]["actionable"] == false %}
-        <div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}warning{% endif %}"></i>&nbsp;&nbsp;
+        <div class="u-toggle__supplemental p-contract-name__meta"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}warning{% endif %}"></i>&nbsp;&nbsp;
           {% if contract["contractInfo"]["daysTillExpiry"] < 0 %}
             Expired
           {% elif contract["contractInfo"]["daysTillExpiry"] == 0 %}

--- a/templates/credentials/base_cred.html
+++ b/templates/credentials/base_cred.html
@@ -10,7 +10,7 @@
 
 {% block outer_content %}
   {% if show_cred_maintenance_alert %}
-    <div class="p-notification--information" style="margin:1rem">
+    <div class="p-notification--information u-margin--medium">
       <div class="p-notification__content">
         <h5 class="p-notification__title">Maintenance Scheduled</h5>
         <p class="p-notification__message" id="cred-maintenance-message"></p>

--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -10,7 +10,7 @@
   <section class="p-suru--fan-top is-dark">
     <div class="row u-equal-height">
       <div class="col-6">
-        <h1 style="font-weight: 800">Canonical Academy Exams FAQ</h1>
+        <h1 class="u-font-weight--bold">Canonical Academy Exams FAQ</h1>
       </div>
     </div>
   </section>
@@ -51,7 +51,7 @@
       </div>
       <div class="col-6">
         <!-- Section 1 -->
-        <h2 id="about" style="font-weight: 600">About the exams</h2>
+        <h2 id="about" class="p-heading--bold">About the exams</h2>
         <h3>What is a qualification? Is this a certificate program or a certification program? What’s the difference?</h3>
         <p>
           Our program combines the rigor of professional certification with the skills validation of a qualification program. Each professional track denotes that the successful candidate is qualified to perform the occupation to Canonical standards.
@@ -142,7 +142,7 @@
         </p>
 
         <!-- Section 2 -->
-        <h2 id="before" style="font-weight: 600">Before your exam</h2>
+        <h2 id="before" class="p-heading--bold">Before your exam</h2>
 
         <h3>Am I ready to take a Canonical Exam?</h3>
         <p>Ultimately, only you can make that decision, but some factors to consider:</p>
@@ -184,7 +184,7 @@
         </p>
 
         <!-- Section 3 -->
-        <h2 id="environment" style="font-weight: 600">Taking the exam: Exam Environment</h2>
+        <h2 id="environment" class="p-heading--bold">Taking the exam: Exam Environment</h2>
 
         <h3>How do I access the environment?</h3>
         <p>
@@ -234,7 +234,7 @@
         </h3>
 
         <!-- Section 4 -->
-        <h2 id="proctoring" style="font-weight: 600">Taking the Exam: Proctoring</h2>
+        <h2 id="proctoring" class="p-heading--bold">Taking the Exam: Proctoring</h2>
 
         <h3>Is this exam proctored?</h3>
         <p>
@@ -275,7 +275,7 @@
         </p>
 
         <!-- Section 5 -->
-        <h2 id="examQuestions" style="font-weight: 600">Taking the Exam: Exam Questions</h2>
+        <h2 id="examQuestions" class="p-heading--bold">Taking the Exam: Exam Questions</h2>
 
         <h3>What should I expect from the exam questions?</h3>
         <p>
@@ -296,7 +296,7 @@
         <p>Yes, you are able to mark items for review before completing the exam.</p>
 
         <!-- Section 6 -->
-        <h2 id="problems" style="font-weight: 600">Problems during the exam</h2>
+        <h2 id="problems" class="p-heading--bold">Problems during the exam</h2>
 
         <h3 id="problems-0">What happens if I close my browser tab during the exam?</h3>
         <p>
@@ -324,7 +324,7 @@
         </p>
 
         <!-- Section 7 -->
-        <h2 id="after" style="font-weight: 600">After the exam</h2>
+        <h2 id="after" class="p-heading--bold">After the exam</h2>
 
         <h3>When will I receive my result?</h3>
         <p>

--- a/templates/credentials/self-study.html
+++ b/templates/credentials/self-study.html
@@ -26,7 +26,7 @@
   </section>
   <section>
     <div class="row">
-      <div class="p-tabs" style="padding-bottom:4rem;">
+      <div class="p-tabs u-padding-bottom--xx-large">
         <div class="p-tabs__list u-no-margin--bottom"
              role="tablist"
              aria-label="CUE Syllabus">
@@ -63,7 +63,7 @@
           </div>
         </div>
       </div>
-      <div class="col-12" style="padding-bottom:4rem;">
+      <div class="col-12 u-padding-bottom--xx-large">
         <div tabindex="0"
              role="tabpanel"
              id="generalResources-tab"

--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -38,9 +38,9 @@
                     <span class="p-radio__label">{{ exam.displayName }}</span>
                   </label>
                   <hr class="p-rule" />
-                  <p style="padding-left: 1rem; padding-right: 1rem;">{{ exam.metadata[0].value }}</p>
+                  <p class="u-padding-left--medium u-padding-right--medium">{{ exam.metadata[0].value }}</p>
                   <hr class="p-rule" />
-                  <h5 id="exam-price" class="u-align--right" style="padding-right: 1rem">
+                  <h5 id="exam-price" class="u-align--right u-padding-right--medium">
                     {% if is_disabled %}
                       Coming soon
                     {% else %}
@@ -69,18 +69,16 @@
         {% set is_discounted = True if metadata_length > 1 and exam.metadata[1].discountPrice else False %}
         <div class="col-12 u-hide u-show--small">
           <div id="price-card-{{ loop.index0 }}"
-               class="p-card--radio--column {% if loop.index0 == exam_index %}is-selected{% endif %}"
-               style="margin-left: 1rem;
-                      margin-right: 1rem">
+               class="p-card--radio--column {% if loop.index0 == exam_index %}is-selected{% endif %} u-margin-left--medium u-margin-right--medium">
             <label class="p-radio--inline" label="{{ exam.name }}">
               <input id="price-radio" {% if is_disabled %}disabled{% endif %} class="p-radio__input" type="radio" name="exam-radio--small" value={{ loop.index0 }} {% if loop.index0 == exam_index %}checked{% endif %} {% if is_disabled %}disabled{% endif %} />
               <span class="p-radio__label">{{ exam.displayName }}</span>
             </label>
             <span>
-              <p style="padding-left: 1rem; padding-right: 1rem;">{{ exam.metadata[0].value }}</p>
+              <p class="u-padding-left--medium u-padding-right--medium">{{ exam.metadata[0].value }}</p>
             </span>
             <span>
-              <h5 id="exam-price" class="u-align--right" style="padding-right: 1rem">
+              <h5 id="exam-price" class="u-align--right u-padding-right--medium">
                 {% if is_disabled %}
                   Coming Soon!
                 {% else %}
@@ -109,13 +107,12 @@
       <div class="row">
         {% set exam = exams[exam_index] %}
         {% set is_discounted = True if exam.metadata|length > 1 and exam.metadata[1].discountPrice else False %}
-        <div class="col-6" style="display: flex;">
+        <div class="col-6 u-vertically-center">
           <p id="selected-product-name"
-             class="order-name p-heading--2"
-             style="margin-block: auto">{{ exam.displayName }}</p>
+             class="order-name p-heading--2">{{ exam.displayName }}</p>
         </div>
-        <div class="col-3 col-small-2" style="display: flex;">
-          <p id="exam-price" class="p-heading--2" style="margin-block: auto;">
+        <div class="col-3 col-small-2 u-vertically-center">
+          <p id="exam-price" class="p-heading--2">
             <span id="total-price" class="exam-price">
               {% if is_discounted %}
                 {{ exam.metadata[1].currency }}{{ exam.metadata[1].discountPrice }}
@@ -125,8 +122,8 @@
             </span>
           </p>
         </div>
-        <div class="col-3 col-small-2 u-align--right" style="display: flex;">
-          <button type="submit" class="p-button--positive" style="margin-block: auto;">Buy now</button>
+        <div class="col-3 col-small-2 u-align--right u-vertically-center">
+          <button type="submit" class="p-button--positive">Buy now</button>
         </div>
       </div>
     </section>

--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -50,7 +50,7 @@
              id="{{ exam['exam_name'] }}-tab"
              aria-labelledby="{{ exam['exam_name'] }}"
              {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
-          <div class="row" style="padding: 4rem 0rem;">
+          <div class="row u-padding-y--xx-large">
             <div class="col-6">
               <p class="p-heading--5">OVERVIEW</p>
             </div>
@@ -75,7 +75,7 @@
     </div>
     <div class="u-fixed-height">
       <div class="row">
-        <a href="/credentials/schedule" style="display: none;">
+        <a href="/credentials/schedule" class="u-hide">
           <button class="p-button--positive">Schedule your exam now</button>
         </a>
       </div>

--- a/templates/credentials/thank-you.html
+++ b/templates/credentials/thank-you.html
@@ -53,10 +53,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/download/amd/index.html
+++ b/templates/download/amd/index.html
@@ -19,7 +19,7 @@
   <section class="p-strip is-deep">
     <div class="row">
       <div class="col-3 col-medium-2">
-        <div class="p-strip is-shallow" style="padding-top: 1rem;">
+        <div class="p-strip is-shallow u-padding-top--medium">
           {{
             image(
               url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",

--- a/templates/download/cloud/tabs/_azure.html
+++ b/templates/download/cloud/tabs/_azure.html
@@ -3,8 +3,7 @@
      role="tabpanel"
      id="azure-tab"
      aria-labelledby="azure">
-  <div class="col-3 col-medium-3 p-section--shallow"
-       style="margin-top: -40px">
+  <div class="col-3 col-medium-3 p-section--shallow p-nudge-margin-top--negative">
     {{ image(url="https://assets.ubuntu.com/v1/b009a1df-microsoft-azure-logo-light.png",
         alt="Azure",
         width="100",

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -127,8 +127,7 @@
                 <label for="amount-community-input" class="u-off-screen">
                   Contribution amount to community projects in US dollars
                 </label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-community-input"
@@ -153,8 +152,7 @@
                        id="amount-desktop"
                        type="range" />
                 <label for="amount-desktop-input" class="u-off-screen">Contribution to desktop projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-desktop-input"
@@ -179,8 +177,7 @@
                        id="amount-canonical"
                        type="range" />
                 <label for="amount-canonical-input" class="u-off-screen">Contribution to canonical projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-canonical-input"
@@ -205,8 +202,7 @@
                        id="amount-things"
                        type="range" />
                 <label for="amount-things-input" class="u-off-screen">Contribution to IOT projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-things-input"
@@ -231,8 +227,7 @@
                        id="amount-cloud"
                        type="range" />
                 <label for="amount-cloud-input" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-cloud-input"

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -135,7 +135,7 @@
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases_yaml.latest.core_version }}', 'eventValue' : undefined });"
              class="p-button">Download Ubuntu Core {{ releases_yaml.latest.core_version }}</a>
           {% if releases_yaml.latest.rasp_pi_core_24_size %}
-            <span class="u-text--muted" style="margin-top: 0.5rem;">{{ releases_yaml.latest.rasp_pi_core_24_size }}</span>
+            <span class="u-text--muted u-margin-top--small">{{ releases_yaml.latest.rasp_pi_core_24_size }}</span>
           {% endif %}
         </p>
       </div>
@@ -166,16 +166,16 @@
   <section class="p-section">
     <div class="row">
       <div class="col-medium-6 col-9 col-start-large-4 u-table-scroll--medium u-table-scroll--small">
-        <table class="u-table-horizontal-scroll__table"
+        <table class="u-table-horizontal-scroll__table p-table--rpi-support"
                aria-label="Raspberry Pi support with Ubuntu">
           <thead>
             <tr>
-              <th style="width: 15%;"></th>
-              <th style="width: 10%;"></th>
-              <th style="width: 18%">
+              <th></th>
+              <th></th>
+              <th>
                 Ubuntu 26.04 <abbr title="Long-term support">LTS</abbr>
               </th>
-              <th style="width: 15%">Ubuntu Core 24</th>
+              <th>Ubuntu Core 24</th>
             </tr>
           </thead>
           <tbody>
@@ -307,7 +307,7 @@
         <div class="row p-section--shallow" id="blog-latest"></div>
       </div>
     </div>
-    <template style="display:none" id="blog-template">
+    <template id="blog-template">
       <div class="col-3 col-medium-2">
         <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
         <h3 class="p-heading--5">

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -153,7 +153,7 @@
       </div>
     </div>
 
-    <template style="display:none" id="blog-template">
+    <template id="blog-template">
       <div class="col-3 col-medium-2">
         <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
         <h3 class="p-heading--5">

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -467,7 +467,7 @@
       </div>
     </div>
 
-    <template style="display:none" id="ubuntu-server-template">
+    <template id="ubuntu-server-template">
       <div class="col-3 col-medium-2">
         <div class="u-crop--16-9">
           <div class="article-image p-image-wrapper"></div>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -226,7 +226,7 @@
       </div>
     </div>
 
-    <template style="display:none" id="ubuntu-server-template">
+    <template id="ubuntu-server-template">
       <div class="col-3 col-medium-2">
         <h3 class="p-heading--5">
           <a class="article-link article-title"></a>

--- a/templates/download/shared/_first-boot-setup.html
+++ b/templates/download/shared/_first-boot-setup.html
@@ -8,7 +8,7 @@
       <li class="p-list__item">Press enter then select "Start" to begin configuring your network and an administrator account. Follow the instructions on the screen, you will be asked to configure your network and enter your Ubuntu SSO credentials.</li>
       <li class="p-list__item">
         At the end of the process, you will see your credentials to access your Ubuntu Core machine:
-        <pre style="margin-top: 1rem;"><code>This device is registered to &lt;Ubuntu SSO email address&gt;.
+        <pre class="u-margin-top--medium"><code>This device is registered to &lt;Ubuntu SSO email address&gt;.
 Remote access was enabled via authentication with the SSO user &lt;Ubuntu SSO user name&gt;
 Public SSH keys were added to the device for remote access.</code></pre>
       </li>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -13,7 +13,7 @@
         <li class="p-list__item is-ticked">40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
       </ul>
 
-      <div class="p-card--highlighted u-hide--small" style="display: inline-block;">
+      <div class="p-card--highlighted u-hide--small u-display--inline-block">
         {{
           image(
             url="https://assets.ubuntu.com/v1/33792cb9-IoTSecurityWhitepaper-cover.jpg",
@@ -31,7 +31,7 @@
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
       <form action="/marketo/submit" method="post" id="mktoForm_1917">
-        <fieldset style="border: 0;">
+        <fieldset class="u-no-border">
           <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -17,7 +17,7 @@
         Canonical's MAAS helps organisations to take full advantage of existing hardware investments by maximising hardware efficiency, and a pathway to leverage the performance and security of hardware based solutions with the economics and efficiencies of the cloud.
       </p>
 
-      <div class="p-card--highlighted" style="display: inline-block;">
+      <div class="p-card--highlighted u-display--inline-block">
         {{
           image(
             url="https://assets.ubuntu.com/v1/a7595f5e-network-admin-ebook.png",
@@ -35,7 +35,7 @@
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
       <form action="/marketo/submit" method="post" id="mktoForm_1862">
-        <fieldset style="border: 0;">
+        <fieldset class="u-no-border">
           <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">

--- a/templates/download/shared/_instructions-resources.html
+++ b/templates/download/shared/_instructions-resources.html
@@ -38,7 +38,7 @@
           <ul class="p-list--divided" id="latest-articles">
             <li class="p-list__item"><i class="p-icon--spinner u-animation--spin">Loading...</i></li>
           </ul>
-          <template style="display:none" id="article-template">
+          <template id="article-template">
             <li class="p-list__item">
               <a class="article-link article-title"></a>
             </li>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -37,8 +37,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/pricing/pro/application.html
+++ b/templates/pricing/pro/application.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="application-tab" aria-labelledby="application">
   <div class="grid-row--25-75">
     <div class="grid-col">
-      <div class="p-side-navigation is-sticky" id="application-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="application-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="application-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="application side navigation">
           <ul>

--- a/templates/pricing/pro/infrastructure.html
+++ b/templates/pricing/pro/infrastructure.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="infrastructure-tab" aria-labelledby="infrastructure">
   <div class="grid-row--25-75">
     <div class="grid-col">
-      <div class="p-side-navigation is-sticky" id="infrastructure-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="infrastructure-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="infrastructure-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="infrastructure side navigation">
           <ul>

--- a/templates/pricing/pro/operations-and-management.html
+++ b/templates/pricing/pro/operations-and-management.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="operations-management-tab" aria-labelledby="operations-management">
     <div class="grid-row--25-75">
       <div class="grid-col">
-        <div class="p-side-navigation is-sticky" id="operations-management-drawer" style="top: 4rem;">
+        <div class="p-side-navigation is-sticky u-sticky-below-header" id="operations-management-drawer">
           <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="operations-management-drawer"></div>
           <nav class="p-side-navigation__drawer" aria-label="operations management side navigation">
             <ul>

--- a/templates/pricing/pro/security-and-compliance.html
+++ b/templates/pricing/pro/security-and-compliance.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="security-compliance-tab" aria-labelledby="security-compliance">
   <section class="row">
     <aside class="col-3">
-      <div class="p-side-navigation is-sticky" id="security-compliance-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="security-compliance-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="security-compliance-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="security compliance side navigation">
           <ul>

--- a/templates/pricing/pro/services.html
+++ b/templates/pricing/pro/services.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="services-tab" aria-labelledby="services">
   <div class="grid-row--25-75">
     <div class="grid-col">
-      <div class="p-side-navigation is-sticky" id="services-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="services-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="services-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="services side navigation">
           <ul>

--- a/templates/pricing/shared/_enablement-strip.html
+++ b/templates/pricing/shared/_enablement-strip.html
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="row p-divider" style="padding-top: 1.9rem;">
+  <div class="row p-divider p-nudge-top--large">
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--5">Beyond BSPs</h3>
       <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>

--- a/templates/pricing/ubuntu-pro.html
+++ b/templates/pricing/ubuntu-pro.html
@@ -66,7 +66,7 @@
                 <table aria-label="What is included in a free Pro subscription?">
                   <thead>
                     <tr>
-                      <th style="width: 79%;" scope="col">Security and Compliance</th>
+                      <th class="u-width--79" scope="col">Security and Compliance</th>
                       <th scope="col">
                         Free tier
                         <br />
@@ -110,7 +110,7 @@
         <table aria-label="Ubuntu Pro Pricing">
           <thead>
             <tr>
-              <td style="width: 40%;" role="presentation">&nbsp;</td>
+              <td class="u-table-col--two-fifths" role="presentation">&nbsp;</td>
               <th scope="col">
                 Self-Support
                 <br />
@@ -162,7 +162,7 @@
         <table aria-label="Ubuntu Pro security and compliance">
           <thead>
             <tr>
-              <td style="width: 40%;" role="presentation">&nbsp;</td>
+              <td class="u-table-col--two-fifths" role="presentation">&nbsp;</td>
               <th scope="col">
                 Self-Support
                 <br />
@@ -356,7 +356,7 @@
         <table aria-label="Phone and ticket support">
           <thead>
             <tr>
-              <td style="width: 40%;" role="presentation">&nbsp;</td>
+              <td class="u-table-col--two-fifths" role="presentation">&nbsp;</td>
               <th scope="col">
                 Self-Support
                 <br />

--- a/templates/pro/activate.html
+++ b/templates/pro/activate.html
@@ -24,9 +24,9 @@
                 <input class="p-radio__input radio-organisation" type="radio" aria-labelledby="activate-organisation-input" name="activate-buy-for" value="organisation">
                 <span class="p-radio__label" id="activate-organisation">Organisation</span>
               </label>
-              <div class="p-form__group js-organisation-name-container" style="display:none">
+              <div class="p-form__group js-organisation-name-container u-hide">
                 <label for="activate-organisation-name" class="p-form__label">Organisation name: </label>
-                <input class="u-no-margin--bottom" type="text" id="activate-organisation-name" name="activate-organisation-name" placeholder="Ex: Canonical" style="margin-top: .25rem;" aria-label="What?">
+                <input class="u-no-margin--bottom p-nudge-margin-top--x-small" type="text" id="activate-organisation-name" name="activate-organisation-name" placeholder="Ex: Canonical" aria-label="What?">
               </div>
             </div>
           </div>
@@ -49,7 +49,7 @@
       <form id="activate-key-form">
         <div class="p-form__group">
           <label for="pro-activation-key" class="p-form__label">Enter your code</label>
-          <div class="p-form__control" style="min-width: 15rem">
+          <div class="p-form__control u-min-width--15rem">
             <input type="text" id="pro-activation-key" class="activate-input" name="key" autocomplete="off" placeholder="Ex: Kabcedfghij12345678910-" required="" aria-describedby="pro-activate-input">
             <p class="p-form-validation__message" id="pro-activatio-validation__message"></p>
           </div>
@@ -58,7 +58,7 @@
       </form>
     </div>
     <div class="u-fixed-width">
-      <div class="p-notification--negative" id="notification" style="display: none">
+      <div class="p-notification--negative u-hide" id="notification">
         <div class="p-notification__content">
           <h5 class="p-notification__title">Something went wrong</h5>
             <p class="p-notification__message" id="notification-message"></p>

--- a/templates/pro/devices.html
+++ b/templates/pro/devices.html
@@ -366,7 +366,7 @@ meta_copydoc %}
         <div class="col-9">
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/9c8bfd51-Aaeon-Logo.png",
                 alt="AAEON logo",
@@ -399,7 +399,7 @@ meta_copydoc %}
           <hr class="p-rule--muted is-fixed-width" />
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/4ed674b0-advantech-logo.png",
                 alt="advantech logo",
@@ -429,7 +429,7 @@ meta_copydoc %}
           <hr class="p-rule--muted is-fixed-width" />
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/8b7059c4-DFI-logo.png",
                 alt="DFI logo",
@@ -462,7 +462,7 @@ meta_copydoc %}
           <hr class="p-rule--muted is-fixed-width" />
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/0ed224e1-adlink-logo.png",
                 alt="adlink logo",

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -410,7 +410,7 @@
             <table>
               <thead>
                 <tr>
-                  <th style="width: 35%;">Category</th>
+                  <th class="u-width--35">Category</th>
                   <th>Example applications and toolchains covered by Ubuntu Pro</th>
                 </tr>
               </thead>

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -31,8 +31,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -23,9 +23,8 @@
         <p class="p-heading--5">Tailor your email preferences</p>
       </div>
       <div class="col-8">
-        <div class="p-search-and-filter"
+        <div class="p-search-and-filter u-margin-bottom--medium"
              id="subscription-centre-search"
-             style="margin-bottom:1rem"
              aria-hidden="true"
              hidden>
           <button class="p-search-and-filter__clear" aria-hidden="true" hidden="">
@@ -47,10 +46,8 @@
             </div>
           </div>
 
-          <div class="p-search-and-filter__panel"
-               aria-hidden="true"
-               style="background:#f7f7f7;
-                      padding-top:0"></div>
+          <div class="p-search-and-filter__panel u-background--light u-no-padding--top"
+               aria-hidden="true"></div>
 
           <template id="search-result-template">
             <div class="p-search-and-filter__search-prompt" role="button" tabindex="0">
@@ -73,7 +70,7 @@
                    {% if updatesOptIn %}checked{% endif %} />
             <span class="p-checkbox__label">I agree to receive information about Canonical's products and services</span>
           </label>
-          <hr style="margin-top:1rem;margin-bottom:0;" />
+          <hr class="u-margin-top--medium u-no-margin--bottom" />
           <div class="p-accordion">
             <ul class="p-accordion__list" id="subscriptions-list">
               {% for category in categories %}
@@ -121,8 +118,7 @@
         </form>
       </div>
     </div>
-    <hr class="p-rule is-fixed-width u-no-margin--top"
-        style="margin-bottom:1rem" />
+    <hr class="p-rule is-fixed-width u-no-margin--top u-margin-bottom--medium" />
     <div class="row">
       <div class="col-start-large-5">
         <span class="u-sv3">In submitting this form, I confirm that I have read and agree to <a href="https://canonical.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://canonical.com/legal/data-privacy">Privacy Policy</a>.</span>


### PR DESCRIPTION
## Done
- Chunk of https://github.com/canonical/ubuntu.com/pull/16476
- Removed inline style= attributes.
- Added static/sass/_utilities.scss atomic properties

## QA
- Open demo
- Navigate to pages that are modified by `Files changed`
- Ensure there are no breaking CSS changes (eg. buttons work as expected and things don't look strange)
- Open console and ensure there are no errors caused by removing inline styles.
