### PR TITLE
feat: Enrich sentry form errors

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1285,7 +1285,7 @@ demo:
         name: marketo
 
     - name: SENTRY_DSN
-      value: https://624a17f6cb841af9f2c4b0998b8f30d2@o4510662863749120.ingest.de.sentry.io/4510709886419024
+      value: https://26f047659075983d689a1fe068b11b20@o4510662863749120.ingest.de.sentry.io/4511647999590480
 
     - name: BADGR_URL
       value: https://api.test.badgr.com
@@ -1360,7 +1360,7 @@ demo:
         name: discourse-api
 
     - name: FLASK_ENV
-      value: "demo"    
+      value: "demo"
 
     - name: WORDPRESS_APPLICATION_PASSWORD
       secretKeyRef:

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -60,6 +60,7 @@ export function setupIntlTelInput(countryCode, phoneInput) {
     separateDialCode: true,
     hiddenInput: (phoneInputName) => ({
       phone: phoneInputName,
+      country: `${phoneInputName}_country`, // TODO: Remove after QA, to check failing payload submissions
     }),
     initialCountry: countryCode.toLowerCase(),
   });

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -60,7 +60,6 @@ export function setupIntlTelInput(countryCode, phoneInput) {
     separateDialCode: true,
     hiddenInput: (phoneInputName) => ({
       phone: phoneInputName,
-      country: `${phoneInputName}_country`, // TODO: Remove after QA, to check failing payload submissions
     }),
     initialCountry: countryCode.toLowerCase(),
   });

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1232,7 +1232,7 @@ def marketo_submit():
                 error_msg="Please ensure the form exists and try again.",
             )
 
-        if "result" not in data:
+        if not data.get("result"):
             marketo_sentry_report(
                 "Marketo form API Issue",
                 payload=payload,
@@ -1247,17 +1247,10 @@ def marketo_submit():
                 400,
             )
 
-        if data["result"][0]["status"] == "skipped":
-            marketo_sentry_report(
-                f"Marketo form {payload['formId']} failed to submit",
-                payload=payload,
-                response=data,
-                enrichment_fields=enrichment_fields,
-            )
-
     except Exception:
         marketo_sentry_report(
             "Marketo form submission failed with Exception",
+            exception=True,
             payload=payload,
             enrichment_fields=enrichment_fields,
         )
@@ -1277,9 +1270,10 @@ def marketo_submit():
         ).json()
     except Exception:
         marketo_sentry_report(
-            "Marketo enrichment form submission failed",
+            "Marketo enrichment form submission failed with Exception",
+            exception=True,
             enriched_payload=enriched_payload,
-            payload=payload
+            payload=payload,
         )
 
     # Redirect to success page only if both submissions were successful.
@@ -1288,7 +1282,7 @@ def marketo_submit():
     # even though the top-level API response still reports success. Treat it
     # as an explicit failure so it can never be silently reported as success.
     payload_status = data["result"][0]["status"]
-    
+
     if (
         enrichment_submission["success"] is True
         and data["success"] is True
@@ -1374,15 +1368,25 @@ def marketo_submit():
     return flask.redirect("/thank-you")
 
 
-def marketo_sentry_report(message, **extras):
+def marketo_sentry_report(message, exception=False, **extras):
     """
-    Report a Marketo event to Sentry as a captured message, attaching any
-    keyword arguments as extra context (e.g. payload=payload, response=data).
+    Report a Marketo event to Sentry, attaching any keyword arguments as extra
+    context (e.g. payload=payload, response=data).
+
+    Pass ``exception=True`` when calling from within an ``except`` block to
+    capture the active exception (preserving its traceback) with ``message``
+    attached as extra context. Otherwise the human-readable ``message`` is
+    captured directly.
     """
     with sentry_sdk.push_scope() as scope:
         for key, value in extras.items():
             scope.set_extra(key, value)
-        sentry_sdk.capture_message(message)
+
+        if exception:
+            scope.set_extra("message", message)
+            sentry_sdk.capture_exception()
+        else:
+            sentry_sdk.capture_message(message)
 
 
 def thank_you():

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1386,7 +1386,9 @@ def marketo_sentry_report(message, exception=False, **extras):
             scope.set_extra("message", message)
             sentry_sdk.capture_exception()
         else:
-            sentry_sdk.capture_message(message)
+            sentry_sdk.capture_message(message, level="error")
+
+        sentry_sdk.flush(timeout=2)
 
 
 def thank_you():

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1192,9 +1192,11 @@ def marketo_submit():
             "There was a problem submitting your form.",
             "contact-form-fail",
         )
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("enrichment_fields", enrichment_fields)
-            sentry_sdk.capture_message("Marketo form ID missing")
+        marketo_sentry_report(
+            "Marketo form ID missing",
+            enrichment_fields=enrichment_fields,
+            form_fields=form_fields,
+        )
         return flask.redirect(f"{referrer}#contact-form-fail")
 
     payload = {
@@ -1219,16 +1221,24 @@ def marketo_submit():
         data = r.json()
 
         if "errors" in data and data["errors"][0]["code"] == "609":
+            marketo_sentry_report(
+                "Marketo form ID does not exist",
+                payload=payload,
+                response=data,
+                enrichment_fields=enrichment_fields,
+            )
             return flask.render_template(
                 "/400.html",
                 error_msg="Please ensure the form exists and try again.",
             )
 
         if "result" not in data:
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra("payload", payload)
-                scope.set_extra("response", data)
-                sentry_sdk.capture_message("Marketo form API Issue")
+            marketo_sentry_report(
+                "Marketo form API Issue",
+                payload=payload,
+                response=data,
+                enrichment_fields=enrichment_fields,
+            )
 
             return (
                 flask.jsonify(
@@ -1238,15 +1248,19 @@ def marketo_submit():
             )
 
         if data["result"][0]["status"] == "skipped":
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra("payload", payload)
-                scope.set_extra("response", data)
-                sentry_sdk.capture_message(
-                    (f"Marketo form {payload['formId']} failed to submit")
-                )
+            marketo_sentry_report(
+                f"Marketo form {payload['formId']} failed to submit",
+                payload=payload,
+                response=data,
+                enrichment_fields=enrichment_fields,
+            )
 
     except Exception:
-        sentry_sdk.capture_exception(extra={"payload": payload})
+        marketo_sentry_report(
+            "Marketo form submission failed with Exception",
+            payload=payload,
+            enrichment_fields=enrichment_fields,
+        )
 
         return (
             flask.jsonify(
@@ -1262,11 +1276,11 @@ def marketo_submit():
             enriched_payload
         ).json()
     except Exception:
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("enriched_payload", enriched_payload)
-            sentry_sdk.capture_message(
-                "Marketo enrichment form submission failed"
-            )
+        marketo_sentry_report(
+            "Marketo enrichment form submission failed",
+            enriched_payload=enriched_payload,
+            payload=payload
+        )
 
     # Redirect to success page only if both submissions were successful.
     # A "skipped" payload status means Marketo rejected the main form
@@ -1274,7 +1288,7 @@ def marketo_submit():
     # even though the top-level API response still reports success. Treat it
     # as an explicit failure so it can never be silently reported as success.
     payload_status = data["result"][0]["status"]
-
+    
     if (
         enrichment_submission["success"] is True
         and data["success"] is True
@@ -1334,12 +1348,13 @@ def marketo_submit():
             )
             flash_message = "There was an issue submitting the form."
 
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("payload", payload)
-            scope.set_extra("response", data)
-            scope.set_extra("enriched_payload", enriched_payload)
-            scope.set_extra("enrichment_response", enrichment_submission)
-            sentry_sdk.capture_message(sentry_message)
+        marketo_sentry_report(
+            sentry_message,
+            payload=payload,
+            response=data,
+            enriched_payload=enriched_payload,
+            enrichment_response=enrichment_submission,
+        )
 
         flask.flash(flash_message, "contact-form-fail")
 
@@ -1357,6 +1372,17 @@ def marketo_submit():
         return flask.redirect(f"/thank-you?referrer={referrer}")
 
     return flask.redirect("/thank-you")
+
+
+def marketo_sentry_report(message, **extras):
+    """
+    Report a Marketo event to Sentry as a captured message, attaching any
+    keyword arguments as extra context (e.g. payload=payload, response=data).
+    """
+    with sentry_sdk.push_scope() as scope:
+        for key, value in extras.items():
+            scope.set_extra(key, value)
+        sentry_sdk.capture_message(message)
 
 
 def thank_you():

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1262,12 +1262,24 @@ def marketo_submit():
             enriched_payload
         ).json()
     except Exception:
-        pass
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("enriched_payload", enriched_payload)
+            sentry_sdk.capture_message(
+                "Marketo enrichment form submission failed"
+            )
 
-    # Redirect to success page only if both submissions were successful
+    # Redirect to success page only if both submissions were successful.
+    # A "skipped" payload status means Marketo rejected the main form
+    # submission (e.g. an unexpected field such as a stray hidden input),
+    # even though the top-level API response still reports success. Treat it
+    # as an explicit failure so it can never be silently reported as success.
     payload_status = data["result"][0]["status"]
 
-    if enrichment_submission["success"] is True and data["success"] is True:
+    if (
+        enrichment_submission["success"] is True
+        and data["success"] is True
+        and payload_status != "skipped"
+    ):
         flask.flash(
             "Your form was submitted successfully.", "contact-form-success"
         )
@@ -1295,42 +1307,41 @@ def marketo_submit():
 
             return flask.redirect(return_url)
     else:
-        # Log failed form submissions to Sentry and display error notification
+        # Log every failed submission to Sentry with the tried payload, then
+        # display an error notification to the user.
         if (
             payload_status == "skipped"
             and enrichment_submission["success"] is False
         ):
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra("payload", payload)
-                scope.set_extra("enriched_payload", enriched_payload)
-                sentry_sdk.capture_message(
-                    (
-                        f"Marketo form {payload['formId']} and "
-                        "enrichment payload failed to submit"
-                    )
-                )
-            flask.flash(
-                (
-                    "There was an issue submitting the form contact details "
-                    "and payload."
-                ),
-                "contact-form-fail",
+            sentry_message = (
+                f"Marketo form {payload['formId']} and "
+                "enrichment payload failed to submit"
+            )
+            flash_message = (
+                "There was an issue submitting the form contact details "
+                "and payload."
             )
         elif payload_status == "skipped":
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra("payload", payload)
-                scope.set_extra("response", data)
-                scope.set_extra("enriched_payload", enriched_payload)
-                sentry_sdk.capture_message(
-                    (
-                        f"Marketo form {payload['formId']} "
-                        "payload failed to submit"
-                    )
-                )
-            flask.flash(
-                "There was an issue submitting the form payload.",
-                "contact-form-fail",
+            sentry_message = (
+                f"Marketo form {payload['formId']} payload failed to submit"
             )
+            flash_message = "There was an issue submitting the form payload."
+        else:
+            # Payload was accepted but enrichment failed, or the API
+            # reported failure for another reason.
+            sentry_message = (
+                f"Marketo form {payload['formId']} submission failed"
+            )
+            flash_message = "There was an issue submitting the form."
+
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("payload", payload)
+            scope.set_extra("response", data)
+            scope.set_extra("enriched_payload", enriched_payload)
+            scope.set_extra("enrichment_response", enrichment_submission)
+            sentry_sdk.capture_message(sentry_message)
+
+        flask.flash(flash_message, "contact-form-fail")
 
         if return_url:
             # Remove anchor from url


### PR DESCRIPTION
## Done

- Always include enrichment payload and form payload on failing form errors and report them to Sentry
- Check for "skipped" payload status for failing payload submissions
- Added new "ubuntu-com-demos" project on Sentry
  - Rate limiting on "ubuntu-com" is silently dropping logs sent from demos. Therefore, a new demos instance is created to ensure that demo logs are received as expected

## QA

- Go to https://ubuntu-com-16498.demos.haus/#get-in-touch or any forms
- Fill up form, expect an error 
- Check that the error is reported [on Sentry](https://canonical-ax.sentry.io/organizations/canonical-ax/issues/?guidedStep=3&project=4511647999590480&query=&referrer=issue-list&statsPeriod=24h)
- Note: search for "Marketo form X payload failed to submit"

## Issue / Card

Fixes [WD-37312](https://warthogs.atlassian.net/browse/WD-37312)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37312]: https://warthogs.atlassian.net/browse/WD-37312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ