### PR TITLE
certified: Use download_instructions_url and release_notes_url when provided

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -99,6 +99,9 @@
               </p>
               <p>
                 <a href="{{ release.download_url }}" class="p-button">Download</a>
+                {% if release.release_notes_url %}
+                  <a href="{{ release.release_notes_url }}" class="p-button">Release Notes</a>
+                {% endif %}
               </p>
             {% endif %}
 

--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -12,8 +12,9 @@ def get_download_url(model_details):
     """
     platform_category = model_details.get("category", "").lower()
     architecture = model_details.get("architecture", "").lower()
-    make = model_details.get("make", "").lower()
-    configuration_name = model_details.get("model", "").lower()
+
+    if model_details.get("download_instructions_url"):
+        return model_details.get("download_instructions_url")
 
     if model_details.get("level") == "Enabled":
         # Enabled systems use oem images without download links.
@@ -22,22 +23,7 @@ def get_download_url(model_details):
     if platform_category in ["desktop", "laptop"]:
         return "https://ubuntu.com/download/desktop"
 
-    if make == "nvidia" and "jetson" in configuration_name:
-        return "https://ubuntu.com/download/nvidia-jetson"
-
-    if "qualcomm" in make and "dragonwing" in configuration_name:
-        return "https://ubuntu.com/download/qualcomm-iot#evaluation-kit"
-
-    if "thundercomm" in make and "rubik pi 3" in configuration_name:
-        return "https://ubuntu.com/download/qualcomm-iot#rubikpi3"
-
-    if "renesas" in make and "rz/g" in configuration_name:
-        return "https://ubuntu.com/download/renesas-iot"
-
     if "core" in platform_category:
-        if make == "xilinx":
-            return "https://ubuntu.com/download/amd"
-
         return "https://ubuntu.com/download/iot/"
 
     if "server" in platform_category:

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -603,6 +603,7 @@ def certified_model_details(canonical_id):
             "notes": model_release["notes"],
             "version": ubuntu_version,
             "download_url": get_download_url(model_release),
+            "release_notes_url": model_release["release_notes_url"],
             "components": {},
         }
 

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -603,7 +603,7 @@ def certified_model_details(canonical_id):
             "notes": model_release["notes"],
             "version": ubuntu_version,
             "download_url": get_download_url(model_release),
-            "release_notes_url": model_release["release_notes_url"],
+            "release_notes_url": model_release.get("release_notes_url"),
             "components": {},
         }
 


### PR DESCRIPTION
## Done

The C3 API was updated to include two new fields:

- download_instructions_url
- release_notes_url

These fields are (optionally) populated when the Certificates are issued and come from a Django URLField, and contain a link to a dedicated ubuntu.com/download page with specific instructions on how to get started for an end user, as well as specific Release Notes.

As a result, the specific conditions in certified/helpers.py are not needed anymore, since the Certificates for these projects has been updated to point to the right URL.

A "Release Notes" button is added to the model-details.html page when this field is populated.

## QA

- Open http://127.0.0.1:8001/certified/202507-36970 and check that the Download button points to https://ubuntu.com/download/qualcomm-iot#rubikpi3
- Open http://127.0.0.1:8001/certified/202508-37859 and check that Download button points to https://ubuntu.com/download/nvidia-jetson and there is a Release Notes button pointing to https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/classic/release-note-noble-thor-ga/

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/C3-1053

## Screenshots

<img width="2957" height="1833" alt="image" src="https://github.com/user-attachments/assets/98d3bba0-aedb-4bec-89ab-46c943223cdd" />