### PR TITLE
fix: update deprecated authd link

### DIFF
--- a/templates/desktop/organizations.html
+++ b/templates/desktop/organizations.html
@@ -328,7 +328,7 @@
             </p>
             <hr class="p-rule" />
             <p>
-              <a href="https://canonical-authd.readthedocs-hosted.com/en/latest/">Authd documentation&nbsp;&rsaquo;</a>
+              <a href="https://ubuntu.com/docs/authd/stable-docs/">Authd documentation&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Update authd documentation link
- [Copy doc](https://docs.google.com/document/d/1RuxCA6GYh9UriNv26HCZP9UHo4b4_9fYaaMtGQuH_xc/edit?tab=t.0)

## QA

- Go to https://ubuntu-com-16511.demos.haus/desktop/organizations
- Search for `Authd documentation`
- Check that the link works

## Issue / Card

Fixes [WD-37371](https://warthogs.atlassian.net/browse/WD-37371)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37371]: https://warthogs.atlassian.net/browse/WD-37371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ