### PR TITLE
fix: remove inline styles from shared and base templates

### DIFF
--- a/templates/0_docs/strips.html
+++ b/templates/0_docs/strips.html
@@ -63,9 +63,7 @@
   </div>
 </section>
 <section class="p-strip--light u-no-padding--top">
-  <div class="row u-vertically-center"
-       style="position: relative;
-              top: -2rem">
+  <div class="row u-vertically-center p-strip--pulled-up">
     <div class="col-6">
       <h2>Second strip heading</h2>
       <p>This strip should only be used on overview/main pages and is meant to be followed by a light-grey section.</p>

--- a/templates/16-04/_release-chart-1604.html
+++ b/templates/16-04/_release-chart-1604.html
@@ -1,7 +1,7 @@
 <div class="row">
-  <div class="col-10" style="overflow: auto;">
+  <div class="col-10 u-overflow--auto">
     <div class="u-hide--small" id="eol-1604"></div>
-    <table class="u-hide--medium u-hide--large" style="width: auto;">
+    <table class="u-hide--medium u-hide--large u-width--auto">
       <thead>
         <tr>
           <td>&nbsp;</td>

--- a/templates/18-04/_release-chart-1604.html
+++ b/templates/18-04/_release-chart-1604.html
@@ -1,7 +1,7 @@
 <div class="row">
-  <div class="col-10" style="overflow: auto;">
+  <div class="col-10 u-overflow--auto">
     <div class="u-hide--small" id="eol-1604"></div>
-    <table class="u-hide--medium u-hide--large" style="width: auto;">
+    <table class="u-hide--medium u-hide--large u-width--auto">
       <thead>
         <tr>
           <td>&nbsp;</td>

--- a/templates/20years/index.html
+++ b/templates/20years/index.html
@@ -1291,7 +1291,7 @@
   <section class="p-section">
     <div class="p-section--shallow u-fixed-width">
       <hr class="p-rule--highlight" />
-      <h2 class="p-text--small-caps" style="margin-top: 0.5rem;">Birthday wishes from our partners</h2>
+      <h2 class="p-text--small-caps u-margin-top--small">Birthday wishes from our partners</h2>
     </div>
     <div class="p-section">
       <div class="row--25-75">

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -592,8 +592,7 @@
           </ul>
         </div>
         <div class="col">
-          <div class="p-image-wrapper u-hide--medium p-image-container--2-3 u-vertically-center"
-               style="background: rgba(0, 0, 0, 0.15)">
+          <div class="p-image-wrapper u-hide--medium p-image-container--2-3 u-vertically-center u-background--shade-medium">
             {{ image(url="https://assets.ubuntu.com/v1/1cbb17af-Multi-cloud%20Kubernetes%20%20and%20containers.png",
                         alt="",
                         width="1132",
@@ -759,8 +758,7 @@
       <div class="row--50-50-on-large p-section--shallow">
         <hr class="p-rule" />
         <div class="col">
-          <div class="p-image-wrapper u-vertically-center p-image-container--2-3 u-hide--medium"
-               style="background: rgba(0, 0, 0, 0.15)">
+          <div class="p-image-wrapper u-vertically-center p-image-container--2-3 u-hide--medium u-background--shade-medium">
             {{ image(url="https://assets.ubuntu.com/v1/21ef9142-Ultra%20Secure%20Things.png",
                         alt="",
                         width="1200",
@@ -1294,8 +1292,7 @@
 
     <section class="p-section--deep">
       <div class="u-fixed-width">
-        <div class="u-align--center p-image-container--cinematic is-cover"
-             style="background: rgba(0, 0, 0, 0.15)">
+        <div class="u-align--center p-image-container--cinematic is-cover u-background--shade-medium">
           {{ image(url="https://assets.ubuntu.com/v1/6d657910-Multi-cloud%20Applications%C2%A0%C2%A0Beyond%20PAAS.png",
                     alt="",
                     width="2464",

--- a/templates/macros/_macros-resource.jinja
+++ b/templates/macros/_macros-resource.jinja
@@ -32,11 +32,11 @@
       <div class="col-6 col-medium-3">
         {%- if title_link|trim|length > 0 -%}
           {%- if title_header == "h3" -%}
-            <h3 class="p-heading--4 u-hide--medium" style="padding-top: 0.275rem;">
+            <h3 class="p-heading--4 u-hide--medium p-nudge-top--x-small">
               {{ title_link | safe }}
             </h3>
           {%- else -%}
-            <h2 class="p-heading--4 u-hide--medium" style="padding-top: 0.275rem;">
+            <h2 class="p-heading--4 u-hide--medium p-nudge-top--x-small">
               {{ title_link | safe }}
             </h2>
           {%- endif -%}

--- a/templates/macros/_vf-latest-news.jinja
+++ b/templates/macros/_vf-latest-news.jinja
@@ -53,7 +53,7 @@
     <div class="row">
       <div class="{% if items == 4 %}col-12 {% else %}col-9 col-start-large-4{% endif %}">
         <div id="latest-articles-container" class="p-equal-height-row--wrap">
-          <div class="u-vertically-center u-align--center" style="min-height: 9.1rem">
+          <div class="u-vertically-center u-align--center p-loading-placeholder">
             <i class="p-icon--spinner u-animation--spin">Loading...</i>
           </div>
         </div>
@@ -61,7 +61,7 @@
     </div>
 
     {# The template used by latest-news.js to render each article #}
-    <template style="display:none" id="latest-articles-template">
+    <template id="latest-articles-template">
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="u-crop--16-9">

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -1,8 +1,6 @@
 {% if colour == 'dark' %}
 
-  <div class="p-strip--accent is-dark is-bordered is-x-shallow"
-       style="background-blend-mode: color;
-              background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%)">
+  <div class="p-strip--accent is-dark is-bordered is-x-shallow p-strip--call-sales-dark">
     <div class="row u-vertically-center">
       <div class="col-1 u-vertically-center u-hide--medium u-hide--small">
 
@@ -41,7 +39,7 @@
             {% endif %}
 
             <div class="col-11 u-no-margin--left u-no-margin--bottom">
-              <h4 style="margin-bottom: 0.5rem;">Any questions?</h4>
+              <h4 class="u-margin-bottom--small">Any questions?</h4>
               <p class="u-no-margin--bottom u-no-max-width">
                 <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us&nbsp;&rsaquo;</a>
               </p>

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -20,7 +20,7 @@
               name="UbuntuDesktopPlannedUsage"
               maxlength="2000"></textarea>
     <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage">How do you plan to use Ubuntu Desktop?</label>
-    <div class="p-section--shallow" id="ubuntu_desktop_usage_fields" style="display: flex; align-items: center; gap: 24px;">
+    <div class="p-section--shallow p-inline-options" id="ubuntu_desktop_usage_fields">
         <label class="p-checkbox js-checkbox u-no-margin">
           <input type="checkbox" aria-labelledby="work" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="work">Work</span>

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -1,6 +1,5 @@
-<div class="p-section--shallow u-hide--small"
-     id="kernel-eol"
-     style="overflow: hidden"></div>
+<div class="p-section--shallow u-hide--small u-overflow--hidden"
+     id="kernel-eol"></div>
 <div class="u-table-scroll--medium u-table-scroll--small">
   <table class="u-table-horizontal-scroll__table">
     <thead>

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -26,7 +26,7 @@
   <div class="row">
     <div class="{% if spotlight %}col-9{% else %}col-12{% endif %}">
       <div id="horizontal-latest-articles" class="p-equal-height-row--wrap">
-        <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
+        <div class="p-loading-placeholder"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
       </div>
     </div>
     {% if spotlight %}
@@ -35,7 +35,7 @@
     {% endif %}
   </div>
 
-  <template style="display:none" id="horizontal-articles-template">
+  <template id="horizontal-articles-template">
     <div class="p-equal-height-row__col">
       {% if not hide_date %}
         <div class="p-equal-height-row__item">
@@ -65,7 +65,7 @@
   </template>
 
   {% if spotlight %}
-  <template style="display:none" id="spotlight-template">
+  <template id="spotlight-template">
     <hr class="p-rule--muted u-hide--large" />
     <div class="row">
       <div class="col-medium-2 col-small-4 col-3">

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -3,7 +3,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         {% if icon %}<img src="{{icon}}" alt="" class="p-heading-icon__img" />{% endif %}
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="{{url}}">{{text}}&nbsp;&rsaquo;</a></h4>
+        <h4 class="p-heading-icon__title p-nudge-top--medium"><a href="{{url}}">{{text}}&nbsp;&rsaquo;</a></h4>
       </div>
     </div>
   </div>

--- a/templates/shared/_pagination.html
+++ b/templates/shared/_pagination.html
@@ -1,6 +1,6 @@
 <div class="u-fixed-width">
   {% if current_page and total_pages and total_pages > 1 %}
-    <ol class="p-pagination {% if align %} {{ align }} {% else %} u-align--center {% endif %}" style="flex-wrap: wrap;">
+    <ol class="p-pagination {% if align %} {{ align }} {% else %} u-align--center {% endif %} u-flex-wrap--wrap">
       <li class="p-pagination__item">
         {% if current_page > 1 %}
           {% if limit %}

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -14,9 +14,9 @@
     {% endif %}
   </div>
   <div class="row">
-    <div class="col-10" style="overflow: auto;">
+    <div class="col-10 u-overflow--auto">
       <div class="u-hide--small" id="server-desktop-eol-old"></div>
-      <table class="u-hide--medium u-hide--large" style="width: auto;">
+      <table class="u-hide--medium u-hide--large u-width--auto">
         <thead>
           <tr>
             <td>&nbsp;</td>

--- a/templates/shared/_share_this.html
+++ b/templates/shared/_share_this.html
@@ -1,5 +1,5 @@
 <div class="share-this">
-	<iframe title="Share on Facebook" src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20" style="border:none; overflow:hidden; height:21px; padding-right:23px;"></iframe>
+	<iframe class="p-facebook-like" title="Share on Facebook" src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20"></iframe>
 	<div class="g-plusone" data-size="medium"></div>
     <script nonce="{{ csp_nonce }}">
       window.___gcfg = {lang: 'en-GB'};

--- a/templates/shared/_ubuntu-advantage-service-description-ja.html
+++ b/templates/shared/_ubuntu-advantage-service-description-ja.html
@@ -1,9 +1,9 @@
   <div class="u-fixed-width">
-    <div style="overflow-x: auto;">
-      <table class="p-table" style="width: auto;">
+    <div class="u-overflow-x--auto">
+      <table class="p-table u-width--auto">
         <thead>
           <tr>
-            <th style="width: 40%;"></th>
+            <th class="u-table-col--two-fifths"></th>
             <th width="200" class="u-align--center">Essential</th>
             <th width="200" class="u-align--center">Standard</th>
             <th width="200" class="u-align--center">Advanced</th>

--- a/templates/shared/_ubuntu-pro-description.html
+++ b/templates/shared/_ubuntu-pro-description.html
@@ -1,9 +1,9 @@
   <div class="u-fixed-width">
-    <div style="overflow-x: auto;">
-      <table class="p-table" style="width: auto;">
+    <div class="u-overflow-x--auto">
+      <table class="p-table u-width--auto">
         <thead>
           <tr>
-            <th style="width: 40%;"></th>
+            <th class="u-table-col--two-fifths"></th>
             <th width="200" class="u-align--center">Ubuntu Pro</th>
             <th width="200" class="u-align--center">Ubuntu Pro + support (weekday)</th>
             <th width="200" class="u-align--center">Ubuntu Pro + support (24/7)</th>

--- a/templates/shared/contextual_footers/_ai_further_reading.html
+++ b/templates/shared/contextual_footers/_ai_further_reading.html
@@ -5,7 +5,7 @@
   </ul>
 </div>
 
-<template style="display:none" id="article-template">
+<template id="article-template">
   <li class="p-list__item">
     <a class="article-link article-title"></a>
   </li>

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -19,8 +19,8 @@
                   <label class="u-off-screen" for="mce-EMAIL">Your email</label>
                   <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" value="" name="EMAIL" class="required email" id="mce-EMAIL" />
                   <div id="mce-responses">
-                      <div class="response" id="mce-error-response" style="display: none; width: 100%;"></div>
-                      <div class="response" id="mce-success-response" style="display: none; width: 100%;"></div>
+                      <div class="response u-hide u-width--full" id="mce-error-response"></div>
+                      <div class="response u-hide u-width--full" id="mce-success-response"></div>
                   </div>
               </li>
               <li>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -7,7 +7,7 @@
   </ul>
 </div>
 
-<template style="display:none" id="article-template">
+<template id="article-template">
   <li class="p-list__item">
     <a class="article-link article-title"></a>
   </li>

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -13,13 +13,9 @@
            role="dialog"
            aria-labelledby="modal-title"
            aria-describedby="modal-description">
-        <header class="p-modal__header"
-                style="display: block;
-                       border-bottom: 0;
-                       overflow: auto">
-          <button class="p-modal__close js-close"
-                  aria-label="Close active modal"
-                  style="margin-left: -1rem">Close</button>
+        <header class="p-modal__header p-modal__header--scroll">
+          <button class="p-modal__close js-close p-form-template__field"
+                  aria-label="Close active modal">Close</button>
           <div class="u-fixed-width">
             <h3>{{ formData.title }}</h3>
           </div>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -1,6 +1,6 @@
 <div class="u-fixed-width">
-  <div style="overflow-x: auto;">
-    <table class="p-table" style="width: auto;">
+  <div class="u-overflow-x--auto">
+    <table class="p-table u-width--auto">
       <thead>
         <tr>
           <th>&nbsp;</th>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -1,4 +1,4 @@
-<table style="width: 100%;">
+<table>
   <thead>
     <tr>
       <th>&nbsp;</th>

--- a/templates/shared/pricing/_maas-pricing.html
+++ b/templates/shared/pricing/_maas-pricing.html
@@ -1,9 +1,9 @@
 <div class="u-fixed-width">
-  <div style="overflow-x: auto;">
+  <div class="u-overflow-x--auto">
     <table class="p-table">
       <thead>
         <tr>
-          <th style="width: 50%;">&nbsp;</th>
+          <th class="u-table-col--half">&nbsp;</th>
           <th class="u-align--right">No support</th>
           <th class="u-align--right">Weekday support</th>
           <th class="u-align--right">24/7 support</th>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -1,16 +1,16 @@
-<div style="overflow: auto;">
-  <table style="width: auto;">
+<div class="u-overflow--auto">
+  <table class="u-width--auto">
     <thead>
       <tr>
-        <th style="width: 40%;">&nbsp;</th>
-        <th class="u-align--center" style="width: 20%;">MAAS</th>
+        <th class="u-table-col--two-fifths">&nbsp;</th>
+        <th class="u-align--center u-table-col--one-fifth">MAAS</th>
         <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for MAAS</th>
       </tr>
       <tr>
         <th>&nbsp;</th>
         <th class="u-align--center">Without support</th>
-        <th class="p-table__cell--highlight u-align--center" style="width: 20%;">Standard</th>
-        <th class="p-table__cell--highlight u-align--center" style="width: 20%;">Advanced</th>
+        <th class="p-table__cell--highlight u-align--center u-table-col--one-fifth">Standard</th>
+        <th class="p-table__cell--highlight u-align--center u-table-col--one-fifth">Advanced</th>
       </tr>
     </thead>
 

--- a/templates/shared/pricing/_managed-pricing.html
+++ b/templates/shared/pricing/_managed-pricing.html
@@ -1,6 +1,6 @@
 <div class="u-fixed-width">
-  <div style="overflow-x: auto;">
-    <table class="p-table" style="width: auto;">
+  <div class="u-overflow-x--auto">
+    <table class="p-table u-width--auto">
       <thead>
         <tr>
           <th>All prices are annual&nbsp;</th>

--- a/templates/shared/pricing/_openstack-kubernetes-lma.html
+++ b/templates/shared/pricing/_openstack-kubernetes-lma.html
@@ -1,9 +1,9 @@
 <div class="u-fixed-width">
-  <div style="overflow-x: auto;">
+  <div class="u-overflow-x--auto">
     <table class="p-table">
       <thead>
         <tr>
-          <th style="width: 50%;">&nbsp;</th>
+          <th class="u-table-col--half">&nbsp;</th>
           <th class="u-align--right">Per VM</th>
           <th class="u-align--right">Per Host</th>
           <th></th>

--- a/templates/shared/pricing/_ua-advanced-storage.html
+++ b/templates/shared/pricing/_ua-advanced-storage.html
@@ -1,9 +1,9 @@
 <div class="u-fixed-width">
-  <div style="overflow-x: auto;">
+  <div class="u-overflow-x--auto">
     <table>
       <thead>
         <tr>
-          <th style="width: 50%;">UA Advanced Storage</th>
+          <th class="u-table-col--half">UA Advanced Storage</th>
           <th class="u-align--right">Tier Price</th>
           <th class="u-align--right">Additional per TB</th>
           <th></th>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -1,6 +1,6 @@
 <div class="row">
-  <div class="col-10" style="overflow: auto;">
-    <table class="p-table" style="width: auto;">
+  <div class="col-10 u-overflow--auto">
+    <table class="p-table u-width--auto">
       <thead>
         <tr>
           <th>&nbsp;</th>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -1,9 +1,9 @@
 <div class="u-fixed-width">
-  <div style="overflow-x: auto;">
+  <div class="u-overflow-x--auto">
     <table class="p-table">
       <thead>
         <tr>
-          <th style="width: 50%;"></th>
+          <th class="u-table-col--half"></th>
           <th class="u-align--right">Ubuntu Pro (Infra-only)</th>
           <th class="u-align--right">Ubuntu Pro</th>
           <th></th>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -1,5 +1,5 @@
-<div style="overflow: auto;">
-  <table class="p-table" style="width: auto;">
+<div class="u-overflow--auto">
+  <table class="p-table u-width--auto">
     <thead>
       <tr>
         <th>&nbsp;</th>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -165,18 +165,15 @@
               {% for child in breadcrumbs.children %}
                 {% if child.title != "Overview" %}
                   {% if child.path == '/blog/topics' %}
-                    <li class="p-navigation__item  {% if child.active %}is-selected{% endif %}"
-                        style="position: relative">
+                    <li class="p-navigation__item {% if child.active %}is-selected{% endif %} u-position--relative">
                       <a aria-controls="#topics"
                          data-trigger="hover"
                          class="p-navigation__link  p-contextual-menu__toggle"
                          href="#">{{ child.title }}</a>
-                      <span class="p-contextual-menu__dropdown"
+                      <span class="p-contextual-menu__dropdown p-navigation__topics-dropdown"
                             id="topics"
                             aria-hidden="true"
-                            aria-label="submenu"
-                            style="position: absolute;
-                                   font-size: .875rem">
+                            aria-label="submenu">
                         <span class="p-contextual-menu__group">
                           {% for item in child.children %}
                             <a href="{{ item.path }}"

--- a/templates/templates/_product.html
+++ b/templates/templates/_product.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 {% block outer_content %}
   {% block content %}
-    <section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/a328d904-MAAS-background-desktop-large-screen.png'); background-size: 100% 100%;">
+    <section class="p-strip--image is-dark is-deep p-product-hero--maas">
       <div class="row">
         <div class="col-8">
           {% block hero %}{% endblock %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -140,8 +140,7 @@
             <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
                     height="0"
                     width="0"
-                    style="display: none;
-                           visibility: hidden"
+                    class="u-hide u-visibility--hidden"
                     title="Google Tag Manager"></iframe>
           </noscript>
           <!-- end google tag manager -->

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -62,15 +62,14 @@
               content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
       </head>
 
-      <body style="padding-top: 0;">
+      <body class="u-no-padding--top">
         <!-- google tag manager -->
         <noscript>
           <iframe title="Google Tag Manager"
                   src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
                   height="0"
                   width="0"
-                  style="display:none;
-                         visibility:hidden"></iframe>
+                  class="u-hide u-visibility--hidden"></iframe>
         </noscript>
         <!-- end google tag manager -->
 
@@ -79,7 +78,7 @@
           {% block header_banner %}
             <div class="u-fixed-width p-navigation__row--25-75">
               <div class="p-navigation__tagged-logo">
-                <a class="p-navigation__link" href="/" style="width:max-content;">
+                <a class="p-navigation__link u-width--max-content" href="/">
                   <div class="p-navigation__logo-tag">
                     <img class="p-navigation__logo-icon"
                          src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"

--- a/templates/templates/docs/markdown.html
+++ b/templates/templates/docs/markdown.html
@@ -39,7 +39,7 @@
             <h1 class="u-no-margin--bottom">{{ title }}</h1>
           </div>
         {% endif %}
-        <div class="p-strip is-shallow" style="overflow: visible;">{{ content | safe }}</div>
+        <div class="p-strip is-shallow u-overflow--visible">{{ content | safe }}</div>
         {% if auto_paginate %}
           <div class="p-article-pagination">
             <a class="p-article-pagination__link--previous js-previous"

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -2,7 +2,7 @@
 
 {% block footer %}
 
-  <footer class="is-dark p-strip u-clearfix" style="background-color: #2d2d2d;">
+  <footer class="is-dark p-strip u-clearfix u-background--charcoal">
     <nav aria-label="Footer navigation"
          id="main-navigation"
          class="p-footer__nav p-section">

--- a/templates/templates/markdown/base.html
+++ b/templates/templates/markdown/base.html
@@ -39,7 +39,7 @@
             <h1 class="u-no-margin--bottom">{{ title }}</h1>
           </div>
         {% endif %}
-        <div class="p-strip is-shallow" style="overflow: visible;">{{ content | safe }}</div>
+        <div class="p-strip is-shallow u-overflow--visible">{{ content | safe }}</div>
       </main>
     </div>
   </div>

--- a/templates/templates/navigation/base.html
+++ b/templates/templates/navigation/base.html
@@ -192,7 +192,7 @@
             {% endfor %}
           {% else %}
             {% for links_section in sections.highlighted_secondary_links %}
-              <p class="p-muted-heading" style="padding-left:0.5rem;">{{ links_section.title }}</p>
+              <p class="p-muted-heading u-padding-left--small">{{ links_section.title }}</p>
               <ul class="p-list">
                 {% for link in links_section.links %}
                   {% with
@@ -298,7 +298,7 @@
     {% if "highlighted_secondary_links" in sections %}
       {% for links_section in sections.highlighted_secondary_links %}
         {% if links_section.title %}
-          <p class="p-muted-heading is-muted" style="padding-top: 1rem;">{{ links_section.title }}</p>
+          <p class="p-muted-heading is-muted u-padding-top--medium">{{ links_section.title }}</p>
         {% endif %}
         {% for link in links_section.links %}
           {% with

--- a/templates/templates/navigation/navigation-nojs.html
+++ b/templates/templates/navigation/navigation-nojs.html
@@ -194,7 +194,7 @@
                   {% endfor %}
                 {% else %}
                   {% for links_section in nav[section].highlighted_secondary_links %}
-                    <p class="p-muted-heading" style="padding-left:0.5rem;">{{ links_section.title }}</p>
+                    <p class="p-muted-heading u-padding-left--small">{{ links_section.title }}</p>
                     <ul class="p-list">
                       {% for link in links_section.links %}
                         {% with

--- a/templates/tests/_thank-you.html
+++ b/templates/tests/_thank-you.html
@@ -49,10 +49,9 @@
   <script type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
-    <div style="display:inline;">
+    <div>
       <img height="1"
            width="1"
-           style="border-style:none"
            alt=""
            src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
     </div>


### PR DESCRIPTION
## Done
- Chunk of https://github.com/canonical/ubuntu.com/pull/16476
- Removed inline style= attributes.
- Added static/sass/_utilities.scss atomic properties

## QA
- Open demo
- Navigate to pages that are modified by `Files changed`
- Ensure there are no breaking CSS changes (eg. buttons work as expected and things don't look strange)
- Open console and ensure there are no errors caused by removing inline styles.

## Done
https://warthogs.atlassian.net/browse/WD-36638

