### PR TITLE
ci: fix flaky blog-links check

### DIFF
--- a/.github/workflows/blog-links.yaml
+++ b/.github/workflows/blog-links.yaml
@@ -1,6 +1,8 @@
 name: Blog Links
 
 on:
+  # QA
+  pull_request:
   schedule:
     - cron: "20 7 * * 1"
 
@@ -13,20 +15,44 @@ jobs:
       - name: Install linkchecker
         run: sudo pip install LinkChecker
 
-      - name: Run linkchecker
+      - name: Write linkchecker config file
         run: |
-          linkchecker --recursion-level=2 \
-          	--check-extern --no-warnings https://ubuntu.com/blog \
-            --timeout 1000 \
-          	--no-follow-url '!https:\/\/ubuntu.com\/blog' \
-          	--ignore-url https://res.cloudinary.com \
-          	--ignore-url q_auto \
-          	--ignore-url fl_sanitize \
-          	--ignore-url c_fill \
-          	--ignore-url e_sharpen \
-          	--ignore-url w_[0-9]* \
-          	--ignore-url h_[0-9]* \
-            --ignore-url https://www.amd.com/*
+          mkdir -p ~/.linkchecker
+          cat > ~/.linkchecker/linkcheckerrc <<EOF
+          [checking]
+          maxrequestspersecond=5
+          recursionlevel=2
+          timeout=1000
+          sslverify=0
+
+          [filtering]
+          checkextern=1
+          nofollow=
+            !https://ubuntu.com/blog
+          ignore=
+            https://res.cloudinary.com
+            q_auto
+            fl_sanitize
+            c_fill
+            e_sharpen
+            w_[0-9]*
+            h_[0-9]*
+            https://ubuntu.com/.*sitemap.*\.xml
+            https://www.amd.com/*
+
+          [output]
+          status=0
+          warnings=0
+          ignoreerrors=
+            ^https?://.* ^.*(471|503|504)
+            ^https?://.* Connection aborted
+            ^https?://.* Connection reset by peer
+            ^https?://.* RemoteDisconnected
+            ^https?://.* Read timed out
+          EOF
+
+      - name: Run linkchecker on ubuntu.com/blog
+        run: linkchecker --no-warnings https://ubuntu.com/blog
 
       - name: Send message on failure
         if: failure()

--- a/.github/workflows/blog-links.yaml
+++ b/.github/workflows/blog-links.yaml
@@ -1,8 +1,6 @@
 name: Blog Links
 
 on:
-  # QA
-  pull_request:
   schedule:
     - cron: "20 7 * * 1"
 
@@ -21,9 +19,6 @@ jobs:
           cat > ~/.linkchecker/linkcheckerrc <<EOF
           [checking]
           maxrequestspersecond=5
-          recursionlevel=2
-          timeout=1000
-          sslverify=0
 
           [filtering]
           checkextern=1
@@ -44,7 +39,7 @@ jobs:
           status=0
           warnings=0
           ignoreerrors=
-            ^https?://.* ^.*(471|503|504)
+            ^https?://.* ^.*(503|504)
             ^https?://.* Connection aborted
             ^https?://.* Connection reset by peer
             ^https?://.* RemoteDisconnected


### PR DESCRIPTION
## Done

- Ignore flaky connection errors
- Exclude sitemaps check in `blog-links`. It was previously crawling dynamic sitemaps which resulted in connection errors and reporting flaky test fails

## QA

- See that [`Blog Links / check-links`](https://github.com/canonical/ubuntu.com/actions/runs/28080066115/job/83132719404?pr=16501) action passes
- Note: Remove the QA step before merging

## Issue / Card

Fixes [WD-37328](https://warthogs.atlassian.net/browse/WD-37328)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37328]: https://warthogs.atlassian.net/browse/WD-37328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ