### PR TITLE
feat(WD-37231): update boot assets download links - /download/mediatek-genio

### DIFF
--- a/templates/download/mediatek-genio/tabs/genio-1200-evk.html
+++ b/templates/download/mediatek-genio/tabs/genio-1200-evk.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>This is a Beta release of Ubuntu 24.04 LTS on MediaTek Genio 1200 EVK. The Certified version is coming soon.</p>
       <a class="p-button"
-        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g1200-evk-boot-assets-20250926-1185.tar.xz">
+        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g1200-evk-boot-assets-20260506-50.tar.xz">
         Download boot assets for Ubuntu 24.04 LTS
       </a>
       <div class="p-section--shallow">

--- a/templates/download/mediatek-genio/tabs/genio-350-evk.html
+++ b/templates/download/mediatek-genio/tabs/genio-350-evk.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>This is a Beta release of Ubuntu 24.04 LTS on MediaTek Genio 350 EVK. The Certified version is coming soon.</p>
       <a class="p-button"
-        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g350-boot-assets-20250926-1185.tar.xz">
+        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g350-boot-assets-20260506-50.tar.xz">
         Download boot assets for Ubuntu 24.04 LTS
       </a>
       <div class="p-section--shallow">

--- a/templates/download/mediatek-genio/tabs/genio-510-evk.html
+++ b/templates/download/mediatek-genio/tabs/genio-510-evk.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>This is a Beta release of Ubuntu 24.04 LTS on MediaTek Genio 510 EVK. The Certified version is coming soon.</p>
       <a class="p-button"
-        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g510-boot-assets-20250926-1185.tar.xz">
+        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g510-boot-assets-20260506-50.tar.xz">
         Download boot assets for Ubuntu 24.04 LTS
       </a>
       <div class="p-section--shallow">

--- a/templates/download/mediatek-genio/tabs/genio-700-evk.html
+++ b/templates/download/mediatek-genio/tabs/genio-700-evk.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>This is a Beta release of Ubuntu 24.04 LTS on MediaTek Genio 700 EVK. The Certified version is coming soon.</p>
       <a class="p-button"
-        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g700-boot-assets-20250926-1185.tar.xz">
+        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g700-boot-assets-20260506-50.tar.xz">
         Download boot assets for Ubuntu 24.04 LTS
       </a>
       <div class="p-section--shallow">

--- a/templates/download/mediatek-genio/tabs/genio-720-evk.html
+++ b/templates/download/mediatek-genio/tabs/genio-720-evk.html
@@ -33,7 +33,7 @@
         The Certified version is coming soon.
       </p>
       <a class="p-button"
-        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g720-evk-boot-assets-20260102-30.tar.xz">
+        href="https://people.canonical.com/~platform/images/mediatek/ubuntu-server-24.04/genio-g720-evk-boot-assets-20260506-50.tar.xz">
         Download boot assets for Ubuntu 24.04 LTS
       </a>
       <div class="p-section--shallow">


### PR DESCRIPTION
## Done

- Update boot asset download links to match [copy doc](https://docs.google.com/document/d/1Tm3cVVkWkzriQQ7kgbgKfKoeGZaew1M5OMbpLPSDGIc/edit?tab=t.vdbpn2ndlbo9)

## QA

- Open the [DEMO](https://ubuntu-com-16519.demos.haus/download/mediatek-genio)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/mediatek-genio
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare each tab's boot assets link with [copy doc](https://docs.google.com/document/d/1Tm3cVVkWkzriQQ7kgbgKfKoeGZaew1M5OMbpLPSDGIc/edit?tab=t.vdbpn2ndlbo9)

## Issue / Card

Fixes [WD-37231](https://warthogs.atlassian.net/browse/WD-37231)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37231]: https://warthogs.atlassian.net/browse/WD-37231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
