### PR TITLE
fix: remove inline styles from cloud and server templates

### DIFF
--- a/templates/account/invoices/_edit_billing_modal.html
+++ b/templates/account/invoices/_edit_billing_modal.html
@@ -1,4 +1,4 @@
-<div style="display: none;" class="p-modal" id="edit-billing-modal">
+<div class="p-modal u-hide" id="edit-billing-modal">
   <section class="p-modal__dialog"
            role="dialog"
            aria-modal="true"

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -10,9 +10,7 @@
 
   <section class="p-strip--suru-topped p-strip-account-page">
     <div class="u-fixed-width">
-      <div style="display: flex;
-                  justify-content: space-between;
-                  align-items: baseline">
+      <div class="p-invoices__header">
         <h1>Billing</h1>
         <button id="edit-billing-btn"
                 class="p-button"
@@ -20,7 +18,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-3" style="padding: 0.75rem 0">
+      <div class="col-3 p-invoices__total">
         <select name="marketplace" id="marketplace-dropdown">
           <option value="">All invoices</option>
           <option value="blender" {% if marketplace == 'blender' %}selected{% endif %}>Blender Support</option>
@@ -37,7 +35,7 @@
               <th>Service</th>
               <th>Date</th>
               <th width="10%">Status</th>
-              <th class="u-align--right" style="padding-right: 5%">Total</th>
+              <th class="u-align--right p-invoices__cell">Total</th>
               <th>Invoice and receipt</th>
             </thead>
             <tbody>
@@ -69,7 +67,7 @@
                       <div class="p-chip is-readonly">Pending</div>
                     {% endif %}
                   </td>
-                  <td class="u-align--right" aria-label="Total" style="padding-right: 5%">
+                  <td class="u-align--right p-invoices__cell" aria-label="Total">
                     {% if invoice.invoice %}
                       <span class="js-format-price">{{ invoice.get_total() }}</span>
                     {% else %}

--- a/templates/account/payment-methods/_confirm-remove-modal.html
+++ b/templates/account/payment-methods/_confirm-remove-modal.html
@@ -1,4 +1,4 @@
-<div style="display: none;" class="p-modal" id="remove-payment-modal">
+<div class="p-modal u-hide" id="remove-payment-modal">
   <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Remove payment method</h2>

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -35,14 +35,13 @@
       <h1>Payment method</h1>
 
       <div id="default-payment-method-section"
-           class="row {% if not default_payment_method.id %}u-hide{% endif %}"
-           style="margin-top: 2rem">
+           class="row {% if not default_payment_method.id %}u-hide{% endif %} u-margin-top--x-large">
         <div class="col-4 current-payment-method">
           {% with brand=default_payment_method["brand"] %}
             {% include "account/payment-methods/_card-logo.html" %}
           {% endwith %}
           <p>
-            <span style="text-transform: capitalize;">{{ default_payment_method["brand"] }}</span> ending in {{ default_payment_method["last4"] }}
+            <span class="u-text-transform--capitalize">{{ default_payment_method["brand"] }}</span> ending in {{ default_payment_method["last4"] }}
           </p>
         </div>
         <p class="col-4 u-text--muted">Default payment method</p>
@@ -55,8 +54,7 @@
       </div>
 
       <div id="edit-payment-method-section"
-           class="row u-hide"
-           style="margin-top: 2rem">
+           class="row u-hide u-margin-top--x-large">
         <div class="col-8">
           <div id="card-element"></div>
           <span id="card-errors" class="p-form-validation__message u-hide"></span>
@@ -72,11 +70,10 @@
            class="p-strip {% if default_payment_method.id %}u-hide{% endif %}">
         <div class="row">
           <div class="u-align--right col-4">
-            <i style="width: 4rem; height: 4rem; margin-top: 0.4rem;" 
-               class="p-icon--credit-card u-hide--medium u-hide--small"></i>
+            <i class="p-icon--credit-card u-hide--medium u-hide--small p-icon--credit-card-large"></i>
           </div>
           <div class="u-align--left col-8 col-medium-4 col-small-3">
-            <p style="margin-bottom: 0;" class="p-heading--4">You have no payment method saved</p>
+            <p class="p-heading--4 u-no-margin--bottom">You have no payment method saved</p>
             <p>Add a card to resize and automatically renew your subscriptions.</p>
             <button class="p-button--positive" id="add-payment-method">Add card</button>
           </div>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -8,7 +8,7 @@
       <section id="order-info" class="p-strip is-shallow u-no-padding--top u-hide">
       </section>
 
-      <section class="p-strip is-shallow u-no-padding" style="overflow-x: visible;">
+      <section class="p-strip is-shallow u-no-padding u-overflow-x--visible">
         <div id="payment-errors" class="p-notification--negative u-hide">
           <div class="p-notification__content">
             <p class="p-notification__message"></p>
@@ -279,19 +279,19 @@
       </span>
 
       <div class="row u-no-padding">
-        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin" style="text-align: center;">
+        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin u-align--center">
           Cancel
         </button>
 
-        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive u-no-margin" style="text-align: center;" disabled type="submit">
+        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive u-no-margin u-align--center" disabled type="submit">
           Continue
         </button>
 
-        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive u-no-margin" style="text-align: center;" disabled type="submit">
+        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive u-no-margin u-align--center" disabled type="submit">
           Pay
         </button>
 
-        <button class="js-close-modal col-small-2 col-medium-2 col-3 p-button" style="text-align: center;">OK</button>
+        <button class="js-close-modal col-small-2 col-medium-2 col-3 p-button u-align--center">OK</button>
       </div>
     </footer>
   </div>

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-12 u-sv3" style="overflow-x: auto">
+  <div class="col-12 u-sv3 u-overflow-x--auto">
     <table class="p-table--mobile-card advantage-table">
       <thead>
         <tr>
@@ -10,7 +10,7 @@
           <th class="u-align--center">Advanced</th>
         </tr>
         <tr>
-          <th colspan="5" style="background-color: #f7f7f7; padding: 0.75rem">
+          <th class="p-table__cell--shaded" colspan="5">
             <strong>What's included</strong>
           </th>
         </tr>
@@ -337,10 +337,7 @@
       </tbody>
       <thead>
         <tr>
-          <th colspan="5"
-              style="background-color: #f7f7f7;
-                     border-top: 1px solid rgba(0, 0, 0, 0.1);
-                     padding: 0.75rem">
+          <th colspan="5" class="p-table__cell--shaded-bordered">
             <strong>Price per year</strong>
           </th>
         </tr>

--- a/templates/advantage/subscribe/_purchase-modal.html
+++ b/templates/advantage/subscribe/_purchase-modal.html
@@ -1,4 +1,4 @@
-<div class="p-modal p-modal--ua-payment is-details-mode" id="purchase-modal" style="display: none;">
+<div class="p-modal p-modal--ua-payment is-details-mode u-hide" id="purchase-modal">
   <div id="react-root" class="p-modal__dialog" role="dialog" aria-labelledby="modal-title">
   </div>
 </div>

--- a/templates/advantage/subscribe/form/_type_select.html
+++ b/templates/advantage/subscribe/form/_type_select.html
@@ -119,8 +119,7 @@
 
     <div
       id="aws-public-cloud"
-      class="col-12 subscribe-section u-hide"
-      style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem"
+      class="col-12 subscribe-section u-hide u-background--light u-margin-bottom--large u-padding--large"
     >
       <span>
         <strong>
@@ -149,8 +148,7 @@
 
     <div
       id="azure-public-cloud"
-      class="col-12 subscribe-section u-hide"
-      style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem"
+      class="col-12 subscribe-section u-hide u-background--light u-margin-bottom--large u-padding--large"
     >
       <span>
         <strong>
@@ -180,8 +178,7 @@
     </div>
     <div
       id="gcp-public-cloud"
-      class="col-12 subscribe-section u-hide"
-      style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem"
+      class="col-12 subscribe-section u-hide u-background--light u-margin-bottom--large u-padding--large"
     >
       <span>
         <strong>

--- a/templates/advantage/subscribe/form/_ubuntu_version_select.html
+++ b/templates/advantage/subscribe/form/_ubuntu_version_select.html
@@ -53,7 +53,7 @@
         </div>
       </div>
       <div class="col-12">
-        <div class="p-card" style="background-color: #f7f7f7">
+        <div class="p-card u-background--light">
           <h4 class="p-card__title">
             For Ubuntu <span id="version-number">18.04</span>, all UA plans
             include:
@@ -93,7 +93,7 @@
   </div>
 </li>
 
-<div class="p-modal" id="other-versions-modal" style="display: none;">
+<div class="p-modal u-hide" id="other-versions-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="other-versions-modal-title" aria-describedby="other-versions-modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="other-versions-modal-title">Other versions?</h2>
@@ -101,7 +101,7 @@
     </header>
     <div class="row">
         <span>Ubuntu Advantage is available only for Ubuntu 20.04 LTS, 18.04 LTS, 16.04 LTS, and 14.04 ESM.<br /><br />You can:</span>
-        <ul style="list-style-type: disc;">
+        <ul class="u-list-style--disc">
           <li>
             <a href="/tutorials/tutorial-upgrading-ubuntu-desktop#1-before-you-start">Upgrade to a supported version</a>
           </li>

--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -14,7 +14,7 @@
     
     {% if contract["renewal"] %}
       {% if contract["renewal"]["renewable"] or contract["renewal"]["actionable"] == false %}
-        <div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}warning{% endif %}"></i>&nbsp;&nbsp;
+        <div class="u-toggle__supplemental p-contract-name__meta"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}warning{% endif %}"></i>&nbsp;&nbsp;
           {% if contract["contractInfo"]["daysTillExpiry"] < 0 %}
             Expired
           {% elif contract["contractInfo"]["daysTillExpiry"] == 0 %}

--- a/templates/ai/data-science.html
+++ b/templates/ai/data-science.html
@@ -35,8 +35,7 @@
       <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
            alt=""
            fetchpriority="high"
-           style="aspect-ratio: 5.1775700934579;
-                  width: 100%" />
+           class="p-suru-banner-image" />
     </div>
   </section>
 

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -39,8 +39,7 @@
       <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
            alt=""
            fetchpriority="high"
-           style="aspect-ratio: 5.1775700934579;
-                  width: 100%" />
+           class="p-suru-banner-image" />
     </div>
   </section>
 
@@ -334,9 +333,7 @@
         </div>
       </div>
       <div class="col">
-        <div style="background:rgba(0, 0, 0, 0.03);
-                    margin-top: 0.5rem"
-             class="u-align--center">
+        <div class="u-align--center u-background--shade u-margin-top--small">
           {{ image (
           url="https://assets.ubuntu.com/v1/3289e116-7f76ac3a-hp-laptop-studio-jammy 5.png",
           alt="",

--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -59,10 +59,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/aws/fips.html
+++ b/templates/aws/fips.html
@@ -266,9 +266,9 @@
         <h2>FIPS-certified Ubuntu components for AWS</h2>
       </div>
       <div class="p-section u-table-scroll--medium u-table-scroll--small">
-        <table style="table-layout: unset"
+        <table
                aria-label="22.04 certified Ubuntu components"
-               class="u-table-horizontal-scroll__table">
+               class="u-table-horizontal-scroll__table u-table-layout--auto">
           <thead>
             <tr>
               <th>Ubuntu LTS</th>
@@ -345,9 +345,9 @@
         </div>
       </div>
       <div class="p-section u-table-scroll--medium u-table-scroll--small">
-        <table style="table-layout: unset"
+        <table
                aria-label="20.04 certified Ubuntu components"
-               class="u-table-horizontal-scroll__table">
+               class="u-table-horizontal-scroll__table u-table-layout--auto">
           <thead>
             <tr>
               <th>Ubuntu LTS</th>
@@ -402,9 +402,9 @@
         </table>
       </div>
       <div class="p-section u-table-scroll--medium u-table-scroll--small">
-        <table style="table-layout: unset"
+        <table
                aria-label="18.04 certified Ubuntu components"
-               class="u-table-horizontal-scroll__table">
+               class="u-table-horizontal-scroll__table u-table-layout--auto">
           <thead>
             <tr>
               <th>Ubuntu LTS</th>
@@ -465,9 +465,9 @@
         </table>
       </div>
       <div class="p-section u-table-scroll--medium u-table-scroll--small">
-        <table style="table-layout: unset"
+        <table
                aria-label="16.04 certified Ubuntu components"
-               class="u-table-horizontal-scroll__table">
+               class="u-table-horizontal-scroll__table u-table-layout--auto">
           <thead>
             <tr>
               <th>Ubuntu LTS</th>
@@ -527,7 +527,7 @@
       </div>
       <div class="col">
         <div class="p-section--shallow">
-          <table style="table-layout: unset;">
+          <table class="u-table-layout--auto">
             <thead>
               <tr>
                 <th>Example instance size</th>

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -119,7 +119,7 @@
     <div class="row--50-50">
       <div class="col">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <div class="row p-section">
             <div class="col-3 col-medium-1 col-small-2">
               <h3>Ubuntu</h3>
@@ -145,7 +145,7 @@
       </div>
       <div class="col">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <div class="row p-section--shallow">
             <div class="col-3 col-medium-1 col-small-2">
               <h3>Ubuntu Pro for AWS</h3>
@@ -259,7 +259,7 @@
         }}
       </div>
       <div class="col-6 col-medium-4 p-section--shallow">
-        <blockquote style="border-left: none;">
+        <blockquote class="u-border-left--none">
           <p class="p-heading--4">
             <i>"The optimizations built into Ubuntu Pro on AWS provide us with the performance requirements needed and a trusted platform to run our operations and fleet."</i>
           </p>

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -62,7 +62,7 @@
     <div class="row--50-50">
       <div class="col">
         <hr class="p-rule--highlight" />
-        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <div class="row p-section">
             <div class="col-3 col-medium-1 col-small-2">
               <h3>Ubuntu</h3>
@@ -89,7 +89,7 @@
       </div>
       <div class="col">
         <hr class="p-rule--highlight" />
-        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <div class="row p-section--shallow">
             <div class="col-3 col-medium-1 col-small-2">
               <h3>Ubuntu Pro for AWS</h3>
@@ -331,7 +331,7 @@
                 <h3 class="p-stepped-list__title p-heading--5">Select the region your AWS Outpost is attached</h3>
               </div>
               <div class="col-6 col-medium-3 col-start-medium-4 p-stepped-list__content">
-                <div style="margin-top: 0.5rem;">
+                <div class="u-margin-top--small">
                   {{ image(url="https://assets.ubuntu.com/v1/78ea4b05-aws-outposts-regions.png",
                                     alt="",
                                     width="300",

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -282,7 +282,7 @@
     </div>
     <div class="row--25-75">
       <div class="col">
-        <table class="p-table" style="width: 100%;">
+        <table class="p-table">
           <thead>
             <tr>
               <td aria-hidden></td>
@@ -376,7 +376,7 @@
         }}
       </div>
       <div class="col-6 col-medium-4 p-section--shallow">
-        <blockquote style="border-left: none;">
+        <blockquote class="u-border-left--none">
           <p class="p-heading--4">
             <i>The new Ubuntu Pro images will deliver a further optimized experience to our customers, providing additional security and performance to their Ubuntu instances, Ubuntu Pro can be purchased, deployed and launched on AWS in a seamless and effortless manner, removing the need for additional provisioning or procurement processes.</i>
           </p>
@@ -395,11 +395,11 @@
     <div class="u-fixed-width">
       <hr class="p-rule" />
       <h2>Choose the right Ubuntu for you</h2>
-      <div style="overflow-x: auto;">
-        <table class="p-table" style="width: 100%;">
+      <div class="u-overflow-x--auto">
+        <table class="p-table p-table--feature-comparison">
           <thead>
             <tr>
-              <td style="width: 45%" area-hidden>&nbsp;</td>
+              <td area-hidden>&nbsp;</td>
               <th class="u-align--center">Ubuntu</th>
               <th class="u-align--center">Ubuntu&nbsp;Pro</th>
             </tr>
@@ -471,7 +471,7 @@
         </h2>
       </div>
       <div class="col">
-        <table class="p-table" style="width: 100%;">
+        <table class="p-table">
           <thead>
             <tr>
               <th>Example instance size</th>

--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -101,7 +101,7 @@
         <table class="p-table">
           <thead>
             <tr>
-              <th style="width: 50%;">Feature</th>
+              <th class="u-table-col--half">Feature</th>
               <th>Ubuntu</th>
               <th>Ubuntu Pro</th>
               <th>Ubuntu Pro with Support</th>

--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -45,10 +45,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/azure/confidential-computing/index.html
+++ b/templates/azure/confidential-computing/index.html
@@ -58,7 +58,7 @@
       </div>
       <div class="col">
         <div class="p-section--shallow">
-          <div class="p-image-container is-highlighted" style="margin-top: 0.55rem;">
+          <div class="p-image-container is-highlighted p-nudge-margin-top--small">
             {{ image(url="https://assets.ubuntu.com/v1/bee89574-azure-logo-updated.png",
                         alt="",
                         width="1200",

--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -286,14 +286,14 @@
       <div class="p-section--shallow">
         <h2>FIPS-certified Ubuntu components</h2>
       </div>
-      <table class="p-table--mobile-card" style="overflow-x: auto;">
+      <table class="p-table--mobile-card p-table--fips u-overflow-x--auto">
         <thead>
           <tr>
-            <th style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 41%;">FIPS certified component</th>
+            <th>Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th class="u-align--left">Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>
@@ -364,14 +364,14 @@
         </em>
       </p>
       <br />
-      <table class="p-table--mobile-card" style="overflow-x: auto;">
+      <table class="p-table--mobile-card p-table--fips u-overflow-x--auto">
         <thead>
           <tr>
-            <th style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 41%;">FIPS certified component</th>
+            <th>Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th class="u-align--left">Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>
@@ -416,14 +416,14 @@
         </tbody>
       </table>
       <br />
-      <table class="p-table--mobile-card" style="overflow-x: auto;">
+      <table class="p-table--mobile-card p-table--fips u-overflow-x--auto">
         <thead>
           <tr>
-            <th style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 41%;">FIPS certified component</th>
+            <th>Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th class="u-align--left">Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>
@@ -474,14 +474,14 @@
         </tbody>
       </table>
       <br />
-      <table class="p-table--mobile-card" style="overflow-x: auto;">
+      <table class="p-table--mobile-card p-table--fips u-overflow-x--auto">
         <thead>
           <tr>
-            <th style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 41%;">FIPS certified component</th>
+            <th>Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th class="u-align--left">Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -86,7 +86,7 @@
     <div class="row">
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <div class="row p-section--shallow">
             <h3>Ubuntu LTS Server</h3>
             <p class="p-heading--4">Free to use</p>
@@ -107,7 +107,7 @@
       </div>
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <div class="row p-section--shallow">
             <h3>Ubuntu Pro</h3>
             <p class="p-heading--4">
@@ -311,10 +311,10 @@
     </div>
   </section>
 
-  <template style="display: none" id="articles-template">
+  <template id="articles-template">
     <div class="col-3">
       <div class="article-image"></div>
-      <h3 class="p-heading--5" style="font-weight: normal">
+      <h3 class="p-heading--5 u-font-weight--normal">
         <a class="article-link article-title"></a>
       </h3>
       <div class="article-excerpt"></div>

--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -169,7 +169,7 @@
       <table class="p-table">
         <thead>
           <tr>
-            <th style="width: 50%;">Feature</th>
+            <th class="u-table-col--half">Feature</th>
             <th>Ubuntu</th>
             <th>Ubuntu Pro</th>
             <th>Ubuntu Pro with Support</th>

--- a/templates/azure/thank-you.html
+++ b/templates/azure/thank-you.html
@@ -49,10 +49,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/blender/thank-you.html
+++ b/templates/blender/thank-you.html
@@ -44,8 +44,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/blog/archives.html
+++ b/templates/blog/archives.html
@@ -3,7 +3,7 @@
 {% block title %}Archives{% endblock %}
 
 {% block content %}
-  <section class="p-strip--accent is-dark is-deep" style="background-color: #333;">
+  <section class="p-strip--accent is-dark is-deep u-background--dark">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-10">
         <h1>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -62,8 +62,7 @@
 
 {% block content %}
   <article>
-    <header class="p-strip--image is-shallow"
-            style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png)">
+    <header class="p-strip--image is-shallow p-strip--blog-paper">
       <div class="row">
         <div class="col-8">
           <h1>{{ article.title.rendered|safe }}</h1>
@@ -149,7 +148,7 @@
       {% endif %}
     </header>
 
-    <section class="p-strip is-shallow" style="overflow-x: initial;">
+    <section class="p-strip is-shallow u-overflow-x--visible">
       <div class="row u-equal-height">
         <div class="col-8">
           {% if 'difference_in_years' in blog_notice %}
@@ -184,8 +183,7 @@
 
       {% for tag in tags %}
         {% if tag.name == 'robotics' %}
-          <section class="p-strip--image is-dark"
-                   style="background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%)">
+          <section class="p-strip--image is-dark p-strip--blog-robotics">
             <div class="row">
               <div class="col-8">
                 <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>

--- a/templates/blog/author.html
+++ b/templates/blog/author.html
@@ -39,11 +39,11 @@
               {% endif %}
 
               {% if author.id == 217 %}
-                <p class="p-media-object__content" style="margin-top: 1rem;">
+                <p class="p-media-object__content u-margin-top--medium">
                   Canonical produces Ubuntu, provides commercial services for Ubuntu's users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.
                 </p>
               {% elif author.description %}
-                <p class="p-media-object__content" style="margin-top: 1rem;">{{ author.description | safe }}</p>
+                <p class="p-media-object__content u-margin-top--medium">{{ author.description | safe }}</p>
               {% endif %}
 
               <ul class="p-inline-list u-no-margin--bottom">

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -22,7 +22,7 @@
     </p>
 
       {% if summary_visible or not article.image.source_url %}
-      <p class="{% if summary_visible %}u-hide--small{% endif %}" style="padding-top:1rem;">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
+      <p class="{% if summary_visible %}u-hide--small{% endif %} u-padding-top--medium">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
       {% endif %}
   </div>
 

--- a/templates/blog/draft-blogs.html
+++ b/templates/blog/draft-blogs.html
@@ -43,8 +43,7 @@
           {% if summary_visible or not article.image.source_url %}
             <p class="{% if summary_visible %}
                         u-hide--small
-                      {% endif %}"
-               style="padding-top:1rem">{{ article.excerpt.raw.replace('[…]', '') |truncate(162) }}</p>
+                      {% endif %} u-padding-top--medium">{{ article.excerpt.raw.replace('[…]', '') |truncate(162) }}</p>
           {% endif %}
         </div>
 

--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -2,7 +2,7 @@
   <form action="" method="get" class="p-form p-form--inline">
     <div class="p-form__group">
       <label for="filter" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
-      <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
+      <select class="js-submit-on-change p-form__control p-blog-filters" id="filter" name="content" aria-label="Filter by content type">
         <option {% if not category %}selected="selected"{% endif %} value="/blog/{{topic}}#posts-list">All content types</option>
         <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=articles#posts-list">Articles</option>
         <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=case-studies#posts-list">Case studies</option>

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -382,10 +382,7 @@
     <div class="row">
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>Charmed Ceph</h3>
           </div>
@@ -407,10 +404,7 @@
       </div>
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>Ceph support on Ubuntu</h3>
           </div>
@@ -436,10 +430,7 @@
     <div class="row">
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>MicroCeph</h3>
           </div>
@@ -459,10 +450,7 @@
       </div>
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>Managed Ceph</h3>
           </div>

--- a/templates/ceph/shared/_large-scale-deployment.html
+++ b/templates/ceph/shared/_large-scale-deployment.html
@@ -16,7 +16,7 @@
         Charmed Ceph is Canonical's fully automated, model-driven approach to installing and managing Ceph. <a href="/ceph">Charmed Ceph</a> is generally deployed on bare-metal hardware that is managed by <a href="https://maas.io/">MAAS</a>.
       </p>
       <div class="p-cta-block">
-        <a href="/ceph/docs/install-ceph" style="margin-right: 1rem">How to install Charmed Ceph&nbsp;&rsaquo;</a>
+        <a class="u-margin-right--medium" href="/ceph/docs/install-ceph">How to install Charmed Ceph&nbsp;&rsaquo;</a>
         <a href="/ceph/docs">Access the Ceph documentation&nbsp;&rsaquo;</a>
       </div>
     </div>

--- a/templates/ceph/thank-you.html
+++ b/templates/ceph/thank-you.html
@@ -47,10 +47,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>
@@ -69,10 +68,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/contact-us/thank-you.html
+++ b/templates/contact-us/thank-you.html
@@ -394,7 +394,7 @@
                         name="UbuntuDesktopPlannedUsage"
                         maxlength="2000"></textarea>
                     <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage_label">How do you plan to use Ubuntu Desktop?</label>
-                    <div class="p-section--shallow" id="ubuntu_desktop_usage_fields" style="display: flex; align-items: center; gap: 24px;">
+                    <div class="p-section--shallow p-inline-options" id="ubuntu_desktop_usage_fields">
                         <label class="p-checkbox js-checkbox u-no-margin">
                         <input type="checkbox" aria-labelledby="work" class="p-checkbox__input" />
                         <span class="p-checkbox__label" id="work">Work</span>
@@ -529,10 +529,10 @@
         </div>
     </div>
 
-    <template style="display: none" id="articles-template">
+    <template id="articles-template">
         <div class="col-3 col-medium-2 u-equal-height-items">
             <div class="article-image"></div>
-            <h3 class="p-heading--5" style="font-weight: normal">
+            <h3 class="p-heading--5 u-font-weight--normal">
                 <a class="article-link article-title"></a>
             </h3>
         </div>
@@ -589,8 +589,8 @@ var google_conversion_value = 0;
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-<div style="display:inline;">
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+<div>
+<img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
 </div>
 </noscript>
 {{ marketo }}

--- a/templates/containers/chiseled/dotnet.html
+++ b/templates/containers/chiseled/dotnet.html
@@ -290,8 +290,7 @@
           <div class="col-3 col-medium-3">
             <div class="p-heading-icon--small">
               <div class="p-heading-icon__header">
-                <div class="p-heading-icon__img u-hide--small u-hide--medium"
-                     style="margin-top: 0.7rem">
+                <div class="p-heading-icon__img u-hide--small u-hide--medium p-nudge-margin-top--medium">
                   {{ image(url="https://assets.ubuntu.com/v1/30798854-settings.svg",
                                     alt="",
                                     width="32",

--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -32,6 +32,18 @@
       height: 16px;
       margin-right: 8px;
     }
+
+    .chart-legend-box--mauve {
+      background: #cba7b8;
+    }
+
+    .chart-legend-box--plum {
+      background: #923a66;
+    }
+
+    .chart-legend-box--black {
+      background: #000000;
+    }
   </style>
 
   <section class="p-strip is-shallow u-no-padding--bottom">
@@ -191,7 +203,7 @@
             <tr>
               <td class="display-on-large u-no-padding--left" rowspan="3">.NET</td>
               <td class="dimmed-text u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#CBA7B8;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--mauve"></div>
                 Ubuntu .NET image
               </td>
               <td class="u-align--right u-no-padding--right">
@@ -200,7 +212,7 @@
             </tr>
             <tr>
               <td class="dimmed-text u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#923A66;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--plum"></div>
                 Chiseled Ubuntu .NET image
               </td>
               <td class="u-align--right u-no-padding--right">
@@ -209,7 +221,7 @@
             </tr>
             <tr>
               <td class="u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#000000;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--black"></div>
                 Chiseled Ubuntu for self contained .NET image
               </td>
               <td class="u-align--right u-no-padding--right">
@@ -254,7 +266,7 @@
             <tr>
               <td class="display-on-large u-no-padding--left" rowspan="2">Java</td>
               <td class="dimmed-text u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#CBA7B8;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--mauve"></div>
                 Eclipse Temurin
               </td>
               <td width="90px" class="u-align--right u-no-padding--right">
@@ -263,7 +275,7 @@
             </tr>
             <tr>
               <td class="u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#000000;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--black"></div>
                 Chiseled Ubuntu for JRE8
               </td>
               <td class="u-align--right u-no-padding--right">
@@ -308,7 +320,7 @@
             <tr>
               <td class="display-on-large u-no-padding--left" rowspan="2">C, C++, Go, R</td>
               <td class="dimmed-text u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#CBA7B8;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--mauve"></div>
                 Google Distroless
               </td>
               <td width="90px" class="u-align--right u-no-padding--right">
@@ -317,7 +329,7 @@
             </tr>
             <tr>
               <td class="u-no-padding--left d-flex u-vertically-center">
-                <div class="chart-legend-box u-hide--large" style="background:#000000;"></div>
+                <div class="chart-legend-box u-hide--large chart-legend-box--black"></div>
                 Chiseled Ubuntu
               </td>
               <td class="u-align--right u-no-padding--right">

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -29,8 +29,8 @@ var google_conversion_value = 0;
 </script>
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {{ marketo }}

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -45,10 +45,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -23,9 +23,8 @@
     <div class="row">
       <hr class="p-rule u-hide--medium u-hide--small" />
       <div class="col-3">
-        <div class="p-side-navigation--raw-html is-sticky"
-             id="drawer"
-             style="top: 4rem">
+        <div class="p-side-navigation--raw-html is-sticky u-sticky-below-header"
+             id="drawer">
           <a href="#drawer"
              class="p-side-navigation__toggle js-drawer-toggle"
              aria-controls="drawer">Toggle table of contents</a>

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -49,10 +49,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/credentials/base_cred.html
+++ b/templates/credentials/base_cred.html
@@ -10,7 +10,7 @@
 
 {% block outer_content %}
   {% if show_cred_maintenance_alert %}
-    <div class="p-notification--information" style="margin:1rem">
+    <div class="p-notification--information u-margin--medium">
       <div class="p-notification__content">
         <h5 class="p-notification__title">Maintenance Scheduled</h5>
         <p class="p-notification__message" id="cred-maintenance-message"></p>

--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -10,7 +10,7 @@
   <section class="p-suru--fan-top is-dark">
     <div class="row u-equal-height">
       <div class="col-6">
-        <h1 style="font-weight: 800">Canonical Academy Exams FAQ</h1>
+        <h1 class="u-font-weight--bold">Canonical Academy Exams FAQ</h1>
       </div>
     </div>
   </section>
@@ -51,7 +51,7 @@
       </div>
       <div class="col-6">
         <!-- Section 1 -->
-        <h2 id="about" style="font-weight: 600">About the exams</h2>
+        <h2 id="about" class="p-heading--bold">About the exams</h2>
         <h3>What is a qualification? Is this a certificate program or a certification program? What’s the difference?</h3>
         <p>
           Our program combines the rigor of professional certification with the skills validation of a qualification program. Each professional track denotes that the successful candidate is qualified to perform the occupation to Canonical standards.
@@ -142,7 +142,7 @@
         </p>
 
         <!-- Section 2 -->
-        <h2 id="before" style="font-weight: 600">Before your exam</h2>
+        <h2 id="before" class="p-heading--bold">Before your exam</h2>
 
         <h3>Am I ready to take a Canonical Exam?</h3>
         <p>Ultimately, only you can make that decision, but some factors to consider:</p>
@@ -184,7 +184,7 @@
         </p>
 
         <!-- Section 3 -->
-        <h2 id="environment" style="font-weight: 600">Taking the exam: Exam Environment</h2>
+        <h2 id="environment" class="p-heading--bold">Taking the exam: Exam Environment</h2>
 
         <h3>How do I access the environment?</h3>
         <p>
@@ -234,7 +234,7 @@
         </h3>
 
         <!-- Section 4 -->
-        <h2 id="proctoring" style="font-weight: 600">Taking the Exam: Proctoring</h2>
+        <h2 id="proctoring" class="p-heading--bold">Taking the Exam: Proctoring</h2>
 
         <h3>Is this exam proctored?</h3>
         <p>
@@ -275,7 +275,7 @@
         </p>
 
         <!-- Section 5 -->
-        <h2 id="examQuestions" style="font-weight: 600">Taking the Exam: Exam Questions</h2>
+        <h2 id="examQuestions" class="p-heading--bold">Taking the Exam: Exam Questions</h2>
 
         <h3>What should I expect from the exam questions?</h3>
         <p>
@@ -296,7 +296,7 @@
         <p>Yes, you are able to mark items for review before completing the exam.</p>
 
         <!-- Section 6 -->
-        <h2 id="problems" style="font-weight: 600">Problems during the exam</h2>
+        <h2 id="problems" class="p-heading--bold">Problems during the exam</h2>
 
         <h3 id="problems-0">What happens if I close my browser tab during the exam?</h3>
         <p>
@@ -324,7 +324,7 @@
         </p>
 
         <!-- Section 7 -->
-        <h2 id="after" style="font-weight: 600">After the exam</h2>
+        <h2 id="after" class="p-heading--bold">After the exam</h2>
 
         <h3>When will I receive my result?</h3>
         <p>

--- a/templates/credentials/self-study.html
+++ b/templates/credentials/self-study.html
@@ -26,7 +26,7 @@
   </section>
   <section>
     <div class="row">
-      <div class="p-tabs" style="padding-bottom:4rem;">
+      <div class="p-tabs u-padding-bottom--xx-large">
         <div class="p-tabs__list u-no-margin--bottom"
              role="tablist"
              aria-label="CUE Syllabus">
@@ -63,7 +63,7 @@
           </div>
         </div>
       </div>
-      <div class="col-12" style="padding-bottom:4rem;">
+      <div class="col-12 u-padding-bottom--xx-large">
         <div tabindex="0"
              role="tabpanel"
              id="generalResources-tab"

--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -38,9 +38,9 @@
                     <span class="p-radio__label">{{ exam.displayName }}</span>
                   </label>
                   <hr class="p-rule" />
-                  <p style="padding-left: 1rem; padding-right: 1rem;">{{ exam.metadata[0].value }}</p>
+                  <p class="u-padding-left--medium u-padding-right--medium">{{ exam.metadata[0].value }}</p>
                   <hr class="p-rule" />
-                  <h5 id="exam-price" class="u-align--right" style="padding-right: 1rem">
+                  <h5 id="exam-price" class="u-align--right u-padding-right--medium">
                     {% if is_disabled %}
                       Coming soon
                     {% else %}
@@ -69,18 +69,16 @@
         {% set is_discounted = True if metadata_length > 1 and exam.metadata[1].discountPrice else False %}
         <div class="col-12 u-hide u-show--small">
           <div id="price-card-{{ loop.index0 }}"
-               class="p-card--radio--column {% if loop.index0 == exam_index %}is-selected{% endif %}"
-               style="margin-left: 1rem;
-                      margin-right: 1rem">
+               class="p-card--radio--column {% if loop.index0 == exam_index %}is-selected{% endif %} u-margin-left--medium u-margin-right--medium">
             <label class="p-radio--inline" label="{{ exam.name }}">
               <input id="price-radio" {% if is_disabled %}disabled{% endif %} class="p-radio__input" type="radio" name="exam-radio--small" value={{ loop.index0 }} {% if loop.index0 == exam_index %}checked{% endif %} {% if is_disabled %}disabled{% endif %} />
               <span class="p-radio__label">{{ exam.displayName }}</span>
             </label>
             <span>
-              <p style="padding-left: 1rem; padding-right: 1rem;">{{ exam.metadata[0].value }}</p>
+              <p class="u-padding-left--medium u-padding-right--medium">{{ exam.metadata[0].value }}</p>
             </span>
             <span>
-              <h5 id="exam-price" class="u-align--right" style="padding-right: 1rem">
+              <h5 id="exam-price" class="u-align--right u-padding-right--medium">
                 {% if is_disabled %}
                   Coming Soon!
                 {% else %}
@@ -109,13 +107,12 @@
       <div class="row">
         {% set exam = exams[exam_index] %}
         {% set is_discounted = True if exam.metadata|length > 1 and exam.metadata[1].discountPrice else False %}
-        <div class="col-6" style="display: flex;">
+        <div class="col-6 u-vertically-center">
           <p id="selected-product-name"
-             class="order-name p-heading--2"
-             style="margin-block: auto">{{ exam.displayName }}</p>
+             class="order-name p-heading--2">{{ exam.displayName }}</p>
         </div>
-        <div class="col-3 col-small-2" style="display: flex;">
-          <p id="exam-price" class="p-heading--2" style="margin-block: auto;">
+        <div class="col-3 col-small-2 u-vertically-center">
+          <p id="exam-price" class="p-heading--2">
             <span id="total-price" class="exam-price">
               {% if is_discounted %}
                 {{ exam.metadata[1].currency }}{{ exam.metadata[1].discountPrice }}
@@ -125,8 +122,8 @@
             </span>
           </p>
         </div>
-        <div class="col-3 col-small-2 u-align--right" style="display: flex;">
-          <button type="submit" class="p-button--positive" style="margin-block: auto;">Buy now</button>
+        <div class="col-3 col-small-2 u-align--right u-vertically-center">
+          <button type="submit" class="p-button--positive">Buy now</button>
         </div>
       </div>
     </section>

--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -50,7 +50,7 @@
              id="{{ exam['exam_name'] }}-tab"
              aria-labelledby="{{ exam['exam_name'] }}"
              {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
-          <div class="row" style="padding: 4rem 0rem;">
+          <div class="row u-padding-y--xx-large">
             <div class="col-6">
               <p class="p-heading--5">OVERVIEW</p>
             </div>
@@ -75,7 +75,7 @@
     </div>
     <div class="u-fixed-height">
       <div class="row">
-        <a href="/credentials/schedule" style="display: none;">
+        <a href="/credentials/schedule" class="u-hide">
           <button class="p-button--positive">Schedule your exam now</button>
         </a>
       </div>

--- a/templates/credentials/thank-you.html
+++ b/templates/credentials/thank-you.html
@@ -53,10 +53,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -12,13 +12,9 @@
 
 {% block content %}
 
-  <section class="p-strip--suru-shape-dark is-dark"
-           style="background-size: 100%">
+  <section class="p-strip--suru-shape-dark is-dark u-background-size--full">
     <div class="row">
-      <div class="col-6"
-           style="display: flex;
-                  flex-direction: column;
-                  align-self: center">
+      <div class="col-6 p-flex-column--center">
         <h1>Dell Technologies and Canonical</h1>
         <p>
           From desktop to the edge, from the data centre to multi-cloud environments, from infrastructure to applications &mdash; Dell Technologies and Canonical bring you a portfolio of open-source solutions and services that address today's most pressing customer requirements and deliver tangible, cost-effective business outcomes.
@@ -278,8 +274,7 @@
       </div>
       <div class="col-6 col-medium-3">
         <div>
-          <div class="p-aspect-ratio-image--2-3"
-               style="background-image: url('https://assets.ubuntu.com/v1/cb3ad1d2-reference-archtecture-dell (1).png')">
+          <div class="p-aspect-ratio-image--2-3 p-aspect-ratio-image--dell-reference">
           </div>
           <p>
             Dell and Canonical designed this architecture guide for making it easy for customers to build their own operational readiness cluster and design their initial offerings.
@@ -311,8 +306,7 @@
       </div>
       <div class="col-6 col-medium-3">
         <div>
-          <div class="p-aspect-ratio-image--2-3"
-               style="background-image: url('https://assets.ubuntu.com/v1/e7ddfcd4-canonical-glance-dellpsd (1).png')">
+          <div class="p-aspect-ratio-image--2-3 p-aspect-ratio-image--dell-glance">
           </div>
           <p>Download this summary portfolio and discover how to help your customers with Canonical and Dell joint offers.</p>
           <a href="/engage/dell-battle-card" class="p-button">Download portfolio&nbsp;<i class="p-icon--begin-downloading"></i></a>
@@ -343,7 +337,7 @@
             </a>
           </p>
         </div>
-        <hr class="p-rule--muted u-fixed-width" style="margin-top: 4rem" />
+        <hr class="p-rule--muted u-fixed-width u-margin-top--xx-large" />
         <div>
           <h2>
             <a href="/blog/dell-emc-poweredge-and-canonical-charmed-ceph">Dell PowerEdge and Canonical Charmed Ceph,
@@ -360,7 +354,7 @@
             </a>
           </p>
         </div>
-        <hr class="p-rule--muted u-fixed-width" style="margin-top: 4rem" />
+        <hr class="p-rule--muted u-fixed-width u-margin-top--xx-large" />
         <div>
           <h2>
             <a href="/blog/dell-xps-13-plus-developer-edition-now-certified-with-ubuntu-22-04-lts">Canonical and Dell provide certified,

--- a/templates/dell/powerflex.html
+++ b/templates/dell/powerflex.html
@@ -103,7 +103,7 @@
     <div class="grid-row">
       <div class="grid-col-4">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div style="padding: 1.5rem" class="p-card--overlay u-no-padding--top">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <h3>
             LXD:
             <br />
@@ -119,7 +119,7 @@
       </div>
       <div class="grid-col-4" sy>
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div style="padding: 1.5rem" class="p-card--overlay u-no-padding--top">
+        <div class="p-card--overlay u-no-padding--top u-padding--large">
           <h3>
             OpenStack:
             <br />

--- a/templates/dell/thank-you.html
+++ b/templates/dell/thank-you.html
@@ -44,8 +44,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -84,7 +84,7 @@
           for Ubuntu releases
         </h2>
       </div>
-      <div class="col u-hide--small" id="server-desktop-eol-key" style="padding-top:1rem;"></div>
+      <div class="col u-hide--small u-padding-top--medium" id="server-desktop-eol-key"></div>
     </div>
     <div class="u-fixed-width">
       <div class="u-hide--small" id="server-desktop-eol"></div>
@@ -461,7 +461,7 @@
       <div class="col-6">
         <p>
           <strong>Operating systems IoT developers prefer –
-            <span style="font-weight: 400">Multiple choice poll</span>
+            <span class="u-font-weight--normal">Multiple choice poll</span>
           </strong>
         </p>
         <br />

--- a/templates/desktop/partial/_desktop-latest-news.html
+++ b/templates/desktop/partial/_desktop-latest-news.html
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <template style="display:none" id="desktop-articles-template">
+  <template id="desktop-articles-template">
     <div class="col-3">
       <div class="u-crop--16-9">
         <div class="article-image p-image-wrapper"></div>

--- a/templates/download/amd/index.html
+++ b/templates/download/amd/index.html
@@ -19,7 +19,7 @@
   <section class="p-strip is-deep">
     <div class="row">
       <div class="col-3 col-medium-2">
-        <div class="p-strip is-shallow" style="padding-top: 1rem;">
+        <div class="p-strip is-shallow u-padding-top--medium">
           {{
             image(
               url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",

--- a/templates/download/cloud/tabs/_azure.html
+++ b/templates/download/cloud/tabs/_azure.html
@@ -3,8 +3,7 @@
      role="tabpanel"
      id="azure-tab"
      aria-labelledby="azure">
-  <div class="col-3 col-medium-3 p-section--shallow"
-       style="margin-top: -40px">
+  <div class="col-3 col-medium-3 p-section--shallow p-nudge-margin-top--negative">
     {{ image(url="https://assets.ubuntu.com/v1/b009a1df-microsoft-azure-logo-light.png",
         alt="Azure",
         width="100",

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -127,8 +127,7 @@
                 <label for="amount-community-input" class="u-off-screen">
                   Contribution amount to community projects in US dollars
                 </label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-community-input"
@@ -153,8 +152,7 @@
                        id="amount-desktop"
                        type="range" />
                 <label for="amount-desktop-input" class="u-off-screen">Contribution to desktop projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-desktop-input"
@@ -179,8 +177,7 @@
                        id="amount-canonical"
                        type="range" />
                 <label for="amount-canonical-input" class="u-off-screen">Contribution to canonical projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-canonical-input"
@@ -205,8 +202,7 @@
                        id="amount-things"
                        type="range" />
                 <label for="amount-things-input" class="u-off-screen">Contribution to IOT projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-things-input"
@@ -231,8 +227,7 @@
                        id="amount-cloud"
                        type="range" />
                 <label for="amount-cloud-input" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
-                <input class="p-slider__input"
-                       style="min-width: 4rem"
+                <input class="p-slider__input u-min-width--4rem"
                        min="0"
                        max="125"
                        id="amount-cloud-input"

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -135,7 +135,7 @@
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases_yaml.latest.core_version }}', 'eventValue' : undefined });"
              class="p-button">Download Ubuntu Core {{ releases_yaml.latest.core_version }}</a>
           {% if releases_yaml.latest.rasp_pi_core_24_size %}
-            <span class="u-text--muted" style="margin-top: 0.5rem;">{{ releases_yaml.latest.rasp_pi_core_24_size }}</span>
+            <span class="u-text--muted u-margin-top--small">{{ releases_yaml.latest.rasp_pi_core_24_size }}</span>
           {% endif %}
         </p>
       </div>
@@ -166,16 +166,16 @@
   <section class="p-section">
     <div class="row">
       <div class="col-medium-6 col-9 col-start-large-4 u-table-scroll--medium u-table-scroll--small">
-        <table class="u-table-horizontal-scroll__table"
+        <table class="u-table-horizontal-scroll__table p-table--rpi-support"
                aria-label="Raspberry Pi support with Ubuntu">
           <thead>
             <tr>
-              <th style="width: 15%;"></th>
-              <th style="width: 10%;"></th>
-              <th style="width: 18%">
+              <th></th>
+              <th></th>
+              <th>
                 Ubuntu 26.04 <abbr title="Long-term support">LTS</abbr>
               </th>
-              <th style="width: 15%">Ubuntu Core 24</th>
+              <th>Ubuntu Core 24</th>
             </tr>
           </thead>
           <tbody>
@@ -307,7 +307,7 @@
         <div class="row p-section--shallow" id="blog-latest"></div>
       </div>
     </div>
-    <template style="display:none" id="blog-template">
+    <template id="blog-template">
       <div class="col-3 col-medium-2">
         <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
         <h3 class="p-heading--5">

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -153,7 +153,7 @@
       </div>
     </div>
 
-    <template style="display:none" id="blog-template">
+    <template id="blog-template">
       <div class="col-3 col-medium-2">
         <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
         <h3 class="p-heading--5">

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -467,7 +467,7 @@
       </div>
     </div>
 
-    <template style="display:none" id="ubuntu-server-template">
+    <template id="ubuntu-server-template">
       <div class="col-3 col-medium-2">
         <div class="u-crop--16-9">
           <div class="article-image p-image-wrapper"></div>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -226,7 +226,7 @@
       </div>
     </div>
 
-    <template style="display:none" id="ubuntu-server-template">
+    <template id="ubuntu-server-template">
       <div class="col-3 col-medium-2">
         <h3 class="p-heading--5">
           <a class="article-link article-title"></a>

--- a/templates/download/shared/_first-boot-setup.html
+++ b/templates/download/shared/_first-boot-setup.html
@@ -8,7 +8,7 @@
       <li class="p-list__item">Press enter then select "Start" to begin configuring your network and an administrator account. Follow the instructions on the screen, you will be asked to configure your network and enter your Ubuntu SSO credentials.</li>
       <li class="p-list__item">
         At the end of the process, you will see your credentials to access your Ubuntu Core machine:
-        <pre style="margin-top: 1rem;"><code>This device is registered to &lt;Ubuntu SSO email address&gt;.
+        <pre class="u-margin-top--medium"><code>This device is registered to &lt;Ubuntu SSO email address&gt;.
 Remote access was enabled via authentication with the SSO user &lt;Ubuntu SSO user name&gt;
 Public SSH keys were added to the device for remote access.</code></pre>
       </li>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -13,7 +13,7 @@
         <li class="p-list__item is-ticked">40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
       </ul>
 
-      <div class="p-card--highlighted u-hide--small" style="display: inline-block;">
+      <div class="p-card--highlighted u-hide--small u-display--inline-block">
         {{
           image(
             url="https://assets.ubuntu.com/v1/33792cb9-IoTSecurityWhitepaper-cover.jpg",
@@ -31,7 +31,7 @@
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
       <form action="/marketo/submit" method="post" id="mktoForm_1917">
-        <fieldset style="border: 0;">
+        <fieldset class="u-no-border">
           <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -17,7 +17,7 @@
         Canonical's MAAS helps organisations to take full advantage of existing hardware investments by maximising hardware efficiency, and a pathway to leverage the performance and security of hardware based solutions with the economics and efficiencies of the cloud.
       </p>
 
-      <div class="p-card--highlighted" style="display: inline-block;">
+      <div class="p-card--highlighted u-display--inline-block">
         {{
           image(
             url="https://assets.ubuntu.com/v1/a7595f5e-network-admin-ebook.png",
@@ -35,7 +35,7 @@
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
       <form action="/marketo/submit" method="post" id="mktoForm_1862">
-        <fieldset style="border: 0;">
+        <fieldset class="u-no-border">
           <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">

--- a/templates/download/shared/_instructions-resources.html
+++ b/templates/download/shared/_instructions-resources.html
@@ -38,7 +38,7 @@
           <ul class="p-list--divided" id="latest-articles">
             <li class="p-list__item"><i class="p-icon--spinner u-animation--spin">Loading...</i></li>
           </ul>
-          <template style="display:none" id="article-template">
+          <template id="article-template">
             <li class="p-list__item">
               <a class="article-link article-title"></a>
             </li>

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -37,8 +37,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -77,10 +77,7 @@
             </div>
           </div>
         {% endif %}
-        <div class="col-3"
-             style="display: flex;
-                    align-items: flex-end;
-                    justify-content: flex-end">
+        <div class="col-3 p-flex--end">
           <div class="u-hide u-show--small">
             <br />
             <br />

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Kontaktinformationen</legend>
     <ul class="p-list u-no-margin--bottom">
       <li>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Información del contacto</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Informazioni sui contatti</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_kr_engage_form.html
+++ b/templates/engage/shared/_kr_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">연락처 정보</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Informações de contato</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-    <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <fieldset class="u-no-padding--top p-engage-form__fieldset">
         <legend class="u-off-screen">Контактная информация</legend>
         <ul class="p-list">
         <li>

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">İletişim bilgileri</legend>
     <ul class="p-list">
       <li>

--- a/templates/engage/shared/_webinar-embed.html
+++ b/templates/engage/shared/_webinar-embed.html
@@ -7,7 +7,7 @@
   <!-- webinar -->
   <section class="p-strip is-shallow" id="register-section">
     <div class="row" id="brighttalk-webinar">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
+      <div class="jsBrightTALKEmbedWrapper p-webinar-embed">
         <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "en-US", "commId" : {{ metadata["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -1,6 +1,6 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top p-engage-form__fieldset">
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li>

--- a/templates/gcp/fips.html
+++ b/templates/gcp/fips.html
@@ -252,14 +252,14 @@
         <h2>FIPS-certified Ubuntu components for Google Cloud</h2>
       </div>
 
-      <table class="p-table--mobile-card">
+      <table class="p-table--mobile-card p-table--fips">
         <thead>
           <tr>
-            <th class="u-align--left" style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 30%;">FIPS certified component</th>
+            <th class="u-align--left">Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th>Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>
@@ -320,14 +320,14 @@
         </tbody>
       </table>
       <br />
-      <table class="p-table--mobile-card">
+      <table class="p-table--mobile-card p-table--fips">
         <thead>
           <tr>
-            <th class="u-align--left" style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 30%;">FIPS certified component</th>
+            <th class="u-align--left">Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th>Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>
@@ -391,14 +391,14 @@
         </tbody>
       </table>
       <br />
-      <table class="p-table--mobile-card">
+      <table class="p-table--mobile-card p-table--fips">
         <thead>
           <tr>
-            <th class="u-align--left" style="width: 9%;">Ubuntu LTS</th>
-            <th style="width: 30%;">FIPS certified component</th>
+            <th class="u-align--left">Ubuntu LTS</th>
+            <th>FIPS certified component</th>
             <th>Description</th>
-            <th class="u-align--right" style="width: 10%;">Version</th>
-            <th class="u-align--right" style="width: 15%;">CMVP Certificate</th>
+            <th class="u-align--right">Version</th>
+            <th class="u-align--right">CMVP Certificate</th>
           </tr>
         </thead>
         <tbody>
@@ -445,13 +445,13 @@
       <div class="p-section--shallow">
         <h2>Pricing</h2>
       </div>
-      <table class="p-table--mobile-card">
+      <table class="p-table--mobile-card p-table--vm-pricing">
         <thead>
           <tr>
             <th>Machine type</th>
             <th>vCPUs</th>
-            <th class="u-align--right" style="width: 7%;">Memory</th>
-            <th class="u-align--right" style="width: 7%;">VM cost</th>
+            <th class="u-align--right">Memory</th>
+            <th class="u-align--right">VM cost</th>
             <th class="u-align--right">Ubuntu Pro cost</th>
             <th class="u-align--right">Total cost (/hour)</th>
           </tr>
@@ -524,7 +524,7 @@
       <div class="row">
         <div class="col-3">
           <ul class="p-list--divided">
-            <li class="p-list__item" style="box-shadow: unset;">
+            <li class="p-list__item u-box-shadow--none">
               <a href="https://console.cloud.google.com/compute">22.04 LTS&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">

--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -75,9 +75,7 @@
     <div class="row--50-50">
       <div class="col">
         <hr class="p-rule--highlight" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay u-no-padding--top p-card--clipped">
           <div class="row p-section--shallow">
             <h3>Ubuntu LTS</h3>
             <p class="p-heading--4">Free to use</p>
@@ -100,9 +98,7 @@
 
       <div class="col">
         <hr class="p-rule--highlight" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay u-no-padding--top p-card--clipped">
           <div class="row p-section--shallow">
             <h3>Ubuntu Pro for Google Cloud</h3>
             <p class="p-heading--4">3-4.5% of an average instance cost</p>

--- a/templates/gcp/pro.html
+++ b/templates/gcp/pro.html
@@ -364,7 +364,7 @@
         <div class="row">
           <div class="col-3">
             <ul class="p-list--divided">
-              <li class="p-list__item" style="box-shadow: unset;">
+              <li class="p-list__item u-box-shadow--none">
                 <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud">24.04 LTS&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">

--- a/templates/gcp/thank-you.html
+++ b/templates/gcp/thank-you.html
@@ -46,10 +46,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/hpc/thank-you.html
+++ b/templates/hpc/thank-you.html
@@ -43,8 +43,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/hpe/index.html
+++ b/templates/hpe/index.html
@@ -346,8 +346,7 @@
       <h5 class="p-text--x-small-capitalised">Resources</h5>
     </div>
     <div class="u-fixed-width">
-      <div class="u-vertically-center u-align--center"
-           style="background-color: #fff">
+      <div class="u-vertically-center u-align--center u-background--white">
         {{ image(url="https://assets.ubuntu.com/v1/5b5a466c-dell server image-2.png",
                 alt="",
                 width="2438",

--- a/templates/ibm/index.html
+++ b/templates/ibm/index.html
@@ -12,10 +12,7 @@
 
 {% block content %}
 
-  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom"
-           style="background-image: url(https://assets.ubuntu.com/v1/3978eb15-cloud-lifestyle-with-screens.png?w=1500);
-                  background-position: right bottom;
-                  background-size: 1246px auto">
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom p-strip--ibm-hero">
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6 u-vertically-center">

--- a/templates/ibm/thank-you.html
+++ b/templates/ibm/thank-you.html
@@ -44,8 +44,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -145,7 +145,7 @@
           <li class="p-list__item has-bullet">Detailed snap metrics</li>
         </ul>
         <div class="p-cta-block">
-          <p style="margin-right: 1rem">Ready to find out more?</p>
+          <p class="u-margin-right--medium">Ready to find out more?</p>
           <a href="/internet-of-things/contact-us?product=appstore"
              class="p-button--positive js-invoke-modal"
              aria-controls="iot-modal">Get in touch</a>
@@ -412,10 +412,7 @@
     <div class="row">
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>Commercial support</h3>
           </div>
@@ -434,10 +431,7 @@
       </div>
       <div class="col-6">
         <hr class="p-rule--highlight u-no-margin--bottom" />
-        <div class="p-card--overlay u-no-padding--top"
-             style="padding: 1.5rem;
-                    height: 95%;
-                    overflow: hidden">
+        <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
           <div class="p-section--shallow">
             <h3>IoT Professional Services</h3>
           </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -185,8 +185,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.screenly.io/">
             {{ image(url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",
                         alt="Screenly",
@@ -204,8 +203,7 @@
            title="View Screenly webinar">View webinar&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.4yousee.com.br/">
             {{ image(url="https://assets.ubuntu.com/v1/391ea778-logo-4yousee.png",
                         alt="4YouSee",
@@ -225,8 +223,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html">
             {{
             image (
@@ -249,8 +246,7 @@
         </p>
       </div>
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.risevision.com/">
             {{ image(url="https://assets.ubuntu.com/v1/f2396b21-logo-risevision.png",
                         alt="Rise Vision",
@@ -279,8 +275,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.boldmind.co.uk/">
             {{ image(url="https://assets.ubuntu.com/v1/d4e5daf4-logo-boldmind.png",
                         alt="Boldmind",
@@ -298,8 +293,7 @@
            title="View Boldmind webinar">View webinar</a>
       </div>
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.limemicro.com/">
             {{ image(url="https://assets.ubuntu.com/v1/5e68dad7-logo-lime-microsystems.png",
                         alt="Lime Micro",
@@ -319,8 +313,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small"
-                style="min-height: 7rem">
+        <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small p-card__logo-header">
           <a href="https://www.hoxtonanalytics.com/">
             {{ image(url="https://assets.ubuntu.com/v1/d4ae60aa-logo-hoxton-analytics.svg",
                         alt="Hoxton Analytics",

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -351,10 +351,7 @@
       <div class="row">
         <div class="col-6">
           <hr class="p-rule--highlight u-no-margin--bottom" />
-          <div class="p-card--overlay u-no-padding--top"
-               style="padding: 1.5rem;
-                      height: 95%;
-                      overflow: hidden">
+          <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
             <div class="p-section--shallow">
               <h3 class="u-no-margin--bottom">Ubuntu</h3>
             </div>
@@ -374,10 +371,7 @@
         </div>
         <div class="col-6">
           <hr class="p-rule--highlight u-no-margin--bottom" />
-          <div class="p-card--overlay u-no-padding--top"
-               style="padding: 1.5rem;
-                      height: 95%;
-                      overflow: hidden">
+          <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
             <div class="p-section--shallow">
               <h3 class="u-no-margin--bottom">Ubuntu Core</h3>
             </div>

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -45,8 +45,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -23,9 +23,7 @@
     </div>
   </section>
   <section class="p-strip--light u-no-padding--top">
-    <div class="row u-vertically-center"
-         style="position: relative;
-                top: -2rem">
+    <div class="row u-vertically-center p-strip--pulled-up">
       <div class="col-12">
         <h5 class="p-muted-heading u-align--center">Watch Ubuntu's original KubeCon demos on multi-cloud Kubernetes</h5>
         <div class="u-embedded-media">
@@ -36,7 +34,7 @@
                   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                   allowfullscreen></iframe>
         </div>
-        <div style="padding-top: 2rem;">
+        <div class="u-padding-top--x-large">
           <p class="p-button--positive p-button--inline"
              onclick="LC_API.open_chat_window();return false">Private Livechat</p>
           <p class="p-button p-button--inline js-invoke-modal"

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -49,7 +49,7 @@
         <table class="p-table--mobile-card">
           <thead>
             <tr>
-              <th style="width: 33.7%">&nbsp;</th>
+              <th class="u-table-col--third">&nbsp;</th>
               <th>
                 MicroK8s,
                 <br />

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -423,10 +423,7 @@
       <div class="row--50-50">
         <div class="col">
           <hr class="p-rule--highlight u-no-margin--bottom" />
-          <div class="p-card--overlay u-no-padding--top"
-               style="padding: 1.5rem;
-                      height: 95%;
-                      overflow: hidden">
+          <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
             <div class="row p-section--shallow">
               <div class="col">
                 <h3>Kubernetes Explorer</h3>
@@ -454,10 +451,7 @@
         </div>
         <div class="col">
           <hr class="p-rule--highlight u-no-margin--bottom" />
-          <div class="p-card--overlay u-no-padding--top"
-               style="padding: 1.5rem;
-                      height: 95%;
-                      overflow: hidden">
+          <div class="p-card--overlay p-card--overlay-compact u-no-padding--top">
             <div class="row">
               <div class="col">
                 <div class="p-section--shallow">
@@ -466,13 +460,10 @@
                     Three-day training and 2-week deployment of reference K8s architecture, including:
                   </p>
                 </div>
-                <div style="display:inline-flex;">
+                <div class="u-display--inline-flex">
                   <span class="p-heading--5">Discoverer</span>
-                  <label class="p-switch"
-                         aria-label="Toggle between Kubernetes Discoverer and Discoverer Plus plans"
-                         style="display: inline-block;
-                                padding-left: 32px;
-                                padding-right: 32px">
+                  <label class="p-switch p-switch--spaced"
+                         aria-label="Toggle between Kubernetes Discoverer and Discoverer Plus plans">
                     <input type="checkbox"
                            class="p-switch__input js-discoverer-switch"
                            role="switch" />

--- a/templates/landscape/compare.html
+++ b/templates/landscape/compare.html
@@ -47,9 +47,8 @@
       <div class="p-section--shallow">
         <h2>Compare Landscape options</h2>
       </div>
-      <div style="overflow-x: auto;">
-        <table aria-label="Pricing comparison table"
-               style="table-layout: unset">
+      <div class="u-overflow-x--auto">
+        <table class="u-table-layout--auto" aria-label="Pricing comparison table">
           <thead>
             <tr>
               <th>Feature</th>

--- a/templates/managed-infrastructure/thank-you.html
+++ b/templates/managed-infrastructure/thank-you.html
@@ -26,8 +26,8 @@ var google_conversion_value = 0;
 </script>
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {{ marketo }}

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -249,7 +249,7 @@
     <div class="row--50-50">
       <div class="col">
         <hr class="p-rule--highlight" />
-        <div style="padding: 0 1rem 1rem 1rem; background-color: #EBEBEB;">
+        <div class="p-managed-services-panel">
           <div class="p-section--shallow">
             <h3>Managed Services</h3>
             <p class="u-text--muted">
@@ -276,7 +276,7 @@
       </div>
       <div class="col">
         <hr class="p-rule--highlight" />
-        <div style="padding: 0 1rem 1rem 1rem; background-color: #EBEBEB;">
+        <div class="p-managed-services-panel">
           <div class="p-section--shallow">
             <h3>Firefighting Support</h3>
             <p class="u-text--muted">

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -166,7 +166,7 @@
                             loading="lazy",
                             attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},) | safe
               }}
-              <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Regain focus</h4>
+              <h4 class="p-heading-icon__title u-padding-top--small">Regain focus</h4>
             </div>
             <ul class="p-list">
               <li class="p-list__item is-ticked">You drive  the business, we maintain the apps</li>
@@ -186,7 +186,7 @@
                             loading="lazy",
                             attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},) | safe
               }}
-              <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Reliable and robust</h4>
+              <h4 class="p-heading-icon__title u-padding-top--small">Reliable and robust</h4>
             </div>
             <ul class="p-list">
               <li class="p-list__item is-ticked">Reduce human-error</li>
@@ -206,7 +206,7 @@
                             loading="lazy",
                             attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},) | safe
               }}
-              <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Predictable pricing</h4>
+              <h4 class="p-heading-icon__title u-padding-top--small">Predictable pricing</h4>
             </div>
             <ul class="p-list">
               <li class="p-list__item is-ticked">Per-machine price</li>
@@ -227,7 +227,7 @@
                             loading="lazy",
                             attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},) | safe
               }}
-              <h4 class="p-heading-icon__title" style="padding-top: .5rem;">
+              <h4 class="p-heading-icon__title u-padding-top--small">
                 Accelerate to market</hh43>
               </div>
               <ul class="p-list">

--- a/templates/managed/thank-you.html
+++ b/templates/managed/thank-you.html
@@ -26,8 +26,8 @@ var google_conversion_value = 0;
 </script>
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {{ marketo }}

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -32,7 +32,7 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="SQL server on Kubernetes" width="560" height="315" src="https://www.youtube.com/embed/sRuVBMclM_k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -54,7 +54,7 @@
       <a href="/core">Find out more about Ubuntu Core&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Industry 4.0 needs a complete automation solution" width="560" height="315" src="https://www.youtube.com/embed/Rv54iqchy5M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -64,7 +64,7 @@
 <section class="p-strip is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Plugging the Boothole" width="560" height="315" src="https://www.youtube.com/embed/2DOcm4yMvMw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -107,18 +107,18 @@
       </p>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Mastering multicloud for HPC systems" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/SGrRqCuiT90" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
   {# Domotz #}
   <div class="row u-equal-height">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Streamlined provisioning of IoT devices" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/8u-sM4xpfZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -143,7 +143,7 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
   {# Plus One Robotics #}
   <div class="row u-equal-height">
@@ -167,7 +167,7 @@
       </p>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="The open (source) road to smarter robots" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/Ma1hzMf6YO0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -183,7 +183,7 @@
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Scaling Years of Growth in One Week" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/WvZB3xn1bWg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -202,7 +202,7 @@
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
 
   <div class="row u-equal-height">
@@ -215,19 +215,19 @@
       <p>This is an introductory look at how distributed and edge computing has enhanced computer vision and sensor fusion workloads. Hear about system architecture design choices and practical examples for deployment.</p>
     </div>
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="An introudction to edge computing for computer vision and robotics" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/txNszs1AJf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Building the data centre" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/dSZqax12Q7A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -251,7 +251,7 @@
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Netflix talks about Extended BPF" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/7pmXdG8-7WU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
@@ -277,7 +277,7 @@
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
@@ -300,19 +300,19 @@
     </div>
 
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="Adobe meets huge demand with a lean approach" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/IUgODRm9Soc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr style="margin: 2rem 0;" />
+    <hr class="u-margin-y--x-large" />
   </div>
 
   <div class="row u-equal-height p-reverse-cols--small">
     <div class="col-6">
-      <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
+      <div class="u-embedded-media u-vertically-center--direct p-embedded-media--centered">
         <iframe title="How Roblox went from Windows to Ubuntu in 7 days for edge compute nodes" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/SwlU4U-BWRo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -169,7 +169,7 @@
         <table class="p-table"aria-label="Private cloud platform table">
           <thead>
             <tr>
-              <th style="width: 34%;"></th>
+              <th class="u-width--34"></th>
               <th>
                 Charmed
                 <br />
@@ -970,7 +970,7 @@
           </li>
         </ul>
 
-        <template style="display:none" id="article-template">
+        <template id="article-template">
           <li class="p-list__item">
             <a class="article-link article-title"></a>
           </li>

--- a/templates/openstack/shared/_guest-list.html
+++ b/templates/openstack/shared/_guest-list.html
@@ -1,23 +1,23 @@
 <div class="row u-equal-height">
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/bd47d87c-google-cloud.svg" alt="" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/bd47d87c-google-cloud.svg" alt="" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Google Cloud Platform</h3>
     <p class="p-card__content"><a href="https://cloud.google.com/partners/partnercredit/?PCN=a0n60000003kyX1&utm_medium=partners&utm_campaign=partner-credit">Get started on GCP</a></p>
   </div>
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/c6fe5e8f-AmazonWebservices_Logo.svg" alt="" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/c6fe5e8f-AmazonWebservices_Logo.svg" alt="" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Amazon Web Services</h3>
     <p class="p-card__content"><a href="https://help.ubuntu.com/community/EC2StartersGuide">The Ubuntu guide to EC2</a></p>
   </div>
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" alt="" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" alt="" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Oracle Cloud</h3>
@@ -27,24 +27,24 @@
 
 <div class="row u-equal-height">
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" alt=""  />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" alt=""  />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Microsoft Azure</h3>
     <p class="p-card__content"><a href="https://www.windowsazure.com/en-us/documentation/services/virtual-machines/">Get started on Microsoft Azure</a></p>
   </div>
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/d3959703-T-SYSTEMS-LOGO2013.svg" alt="" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/d3959703-T-SYSTEMS-LOGO2013.svg" alt="" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">T Systems</h3>
     <p class="p-card__content"><a href="https://www.t-systems.com/de/en/solutions/cloud/solutions/open-telekom-cloud/public-cloud-for-business-customers-247826">Get started on T Systems</a></p>
   </div>
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" alt="" height="35" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" alt="" height="35" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Rackspace</h3>
@@ -54,24 +54,24 @@
 
 <div class="row u-equal-height">
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/3f403c1f-logo.svg" alt="" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/3f403c1f-logo.svg" alt="" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Packet</h3>
     <p class="p-card__content"><a href="https://www.packet.net/">Get started on Packet</a></p>
   </div>
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/939e0279-citycloud-logo.svg" alt="" height="35" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/939e0279-citycloud-logo.svg" alt="" height="35" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">citycloud</h3>
     <p class="p-card__content"><a href="https://www.citycloud.com/">Get started on citycloud</a></p>
   </div>
   <div class="col-4 p-card">
-    <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/3579c4ed-softlayer.svg" alt="" />
+    <header class="no-border u-align--center u-vertically-center p-card__logo-header">
+      <img width="150" src="https://assets.ubuntu.com/v1/3579c4ed-softlayer.svg" alt="" />
     </header>
     <hr class="p-rule--muted" />
     <h3 class="p-card__title u-hide">Softlayer</h3>

--- a/templates/openstack/support.html
+++ b/templates/openstack/support.html
@@ -460,7 +460,7 @@
 
   {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true) -%}
     {%- if slot == 'title' -%}
-      <h2 id="openstack-support" style="scroll-margin: 5rem;">Get OpenStack support from Canonical</h2>
+      <h2 class="u-scroll-margin--large" id="openstack-support">Get OpenStack support from Canonical</h2>
     {%- endif -%}
 
     {%- if slot == 'description' -%}

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -67,10 +67,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>

--- a/templates/pricing/pro/application.html
+++ b/templates/pricing/pro/application.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="application-tab" aria-labelledby="application">
   <div class="grid-row--25-75">
     <div class="grid-col">
-      <div class="p-side-navigation is-sticky" id="application-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="application-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="application-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="application side navigation">
           <ul>

--- a/templates/pricing/pro/infrastructure.html
+++ b/templates/pricing/pro/infrastructure.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="infrastructure-tab" aria-labelledby="infrastructure">
   <div class="grid-row--25-75">
     <div class="grid-col">
-      <div class="p-side-navigation is-sticky" id="infrastructure-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="infrastructure-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="infrastructure-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="infrastructure side navigation">
           <ul>

--- a/templates/pricing/pro/operations-and-management.html
+++ b/templates/pricing/pro/operations-and-management.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="operations-management-tab" aria-labelledby="operations-management">
     <div class="grid-row--25-75">
       <div class="grid-col">
-        <div class="p-side-navigation is-sticky" id="operations-management-drawer" style="top: 4rem;">
+        <div class="p-side-navigation is-sticky u-sticky-below-header" id="operations-management-drawer">
           <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="operations-management-drawer"></div>
           <nav class="p-side-navigation__drawer" aria-label="operations management side navigation">
             <ul>

--- a/templates/pricing/pro/security-and-compliance.html
+++ b/templates/pricing/pro/security-and-compliance.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="security-compliance-tab" aria-labelledby="security-compliance">
   <section class="row">
     <aside class="col-3">
-      <div class="p-side-navigation is-sticky" id="security-compliance-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="security-compliance-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="security-compliance-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="security compliance side navigation">
           <ul>

--- a/templates/pricing/pro/services.html
+++ b/templates/pricing/pro/services.html
@@ -1,7 +1,7 @@
 <div tabindex="1" role="tabpanel" id="services-tab" aria-labelledby="services">
   <div class="grid-row--25-75">
     <div class="grid-col">
-      <div class="p-side-navigation is-sticky" id="services-drawer" style="top: 4rem;">
+      <div class="p-side-navigation is-sticky u-sticky-below-header" id="services-drawer">
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="services-drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="services side navigation">
           <ul>

--- a/templates/pricing/shared/_enablement-strip.html
+++ b/templates/pricing/shared/_enablement-strip.html
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="row p-divider" style="padding-top: 1.9rem;">
+  <div class="row p-divider p-nudge-top--large">
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--5">Beyond BSPs</h3>
       <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>

--- a/templates/pricing/ubuntu-pro.html
+++ b/templates/pricing/ubuntu-pro.html
@@ -66,7 +66,7 @@
                 <table aria-label="What is included in a free Pro subscription?">
                   <thead>
                     <tr>
-                      <th style="width: 79%;" scope="col">Security and Compliance</th>
+                      <th class="u-width--79" scope="col">Security and Compliance</th>
                       <th scope="col">
                         Free tier
                         <br />
@@ -110,7 +110,7 @@
         <table aria-label="Ubuntu Pro Pricing">
           <thead>
             <tr>
-              <td style="width: 40%;" role="presentation">&nbsp;</td>
+              <td class="u-table-col--two-fifths" role="presentation">&nbsp;</td>
               <th scope="col">
                 Self-Support
                 <br />
@@ -162,7 +162,7 @@
         <table aria-label="Ubuntu Pro security and compliance">
           <thead>
             <tr>
-              <td style="width: 40%;" role="presentation">&nbsp;</td>
+              <td class="u-table-col--two-fifths" role="presentation">&nbsp;</td>
               <th scope="col">
                 Self-Support
                 <br />
@@ -356,7 +356,7 @@
         <table aria-label="Phone and ticket support">
           <thead>
             <tr>
-              <td style="width: 40%;" role="presentation">&nbsp;</td>
+              <td class="u-table-col--two-fifths" role="presentation">&nbsp;</td>
               <th scope="col">
                 Self-Support
                 <br />

--- a/templates/pro/activate.html
+++ b/templates/pro/activate.html
@@ -24,9 +24,9 @@
                 <input class="p-radio__input radio-organisation" type="radio" aria-labelledby="activate-organisation-input" name="activate-buy-for" value="organisation">
                 <span class="p-radio__label" id="activate-organisation">Organisation</span>
               </label>
-              <div class="p-form__group js-organisation-name-container" style="display:none">
+              <div class="p-form__group js-organisation-name-container u-hide">
                 <label for="activate-organisation-name" class="p-form__label">Organisation name: </label>
-                <input class="u-no-margin--bottom" type="text" id="activate-organisation-name" name="activate-organisation-name" placeholder="Ex: Canonical" style="margin-top: .25rem;" aria-label="What?">
+                <input class="u-no-margin--bottom p-nudge-margin-top--x-small" type="text" id="activate-organisation-name" name="activate-organisation-name" placeholder="Ex: Canonical" aria-label="What?">
               </div>
             </div>
           </div>
@@ -49,7 +49,7 @@
       <form id="activate-key-form">
         <div class="p-form__group">
           <label for="pro-activation-key" class="p-form__label">Enter your code</label>
-          <div class="p-form__control" style="min-width: 15rem">
+          <div class="p-form__control u-min-width--15rem">
             <input type="text" id="pro-activation-key" class="activate-input" name="key" autocomplete="off" placeholder="Ex: Kabcedfghij12345678910-" required="" aria-describedby="pro-activate-input">
             <p class="p-form-validation__message" id="pro-activatio-validation__message"></p>
           </div>
@@ -58,7 +58,7 @@
       </form>
     </div>
     <div class="u-fixed-width">
-      <div class="p-notification--negative" id="notification" style="display: none">
+      <div class="p-notification--negative u-hide" id="notification">
         <div class="p-notification__content">
           <h5 class="p-notification__title">Something went wrong</h5>
             <p class="p-notification__message" id="notification-message"></p>

--- a/templates/pro/devices.html
+++ b/templates/pro/devices.html
@@ -366,7 +366,7 @@ meta_copydoc %}
         <div class="col-9">
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/9c8bfd51-Aaeon-Logo.png",
                 alt="AAEON logo",
@@ -399,7 +399,7 @@ meta_copydoc %}
           <hr class="p-rule--muted is-fixed-width" />
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/4ed674b0-advantech-logo.png",
                 alt="advantech logo",
@@ -429,7 +429,7 @@ meta_copydoc %}
           <hr class="p-rule--muted is-fixed-width" />
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/8b7059c4-DFI-logo.png",
                 alt="DFI logo",
@@ -462,7 +462,7 @@ meta_copydoc %}
           <hr class="p-rule--muted is-fixed-width" />
           <div class="row">
             <div class="col-3">
-              <div style="padding-top:1rem;">
+              <div class="u-padding-top--medium">
                 {{ image (
                 url="https://assets.ubuntu.com/v1/0ed224e1-adlink-logo.png",
                 alt="adlink logo",

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -410,7 +410,7 @@
             <table>
               <thead>
                 <tr>
-                  <th style="width: 35%;">Category</th>
+                  <th class="u-width--35">Category</th>
                   <th>Example applications and toolchains covered by Ubuntu Pro</th>
                 </tr>
               </thead>

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -31,8 +31,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -85,7 +85,7 @@
           integrity and continuous
           production.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/007d3fe1-Industrial@3x.png",
                     alt="",
                     width="284",
@@ -102,7 +102,7 @@
           critical
           infrastructure they run on.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/04c896e6-Telco@3x.png",
                     alt="",
                     width="284",
@@ -118,7 +118,7 @@
           must complete tasks within
           specified deadlines.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/9969e00e-Healthcare@3x.png",
                     alt="",
                     width="284",
@@ -134,7 +134,7 @@
           infotainment systems, HMIs and
           latency-sensitive scenarios.
         </p>
-        <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        <div class="u-hide--small u-background--shade">
           {{ image(url="https://assets.ubuntu.com/v1/4ffd9127-Automotive@3x.png",
                     alt="",
                     width="284",

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -8,8 +8,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1OA_Eg1200fHpt7YYkE4qubiWfxL_U5fnlA0OObRe2n8/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'
-); background-position: 77% 0%;">
+<section class="p-strip--image is-dark is-deep p-strip--rfp-hero">
 <div class="row">
   <div class="col-7">
     <div class="p-card--overlay">

--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -351,10 +351,10 @@
           <table aria-label="ESM for ROS &ndsah; Ubuntu Pro subscriptions">
             <thead>
               <tr>
-                <th class="u-no-padding--left" style="width: 39%">&nbsp;</th>
-                <th style="width: 25%">Ubuntu LTS</th>
-                <th style="width: 25%">Ubuntu Pro (Infra-only)</th>
-                <th style="width: 25%">Ubuntu Pro</th>
+                <th class="u-no-padding--left u-width--39">&nbsp;</th>
+                <th class="u-table-col--quarter">Ubuntu LTS</th>
+                <th class="u-table-col--quarter">Ubuntu Pro (Infra-only)</th>
+                <th class="u-table-col--quarter">Ubuntu Pro</th>
               </tr>
             </thead>
             <tbody>
@@ -424,7 +424,7 @@
       <div class="grid-row">
         <div class="grid-col-start-large-5 grid-col-4">
           <hr class="p-rule--muted is-fixed-width" />
-          <span style="margin-right: 1rem;">Want to know more?</span>
+          <span class="u-margin-right--medium">Want to know more?</span>
           <a href="/internet-of-things/contact-us?product=robotics"
             class="p-button js-invoke-modal"
             aria-controls="robotics-modal"

--- a/templates/robotics/thank-you.html
+++ b/templates/robotics/thank-you.html
@@ -28,8 +28,8 @@
 <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  <div>
+    <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
   </div>
 </noscript>
 {% endblock footer_extra %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -324,9 +324,9 @@
       <h2>Security support for Ubuntu releases</h2>
     </div>
     <div class="row">
-      <div class="col-10" style="overflow: auto;">
+      <div class="col-10 u-overflow--auto">
         <div class="u-hide--small" id="server-desktop-eol-old"></div>
-        <table class="u-hide--medium u-hide--large" style="width: auto;">
+        <table class="u-hide--medium u-hide--large u-width--auto">
           <thead>
             <tr>
               <td>&nbsp;</td>

--- a/templates/server/maas/thank-you.html
+++ b/templates/server/maas/thank-you.html
@@ -21,8 +21,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/server/partial/_server-footer.html
+++ b/templates/server/partial/_server-footer.html
@@ -41,7 +41,7 @@
           </ul>
         </div>
 
-        <template style="display:none" id="article-template">
+        <template id="article-template">
           <li class="p-list__item">
             <a class="article-link article-title"></a>
           </li>

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -23,9 +23,8 @@
         <p class="p-heading--5">Tailor your email preferences</p>
       </div>
       <div class="col-8">
-        <div class="p-search-and-filter"
+        <div class="p-search-and-filter u-margin-bottom--medium"
              id="subscription-centre-search"
-             style="margin-bottom:1rem"
              aria-hidden="true"
              hidden>
           <button class="p-search-and-filter__clear" aria-hidden="true" hidden="">
@@ -47,10 +46,8 @@
             </div>
           </div>
 
-          <div class="p-search-and-filter__panel"
-               aria-hidden="true"
-               style="background:#f7f7f7;
-                      padding-top:0"></div>
+          <div class="p-search-and-filter__panel u-background--light u-no-padding--top"
+               aria-hidden="true"></div>
 
           <template id="search-result-template">
             <div class="p-search-and-filter__search-prompt" role="button" tabindex="0">
@@ -73,7 +70,7 @@
                    {% if updatesOptIn %}checked{% endif %} />
             <span class="p-checkbox__label">I agree to receive information about Canonical's products and services</span>
           </label>
-          <hr style="margin-top:1rem;margin-bottom:0;" />
+          <hr class="u-margin-top--medium u-no-margin--bottom" />
           <div class="p-accordion">
             <ul class="p-accordion__list" id="subscriptions-list">
               {% for category in categories %}
@@ -121,8 +118,7 @@
         </form>
       </div>
     </div>
-    <hr class="p-rule is-fixed-width u-no-margin--top"
-        style="margin-bottom:1rem" />
+    <hr class="p-rule is-fixed-width u-no-margin--top u-margin-bottom--medium" />
     <div class="row">
       <div class="col-start-large-5">
         <span class="u-sv3">In submitting this form, I confirm that I have read and agree to <a href="https://canonical.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://canonical.com/legal/data-privacy">Privacy Policy</a>.</span>

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -199,15 +199,13 @@
       <div class="u-align--right u-sv1">
         <a href="#"
            id="carousel-previous"
-           class="p-carousel__previous"
-           style="text-decoration: unset">
+           class="p-carousel__previous u-text-decoration--none">
           <i class="p-icon--chevron-left">Previous image</i>
         </a>
         &nbsp;
         <a href="#"
            id="carousel-next"
-           class="p-carousel__next"
-           style="text-decoration: unset">
+           class="p-carousel__next u-text-decoration--none">
           <i class="p-icon--chevron-right">Next image</i>
         </a>
       </div>
@@ -407,7 +405,7 @@
         <div class="p-equal-height-row">
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/fed38b56-new-linux.png",
                                 alt="",
                                 width="566",
@@ -426,7 +424,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/ec34b48a-new-app-ecosystem.png",
                                 alt="",
                                 width="566",
@@ -445,7 +443,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/8a92eed1-new-content-design.png",
                                 alt="",
                                 width="566",
@@ -464,7 +462,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/c71d8fa6-new-community.png",
                                 alt="",
                                 width="566",
@@ -483,7 +481,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/359e01a1-new-infrastructure.png",
                                 alt="",
                                 width="566",
@@ -503,7 +501,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/5fba2c50-new-devices.png",
                                 alt="",
                                 width="566",
@@ -523,7 +521,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/70b56649-new-data.png",
                                 alt="",
                                 width="566",
@@ -542,7 +540,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/5c5e4abc-new-gaming.png",
                                 alt="",
                                 width="566",
@@ -562,7 +560,7 @@
           </div>
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
-              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+              <div class="p-image-container u-hide--small u-overflow--hidden">
                 {{ image(url="https://assets.ubuntu.com/v1/e298d421-new-security.png",
                                 alt="",
                                 width="566",

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -941,12 +941,12 @@
   <noscript>
     <img height="1"
          width="1"
-         style="display:none"
+         class="u-hide"
          alt=""
          src="https://analytics.twitter.com/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
     <img height="1"
          width="1"
-         style="display:none"
+         class="u-hide"
          alt=""
          src="https://t.co/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
   </noscript>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -47,8 +47,8 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    <div>
+      <img height="1" width="1" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
   {{ marketo }}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -141,15 +141,13 @@
               </div>
               <div class="l-tutorial__pagination">
                 {% if loop.first %}
-                  <button class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom"
-                          disabled
-                          style="margin-right: 1rem">
+                  <button class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom u-margin-right--medium"
+                          disabled>
                     <i class="p-icon--chevron-down">Previous step</i>
                   </button>
                 {% else %}
                   <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}"
-                     class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom"
-                     style="margin-right: 1rem">
+                     class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom u-margin-right--medium">
                     <i class="p-icon--chevron-down">Previous step</i>
                   </a>
                 {% endif %}

--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -204,7 +204,7 @@
                 <div class="row p-section--shallow" id="ubuntu-latest"></div>
             </div>
         </div>
-        <template style="display:none" id="blog-template">
+        <template id="blog-template">
             <div class="col-3 col-medium-2">
                 <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
                 <h3 class="p-heading--5">

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -349,7 +349,7 @@
           <div class="row p-section--shallow" id="ubuntu-wsl-latest"></div>
         </div>
       </div>
-      <template style="display:none" id="blog-template">
+      <template id="blog-template">
         <div class="col-3 col-medium-2">
           <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
           <h3 class="p-heading--5">

--- a/templates/wsl/thank-you.html
+++ b/templates/wsl/thank-you.html
@@ -42,10 +42,9 @@
   </script>
   <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>


### PR DESCRIPTION
## Done
- Chunk of https://github.com/canonical/ubuntu.com/pull/16476
- Removed inline style= attributes.
- Added static/sass/_utilities.scss atomic properties

## QA
- Open demo
- Navigate to pages that are modified by `Files changed`
- Ensure there are no breaking CSS changes (eg. buttons work as expected and things don't look strange)
- Open console and ensure there are no errors caused by removing inline styles.

