### PR TITLE
Add Launchpad documentation sitemap to sitemap index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -69,4 +69,7 @@
   <sitemap>
     <loc>https://ubuntu.com/docs/adsys/page/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/launchpad/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Added https://ubuntu.com/docs/launchpad to the sitemap index as suggested in [Migrating documentation](https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/#adding-sitemaps).