### PR TITLE
chore: add redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1296,3 +1296,6 @@ AMI/MiniISO: "https://cdimage.ubuntu.com/ubuntu-mini-iso/releases/noble/release/
 
 # Redirects for TPM/FDE documentation
 desktop/tpm-fde-requirements/?: "https://documentation.ubuntu.com/desktop/en/latest/reference/hardware-backed-disk-encryption-requirements/"
+
+# Hiring blog redirect
+blog/how-we-hire-at-canonical: https://canonical.com/careers/hiring-process


### PR DESCRIPTION
## Done

- Added a redirect for "how-we-hire-at-canonical" blog

## QA

- Open the [DEMO](https://ubuntu-com-16487.demos.haus/blog/how-we-hire-at-canonical)
- Alternatively, checkout this pull request, run the project using `dotrun` and access page at localhost:8001/blog/how-we-hire-at-canonical
- Verify it gets redirected to https://canonical.com/careers/hiring-process

## Issue / Card

Fixes [WD-37262](https://warthogs.atlassian.net/browse/WD-37262)

[WD-37262]: https://warthogs.atlassian.net/browse/WD-37262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
