### PR TITLE
feat: add NIS2 page and contact form

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -33,9 +33,9 @@ let config = {
       extractors: [
         {
           extractor: (content) => {
-            const matches = content.match(/class=["']([^"']+)["']|class=([^\s>]+)|class:\s*{([^}]+)}/g) || [];
+            const matches = content.match(/class=["']([^"']+)["']|class=([^\s>]+)|class:\s*{([^}]+)}|["']class["']:\s*["']([^"']+)["']/g) || [];
             return matches.map(match => {
-              return match.replace(/class=["']|class=|class:\s*{|["'}]/g, '').split(/\s+/);
+              return match.replace(/class=["']|class=|class:\s*{|["']class["']:\s*|["'}]/g, '').split(/\s+/);
             }).flat();
           },
           extensions: ['html']

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1955,3 +1955,8 @@ ol.p-stepped-list.no-full-stop
 .alt-downloads__bittorrent-tab hr {
   display: none;
 }
+
+// Applying tab-section--no-title-space to a tab section will reduce the gap between the section title and the tabs.
+.tab-section--no-title-space > .p-section--shallow {
+  padding-bottom: 0;
+}

--- a/templates/security/nis2/form-data.json
+++ b/templates/security/nis2/form-data.json
@@ -146,6 +146,7 @@
           {
             "title": "How do you consume open source?",
             "id": "how-do-you-consume-open-source",
+            "isRequired": true,
             "inputType": "checkbox",
             "fields": [
               {
@@ -279,7 +280,7 @@
             ]
           },
           {
-            "title": "How should we get in touch?",
+            "title": "About you",
             "id": "about-you",
             "noCommentsFromLead": true,
             "fields": [

--- a/templates/security/nis2/form-data.json
+++ b/templates/security/nis2/form-data.json
@@ -1,0 +1,297 @@
+{
+    "form": {
+      "/security/nis2/contact": {
+        "templatePath": "/security/nis2/index.html",
+        "isModal": true,
+        "modalId": "nis2-modal",
+        "formData": {
+          "title": "Contact us about Canonical solutions for NIS2",
+          "formId": "7918",
+          "returnUrl": "/security/nis2#contact-form-success"
+        },
+        "fieldsets": [
+          {
+            "title": "Tell us about your project",
+            "id": "about-your-project",
+            "isRequired": true,
+            "fields": [
+              {
+                "type": "long-text",
+                "id": "about-your-project",
+                "label": "About your project"
+              }
+            ]
+          },
+          {
+            "title": "If you use Ubuntu, which version(s) are you using?",
+            "id": "ubuntu-versions",
+            "inputType": "checkbox-visibility",
+            "isRequired": true,
+            "fields": [
+              {
+                "fieldTitle": "LTS within standard support",
+                "options": [
+                  {
+                    "type": "checkbox",
+                    "id": "22-04",
+                    "value": "22.04 LTS",
+                    "label": "22.04 LTS"
+                  },
+                  {
+                    "type": "checkbox",
+                    "id": "20-04",
+                    "value": "20.04 LTS",
+                    "label": "20.04 LTS"
+                  }
+                ]
+              },
+              {
+                "fieldTitle": "LTS out of standard support",
+                "options": [
+                  {
+                    "type": "checkbox",
+                    "id": "18-04",
+                    "value": "18.04 LTS",
+                    "label": "18.04 LTS"
+                  },
+                  {
+                    "type": "checkbox",
+                    "id": "16-04",
+                    "value": "16.04 LTS",
+                    "label": "16.04 LTS"
+                  },
+                  {
+                    "type": "checkbox",
+                    "id": "14-04",
+                    "value": "14.04 LTS",
+                    "label": "14.04 LTS"
+                  }
+                ]
+              },
+              {
+                "fieldTitle": "Outdated or non-LTS releases",
+                "options": [
+                  {
+                    "type": "checkbox",
+                    "id": "22-10",
+                    "value": "22.10",
+                    "label": "non-LTS release"
+                  },
+                  {
+                    "type": "checkbox",
+                    "id": "12-04",
+                    "value": "12.04 LTS",
+                    "label": "12.04 LTS"
+                  }
+                ]
+              },
+              {
+                "fieldTitle": "Other",
+                "options": [
+                  {
+                    "type": "checkbox",
+                    "id": "dont-use-ubuntu-today",
+                    "value": "I don't use Ubuntu today",
+                    "label": "I don't use Ubuntu today"
+                  },
+                  {
+                    "type": "checkbox",
+                    "id": "i-dont-know",
+                    "value": "I don't know",
+                    "label": "I don't know"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "title": "How many devices?",
+            "id": "how-many-machines",
+            "inputName": "how-many-machines-do-you-have",
+            "inputType": "radio",
+            "isRequired": true,
+            "fields": [
+              {
+                "type": "radio",
+                "id": "less-5-machines",
+                "value": "less than 5",
+                "label": "< 5 machines"
+              },
+              {
+                "type": "radio",
+                "id": "5-to-15-machines",
+                "value": "5 to 15 machines",
+                "label": "5 - 15 machines"
+              },
+              {
+                "type": "radio",
+                "id": "15-to-50-machines",
+                "value": "15 to 50 machines",
+                "label": "15 - 50 machines"
+              },
+              {
+                "type": "radio",
+                "id": "50-to-100-machines",
+                "value": "50 to 100 machines",
+                "label": "50 - 100 machines"
+              },
+              {
+                "type": "radio",
+                "id": "greater-than-100",
+                "value": "greater than 100",
+                "label": "> 100 machines"
+              }
+            ]
+          },
+          {
+            "title": "How do you consume open source?",
+            "id": "how-do-you-consume-open-source",
+            "inputType": "checkbox",
+            "fields": [
+              {
+                "type": "checkbox",
+                "id": "ubuntu-repositories",
+                "value": "Ubuntu repositories",
+                "label": "Ubuntu repositories"
+              },
+              {
+                "type": "checkbox",
+                "id": "github-upstream",
+                "value": "GitHub/Upstream",
+                "label": "GitHub/Upstream"
+              },
+              {
+                "type": "checkbox",
+                "id": "internally-approved-repository",
+                "value": "Internally approved repository",
+                "label": "Internally approved repository"
+              },
+              {
+                "type": "checkbox",
+                "id": "i-dont-know",
+                "value": "I don't know",
+                "label": "I don't know"
+              }
+            ]
+          },
+          {
+            "title": "Do you have specific compliance or hardening requirements?",
+            "id": "hardening-requirements",
+            "inputType": "checkbox",
+            "fields": [
+              {
+                "type": "checkbox",
+                "id": "nis2-benchmark",
+                "value": "NIS2",
+                "label": "NIS2"
+              },
+              {
+                "type": "checkbox",
+                "id": "cis-benchmark",
+                "value": "CIS Benchmark",
+                "label": "CIS Benchmark"
+              },
+              {
+                "type": "checkbox",
+                "id": "cyber-essentials",
+                "value": "Cyber Essentials",
+                "label": "Cyber Essentials"
+              },
+              {
+                "type": "checkbox",
+                "id": "fips-140",
+                "value": "FIPS 140",
+                "label": "FIPS 140"
+              },
+              {
+                "type": "checkbox",
+                "id": "fedramp",
+                "value": "FedRAMP",
+                "label": "FedRAMP"
+              },
+              {
+                "type": "checkbox",
+                "id": "disa-stig",
+                "value": "DISA-STIG",
+                "label": "DISA-STIG"
+              },
+              {
+                "type": "checkbox",
+                "id": "cmmc",
+                "value": "CMMC",
+                "label": "CMMC"
+              },
+              {
+                "type": "checkbox",
+                "id": "hipaa",
+                "value": "HIPAA",
+                "label": "HIPAA"
+              },
+              {
+                "type": "checkbox",
+                "id": "fisma",
+                "value": "FISMA",
+                "label": "FISMA"
+              },
+              {
+                "type": "checkbox",
+                "id": "ncsc",
+                "value": "NCSC",
+                "label": "NCSC"
+              },
+              {
+                "type": "checkbox",
+                "id": "pci",
+                "value": "PCI-DSS",
+                "label": "PCI-DSS"
+              }
+            ]
+          },
+          {
+            "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+            "id": "responsible-for-tracking",
+            "inputType": "checkbox",
+            "fields": [
+              {
+                "type": "checkbox",
+                "id": "individual-developers",
+                "value": "Individual developers",
+                "label": "Individual developers"
+              },
+              {
+                "type": "checkbox",
+                "id": "project-team",
+                "value": "The project team",
+                "label": "The project team"
+              },
+              {
+                "type": "checkbox",
+                "id": "third-party-vendor",
+                "value": "Third-party vendor",
+                "label": "Third-party vendor"
+              },
+              {
+                "type": "checkbox",
+                "id": "i-dont-know",
+                "value": "I don't know",
+                "label": "I don't know"
+              }
+            ]
+          },
+          {
+            "title": "How should we get in touch?",
+            "id": "about-you",
+            "noCommentsFromLead": true,
+            "fields": [
+              {
+                "type": "tel",
+                "id": "phone",
+                "label": "Phone number",
+                "isRequired": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }

--- a/templates/security/nis2/index.html
+++ b/templates/security/nis2/index.html
@@ -295,7 +295,7 @@ is-paper
               "type": "description",
               "item": {
                 "type": "text",
-                "content": "Get pre-hardened Ubuntu Pro images in the public cloud"
+                "content": "Get pre-hardened Ubuntu Pro images in the public cloud."
               }
             },
             {

--- a/templates/security/nis2/index.html
+++ b/templates/security/nis2/index.html
@@ -1,0 +1,558 @@
+{% extends "security/base_security.html" %}
+
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+{% from "_macros/vf_tab-section.jinja" import vf_tab_section %}
+{% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
+{% from "_macros/vf_divided-section.jinja" import vf_divided_section %}
+{% from "_macros/vf_blog.jinja" import vf_blog %}
+
+
+{% block title %}NIS2 compliance with Ubuntu Pro | Security{% endblock %}
+
+{% block meta_description %}
+How to achieve NIS2 compliance on Linux with Ubuntu Pro
+{% endblock %}
+
+{% block meta_copydoc %}
+https://docs.google.com/document/d/1M3VyC1W3Vq4LBMVCjTB_jYNquUCVOsJjBJXUsnOlNZo/edit?tab=t.0
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+is-paper
+{% endblock body_class %}
+
+{% block content %}
+
+{% call(slot) vf_hero(
+  title_text='Supporting your NIS2 compliance journey with Ubuntu Pro',
+  layout='50/50'
+) -%}
+  {%- if slot == 'description' -%}
+    <p>
+      Take advantage of a complete ecosystem of open source tools and applications, ensuring supply chain security for all of
+      your open source software. Using Canonical software also means accessing up to 15 years of security maintenance to keep
+      systems compliant and stable in the long run.
+    </p>
+  {%- endif -%}
+  {%- if slot == 'cta' -%}
+    <a href="/security/nis2#get-in-touch" class="p-button--positive js-invoke-modal u-no-margin--bottom" aria-controls="nis2-modal"
+      aria-expanded="false">Contact us</a>
+    <a href="/pro" class="p-button u-no-margin--bottom">Get Ubuntu Pro</a>
+  {%- endif -%}
+  {%- if slot == 'image' -%}
+    <div class="u-embedded-media">
+      <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/4DhX_hcLLd0"
+        title="YouTube video player" frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
+    </div>
+  {%- endif -%}
+{% endcall -%}
+
+<section class="p-section--shallow">
+  {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
+    {%- if slot == 'title' -%}
+      <h2>How Ubuntu Pro enables NIS2</h2>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_1' -%}
+      <h3 class="p-heading--5">Supply chain security</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_1' -%}
+      <p>
+        Canonical brings trust and stability to open source through our rigorous process for choosing packages to be included in
+        the distribution. This allows us to prevent malicious dependencies and upstream backdoors impacting your infrastructure.
+        As a one-stop shop, you can rely on us for software and ongoing maintenance of your open source infrastructure.
+      </p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_2' -%}
+      <h3 class="p-heading--5">Patch management</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_2' -%}
+      <p>
+        Canonical provides up to 15 years of security patching for software applications and infrastructure components within
+        the Ubuntu ecosystem, keeping your entire open source estate up-to-date. Ubuntu Pro also includes Livepatch, enabling
+        kernel patching without downtime.
+      </p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_3' -%}
+      <h3 class="p-heading--5">Monitoring at scale</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_3' -%}
+      <p>
+        Monitor and secure your infrastructure at scale on-prem, in the cloud, and in offline environments with Landscape.
+        Landscape is a fleet management tool that allows you to manage your fleet through a single pane of glass and keep it
+        updated.
+      </p>
+    {%- endif -%}
+  {%- endcall -%}
+</section>
+
+{{- vf_tab_section(
+  title={
+    "text": "Security compliance in action"
+  },
+  tabs=[
+    {
+      "tab_html": "Lucid Software",
+      "type": "basic-section",
+      "item": {
+        "items": [
+          {
+            "type": "logo-block",
+            "item": {
+              "logos": [
+                {
+                  "attrs": image(url="https://assets.ubuntu.com/v1/5e0f8073-lucid_logo.png",
+                  alt="Lucid Software",
+                  width="267",
+                  height="311",
+                  hi_def=True,
+                  loading="auto",
+                  output_mode="attrs") ,
+                },
+              ]
+            }
+          },
+          {
+            "type": "description",
+            "item": {
+              "type": "html",
+              "content": '
+                <p class="p-heading--5">Ubuntu Pro helps Lucid Software meet FedRAMP compliance for government contracts</p>
+                <p>
+                  By deploying Ubuntu Pro, Lucid acquired AWS-compatible and FIPS certified packages and became FedRAMP compliant.
+                </p>
+              '
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "link": {
+                "content_html": "Read the case study&nbsp;&rsaquo;",
+                "attrs": {
+                  "href": "https://canonical.com/case-study/lucid-aws-fedramp-compliance-case-study"
+                },
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "tab_html": "Grundium",
+      "type": "basic-section",
+      "item": {
+        "items": [
+          {
+            "type": "logo-block",
+            "item": {
+              "logos": [
+                {
+                  "attrs": image(url="https://assets.ubuntu.com/v1/76a67d40-grundium_logo.png",
+                  alt="Grundium",
+                  width="533",
+                  height="312",
+                  hi_def=True,
+                  loading="auto",
+                  output_mode="attrs") ,
+                },
+              ]
+            }
+          },
+          {
+            "type": "description",
+            "item": {
+              "type": "html",
+              "content": '
+                <p class="p-heading--5">Grundium secures critical systems and improves health outcomes with Ubuntu Pro for Devices</p>
+                <p>
+                  Learn how Grundium must meet stringent security requirements around patient data and confidentiality with Ubuntu Pro.
+                </p>
+              '
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "link": {
+                "content_html": "Read the case study&nbsp;&rsaquo;",
+                "attrs": {
+                  "href": "https://canonical.com/case-study/grundium-ubuntu-pro-for-devices"
+                },
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "tab_html": "OEDIV",
+      "type": "basic-section",
+      "item": {
+        "items": [
+          {
+            "type": "logo-block",
+            "item": {
+              "logos": [
+                {
+                  "attrs": image(url="https://assets.ubuntu.com/v1/a2947028-oediv_logo.png",
+                  alt="OEDIV",
+                  width="366",
+                  height="312",
+                  hi_def=True,
+                  loading="auto",
+                  output_mode="attrs") ,
+                },
+              ]
+            }
+          },
+          {
+            "type": "description",
+            "item": {
+              "type": "html",
+              "content": '
+                <p class="p-heading--5">OEDIV reduces upgrade time by 60% and unlocks 6 years of zero downtime with Ubuntu Pro</p>
+                <p>
+                  By adopting Ubuntu Pro, OEDIV shrank critical maintenance windows from 3 hours down to 45 minutes and reduced manual
+                  engineering tasks by 70%.
+                </p>
+              '
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "link": {
+                "content_html": "Read the case study&nbsp;&rsaquo;",
+                "attrs": {
+                  "href": "https://canonical.com/case-study/oediv"
+                },
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+) -}}
+
+{{- vf_basic_section(
+  title={"text": "What is NIS2?"},
+  items=[
+    {
+      "type": "description",
+      "item": {
+        "type": "text",
+        "content": "The NIS2 Directive (Network and Information Security Directive 2) is a European Union cybersecurity regulation that
+        applies to all EU Member States which aims to strengthen cybersecurity by harmonizing security requirements, improving
+        cooperation among countries, and introducing new focus areas such as supply chain security. Implemented into national
+        law by 17 October 2024, NIS2 expands the scope of regulated organizations to include more critical infrastructure and
+        essential service providers across multiple sectors. Although it applies within the EU, its impact is global:
+        organizations using open source software must manage and secure it with the same rigor as any other critical third-party
+        software."
+      }
+    }
+  ]
+) -}}
+
+{{- vf_divided_section(
+  title={
+    "text": "Ubuntu Pro supports NIS2 compliance everywhere",
+  },
+  blocks=[
+    {
+      "type": "divided-block",
+      "bullet_type": "none",
+      "items": [
+        {
+          "title_text": "On-prem",
+          "contents": [
+            {
+              "type": "description",
+              "item": {
+                "type": "html",
+                "content": "
+                <p>
+                  <a href='/pro'>Ubuntu Pro</a> enables compliance on Ubuntu desktops and servers in private clouds and Virtual Machines.
+                </p>
+                "
+              }
+            }
+          ]
+        },
+        {
+          "title_text": "In the cloud",
+          "contents": [
+            {
+              "type": "description",
+              "item": {
+                "type": "text",
+                "content": "Get pre-hardened Ubuntu Pro images in the public cloud"
+              }
+            },
+            {
+              "type": "linked-logo-block",
+              "item": {
+                "links": [
+                  {
+                    "href": "/aws",
+                    "text": "Learn more&nbsp;&rsaquo;",
+                    "label": "Learn more about Ubuntu on AWS",
+                    "image_attrs": image(
+                      url="https://assets.ubuntu.com/v1/1611d5ca-aws_logo.png",
+                      alt="Amazon Web Services",
+                      width="852",
+                      height="480",
+                      hi_def=True,
+                      loading="lazy",
+                      output_mode="attrs"
+                    )
+                  },
+                  {
+                    "href": "/azure",
+                    "text": "Learn more&nbsp;&rsaquo;",
+                    "label": "Learn more about Ubuntu on Azure",
+                    "image_attrs": image(
+                      url="https://assets.ubuntu.com/v1/c3e1a351-azure_logo.png",
+                      alt="Azure",
+                      width="852",
+                      height="480",
+                      hi_def=True,
+                      loading="lazy",
+                      output_mode="attrs"
+                    )
+                  },
+                  {
+                    "href": "/gcp",
+                    "text": "Learn more&nbsp;&rsaquo;",
+                    "label": "Learn more about Ubuntu on Google Cloud Platform",
+                    "image_attrs": image(
+                      url="https://assets.ubuntu.com/v1/e0db1c3a-google_cloud_logo.png",
+                      alt="Google Cloud",
+                      width="852",
+                      height="480",
+                      hi_def=True,
+                      loading="lazy",
+                      output_mode="attrs"
+                    )
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "title_text": "In air-gapped environments",
+          "contents": [
+            {
+              "type": "description",
+              "item": {
+                "type": "text",
+                "content": 'All Ubuntu Pro features are also available in air-gapped or offline deployments. <a href="https://documentation.ubuntu.com/airgapped/">Explore our documentation here</a>.'
+              }
+            },
+          ]
+        },
+      ]
+    },
+  ],
+) -}}
+
+{{- vf_basic_section(
+  title={"text": 'Take the next step<br class="u-hide--small u-hide--medium" />towards NIS2 compliance'},
+  items=[
+    {
+      "type": "description",
+      "item": {
+        "type": "html",
+        "content": '
+        <p>
+          <a href="/security/certifications">Learn about all our security certifications</a>
+        </p>
+        <p>
+          <a href="/pricing/pro">Explore pricing and find the right subscription for your needs</a>
+        </p>
+        <hr class="p-rule--muted" />
+        '
+      }
+    },
+    {
+      "type": "description",
+      "item": {
+        "type": "text",
+        "content": "Ubuntu Pro provides a strong foundation to achieve NIS2 compliance. It delivers vulnerability patching for Ubuntu OS and
+        Applications; automated, unattended, and restartless security updates; and the best tools needed to secure and manage
+        your Ubuntu infrastructure."
+      }
+    },
+    {
+      "type": "cta-block",
+      "item": {
+        "primary": {
+          "content_html": "Contact us",
+          "attrs": {
+            "href": "/security/nis2#get-in-touch",
+            "class": "js-invoke-modal",
+            "aria-controls": "nis2-modal"
+          }
+        },
+        "secondaries": [
+          {
+            "content_html": "Access a 30-day free trial",
+            "attrs": {
+              "href": "/pro/free-trial"
+            }
+          }
+        ]
+      }
+    }
+  ]
+) -}}
+
+{{- vf_tab_section(
+    attrs={
+      "class": "tab-section--no-title-space",
+    },
+    title={
+      "text": "Resources"
+    },
+    layout="full-width",
+    tabs=[
+      {
+        "tab_html": "Blog",
+        "type": "blog",
+        "item": {
+          "template_config": {
+            "enabled": True, 
+            "template_container_id": "nis2-articles"
+          },
+        }
+      },
+      {
+        "tab_html": "Whitepapers",
+        "type": "blog",
+        "item": {
+          "articles": [
+            {
+              "title": {
+                "text": "A guide to Infrastructure Hardening",
+                "link_attrs": {
+                  "href": "https://ubuntu.com/engage/a-guide-to-infrastructure-hardening"
+                },
+              },
+              "image": {
+                "attrs": {
+                  "src": "https://assets.ubuntu.com/v1/e672ca4a-infra_hardening.jpg",
+                  "alt": "A guide to Infrastructure Hardening",
+                },
+              },
+            },
+            {
+              "title": {
+                "text": "A guide to open source vulnerability management",
+                "link_attrs": {
+                  "href": "https://ubuntu.com/engage/vulnerability-management"
+                },
+              },
+              "image": {
+                "attrs": {
+                  "src": "https://assets.ubuntu.com/v1/f716080e-os_vulnerability_management.jpg",
+                  "alt": "A guide to open source vulnerability management",
+                },
+              },
+            },
+            {
+              "title": {
+                "text": "Cyber Resilience Act: Yocto or Ubuntu Core for embedded devices?",
+                "link_attrs": {
+                  "href": "https://ubuntu.com/engage/cra-yocto-core"
+                },
+              },
+              "image": {
+                "attrs": {
+                  "src": "https://assets.ubuntu.com/v1/3cb955b6-cra.jpg",
+                  "alt": "Cyber Resilience Act: Yocto or Ubuntu Core for embedded devices?",
+                },
+              },
+            }
+          ]
+        }
+      },
+      {
+        "tab_html": "Webinars",
+        "type": "blog",
+        "item": {
+          "articles": [
+            {
+              "title": {
+                "text": "NIS2 Compliance: Open source software supply chain security for critical infrastructure providers within the EU",
+                "link_attrs": {
+                  "href": "https://ubuntu.com/engage/nis2-compliance"
+                },
+              },
+              "image": {
+                "attrs": {
+                  "src": "https://assets.ubuntu.com/v1/67053e2b-nist2_compliance.jpg",
+                  "alt": "NIS2 Compliance: Open source software supply chain security for critical infrastructure providers within the EU",
+                },
+              },
+            },
+            {
+              "title": {
+                "text": "Securing the software supply chain: What every IT leader must know",
+                "link_attrs": {
+                  "href": "https://ubuntu.com/engage/idc-gcp-wbnr"
+                },
+              },
+              "image": {
+                "attrs": {
+                  "src": "https://assets.ubuntu.com/v1/e9d060c3-securing_software_supply.jpg",
+                  "alt": "Securing the software supply chain: What every IT leader must know",
+                },
+              },
+            },
+            {
+              "title": {
+                "text": "How Ubuntu keeps your system secure, stable and current",
+                "link_attrs": {
+                  "href": "https://ubuntu.com/engage/how-ubuntu-keeps-your-system-secure-stable-and-current"
+                },
+              },
+              "image": {
+                "attrs": {
+                  "src": "https://assets.ubuntu.com/v1/b50ef04f-how_ubuntu_keeps.jpg",
+                  "alt": "How Ubuntu keeps your system secure, stable and current",
+                },
+              },
+            }
+          ]
+        }
+      }
+    ]
+) -}}
+
+<script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script>
+  canonicalLatestNews.fetchLatestNews({
+    imageClasses: ["p-image-container__image"],
+    limit: "4",
+    articlesContainerSelector: "#nis2-articles",
+    articleTemplateSelector: "#template",
+    excerptLength: 200,
+    tagIds: "4633,4869,3586,4632",
+    gtmEventLabel: "Latest from our blog"
+  })
+</script>
+
+{{ load_form('/security/nis2/contact') | safe }}
+
+{% endblock content %}

--- a/templates/security/nis2/index.html
+++ b/templates/security/nis2/index.html
@@ -425,6 +425,7 @@ is-paper
       "text": "Resources"
     },
     layout="full-width",
+    padding="deep",
     tabs=[
       {
         "tab_html": "Blog",

--- a/templates/security/standards/index.html
+++ b/templates/security/standards/index.html
@@ -135,7 +135,7 @@
     {%- endif -%}
     {%- if slot == 'list_item_10' -%}
       <h3 id="nis2" class="p-heading--6 p-heading--bold u-no-padding--top">
-        <a href="/blog/a-comprehensive-guide-to-nis2-compliance-part-3-setting-the-roadmap-and-demonstrating-nis2-compliance">NIS2</a>
+        <a href="/security/nis2">NIS2</a>
       </h3>
       <p class="u-no-padding--top">Canonical can help you with your compliance needs related to EU NIS2.</p>
     {%- endif -%}


### PR DESCRIPTION
## Done

- Add a new /security/nis2 page and corresponding contact form.

## QA

- Open [/security/nis2](https://ubuntu-com-16495.demos.haus/security/nis2)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the page matches the [design](https://www.figma.com/design/pc4AcZqcXvWJqrm4t1x1y6/ubuntu.com-security---Sites?node-id=5228-2818&p=f&t=kynqVp2o9wYJGY2i-0) and the [copydoc](https://docs.google.com/document/d/1M3VyC1W3Vq4LBMVCjTB_jYNquUCVOsJjBJXUsnOlNZo/edit?tab=t.0#heading=h.mgh2gmonsycg).
- Click on the 'Contact us' button and the [form](https://docs.google.com/document/d/14SfzNv0KE6bkpxIcxC9Lwk6X8YfUewsm28_EzM7la54/edit?tab=t.0) should appear.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37041.
Fixes https://warthogs.atlassian.net/browse/WD-37124.

## Screenshots

<img width="3024" height="10224" alt="Screenshot 2026-06-23 at 17-59-52 NIS2 compliance with Ubuntu Pro Security Ubuntu" src="https://github.com/user-attachments/assets/0d93e44b-6b19-4b6c-bb3b-00d071436b6a" />

