### PR TITLE
WD-36594: allow regional google.* domains in connect-src for GTM

### DIFF
--- a/build.js
+++ b/build.js
@@ -41,6 +41,8 @@ let entries = {
   prism: "./static/js/src/prism.js",
   "active-nav-scroll": "./static/js/src/active-nav-scroll.js",
   resources: "./static/js/src/resources.js",
+  "cookie-policy-with-callback":
+    "./static/js/src/cookie-policy-with-callback.js",
 };
 
 const isDev = process && process.env && process.env.NODE_ENV === "development";

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
+    "uuid": "^14.0.1",
     "vanilla-framework": "4.50.0",
     "yup": "1.4.0"
   },

--- a/static/js/src/cookie-policy-with-callback.js
+++ b/static/js/src/cookie-policy-with-callback.js
@@ -3,7 +3,7 @@
   If the user has not set their cookie preference, wait for the cookie policy to run first. 
 */
 
-import { v4 as uuidv4 } from "https://jspm.dev/uuid";
+import { v4 as uuidv4 } from "uuid";
 
 const getCookie = (targetCookie) =>
   document.cookie.match(new RegExp("(^| )" + targetCookie + "=([^;]+)"));

--- a/templates/16-04/_release-chart-1604.html
+++ b/templates/16-04/_release-chart-1604.html
@@ -93,5 +93,5 @@
     </table>
   </div>
 </div>
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>

--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -18,7 +18,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+  <script nonce="{{ csp_nonce }}" type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>
 {% endblock extra_metatags %}

--- a/templates/18-04/_release-chart-1604.html
+++ b/templates/18-04/_release-chart-1604.html
@@ -93,5 +93,5 @@
     </table>
   </div>
 </div>
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>

--- a/templates/20years/index.html
+++ b/templates/20years/index.html
@@ -1764,6 +1764,6 @@
     </div>
   </section>
   {{ load_form("/20years") | safe }}
-  <script src="{{ versioned_static('js/third-party/typer.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/third-party/typer.js') }}" defer></script>
 
 {% endblock content %}

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -194,8 +194,8 @@
     tag_name="ubuntu",
     tag_id="1564") }}
 
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-  <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
 
 {% endblock content %}

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -552,12 +552,12 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   {# djlint:off #}
-  <script type="text/javascript">
+  <script nonce="{{ csp_nonce }}" type="text/javascript">
     const productsData = {{ products_data | tojson | safe }};
   </script>
   {# djlint:off #}
-  <script src="{{ versioned_static('js/src/product-releases.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/product-releases.js') }}" defer></script>
 {% endblock content %}

--- a/templates/account/checkout.html
+++ b/templates/account/checkout.html
@@ -37,9 +37,9 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     </script>
-    <script src="{{ versioned_static('js/dist/shopCheckout.js') }}" type="module"></script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/shopCheckout.js') }}" type="module"></script>
 
   {% endblock %}

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -102,7 +102,7 @@
   </section>
   {% include "account/invoices/_edit_billing_modal.html" %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const prices = document.querySelectorAll('.js-format-price');
     prices.forEach(price => {
       const amount = price.innerText.split(' ')[0];
@@ -125,9 +125,9 @@
     })
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.accountId = "{{ account_id }}";
   </script>
-  <script src="{{ versioned_static('js/dist/account-billing.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/account-billing.js') }}"></script>
 
 {% endblock content %}

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -87,19 +87,19 @@
 
   {% include "account/payment-methods/_confirm-remove-modal.html" %}
 
-  <script src="https://js.stripe.com/v3/"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="https://js.stripe.com/v3/"></script>
+  <script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     window.accountId = "{{ account_id }}";
     window.pendingPurchaseId = "{{ pending_purchase_id }}";
     window.hasPaymentMethod = {% if default_payment_method.id %}true{% else %}false{% endif %};
   </script>
-  <script src="/static/js/src/modal.js"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="/static/js/src/modal.js"></script>
+  <script nonce="{{ csp_nonce }}">
     initModals('#remove-payment-modal', '[aria-controls=remove-payment-modal]', false)
   </script>
 
-  <script src="{{ versioned_static('js/dist/ua-payment-methods.js') }}"
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/ua-payment-methods.js') }}"
           type="module"
           defer></script>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -297,8 +297,8 @@
   </div>
 </div>
 
-<script src="https://js.stripe.com/v3/"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="https://js.stripe.com/v3/"></script>
+<script nonce="{{ csp_nonce }}">
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
 </script>
-<script src="{{ versioned_static('js/dist/ua-payment-modal.js') }}" type="module" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/ua-payment-modal.js') }}" type="module" defer></script>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -31,7 +31,7 @@ endblock meta_copydoc %}
   </section>
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     dataLayer.push({
       event: "GAEvent",
       eventCategory: "Advantage",
@@ -52,13 +52,13 @@ endblock meta_copydoc %}
   </div>
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
   localStorage.setItem("isTechnical", {{ is_technical|lower }});
   localStorage.setItem("isInMaintenance", {{ is_in_maintenance|lower }});
 </script>
 
-  <script src="{{ versioned_static('js/dist/uaSubscriptions.js') }}"
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/uaSubscriptions.js') }}"
           type="module"
           defer></script>
 

--- a/templates/advantage/offers/index.html
+++ b/templates/advantage/offers/index.html
@@ -14,9 +14,9 @@
     </div>
 </div>
 
-<script src="/static/js/dist/advantageOffers.js" type="module"></script>
+<script nonce="{{ csp_nonce }}" src="/static/js/dist/advantageOffers.js" type="module"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     window.stripePublishableKey = '{{ get_stripe_publishable_key }}';
 </script>
 

--- a/templates/advantage/subscribe/blender/index.html
+++ b/templates/advantage/subscribe/blender/index.html
@@ -13,13 +13,13 @@
   </section>
 </div>
 
-<script
+<script nonce="{{ csp_nonce }}"
   src="{{ versioned_static('js/dist/blender.js') }}"
   type="module"
   defer
 ></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   window.blenderProductList = {
     {% for listing_id, listing in product_listings.items() %}
       "{{ listing.product.id }}-{{ listing.period }}": {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -29,13 +29,13 @@ endblock meta_copydoc %} {% block content %}
 </div>
 
 <!-- form app -->
-<script
+<script nonce="{{ csp_nonce }}"
   src="{{ versioned_static('js/dist/uaSubscribe.js') }}"
   type="module"
   defer
 ></script>
 
-<script defer>
+<script nonce="{{ csp_nonce }}" defer>
   var productList = {
     {% for listing_id, listing in product_listings.items() %}
       "{{ listing.product.id }}-{{ listing.period }}": {

--- a/templates/advantage/users/index.html
+++ b/templates/advantage/users/index.html
@@ -24,6 +24,6 @@
     </section>
 </div>
 
-<script src="/static/js/dist/advantageAccountUsers.js" type="module"></script>
+<script nonce="{{ csp_nonce }}" src="/static/js/dist/advantageAccountUsers.js" type="module"></script>
 
 {% endblock %}

--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -46,7 +46,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -56,7 +56,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -11,7 +11,7 @@
 
   {% block content %}{% endblock %}
   {{ load_form("/appliance/contact-us",formId=3231, isModal=true) | safe }}
-  <script src="{{ versioned_static('js/dist/appliance.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/appliance.js') }}" defer></script>
 
   <style>
     .p-stepped-list--detailed ol li {

--- a/templates/appliance/hardware.html
+++ b/templates/appliance/hardware.html
@@ -588,6 +588,6 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/appliance/shared/_appliance-os-tabs.html
+++ b/templates/appliance/shared/_appliance-os-tabs.html
@@ -25,4 +25,4 @@
   </ul>
 </nav>
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -259,7 +259,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var downloadForm = document.querySelector(".js-download");
       if (downloadForm) {

--- a/templates/appliance/shared/_download_widget.html
+++ b/templates/appliance/shared/_download_widget.html
@@ -11,7 +11,7 @@
     <a href="/appliance/{{app}}/raspberry-pi" class="p-button--positive p-form__control js-download-button">Download</a>
   </div>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
   (function () {
     var downloadForm = document.querySelector(".js-download");
     if (downloadForm) {

--- a/templates/appliance/shared/_verify-checksums-pc.html
+++ b/templates/appliance/shared/_verify-checksums-pc.html
@@ -13,7 +13,7 @@
   </span>
 </p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Closes dropdown when click is registered outside of the tooltip
   function toggleChecksumDropdown() {
     const toggleControl = document.querySelector(".js-checksum-toggle");

--- a/templates/appliance/shared/_verify-checksums.html
+++ b/templates/appliance/shared/_verify-checksums.html
@@ -13,7 +13,7 @@
   </span>
 </p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Closes dropdown when click is registered outside of the tooltip
   function toggleChecksumDropdown() {
     const toggleControl = document.querySelector(".js-checksum-toggle");

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -384,6 +384,6 @@
 
   {{ load_form("/aws") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/aws/shared/_aws-pie-chart.html
+++ b/templates/aws/shared/_aws-pie-chart.html
@@ -3,9 +3,9 @@
 <p class="u-no-margin--bottom"><small>Ubuntu Pro has both <a href="https://help.ubuntu.com/community/Repositories/Ubuntu">Ubuntu main and universe</a> repositories under our security team's watch. Updated packages are streamed to AWS in-region mirrors and built into our AMIs, which are refreshed daily and promoted weekly to <a href="https://aws.amazon.com/marketplace">AWS Marketplace</a>.</small></p>
 
 
-<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function drawChart() {
   'use strict';
   document.querySelector('#ubuntu-pie').innerHTML = "";

--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -32,7 +32,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -42,7 +42,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -321,8 +321,8 @@
     </div>
   </template>
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-posts",
       articleTemplateSelector: "#articles-template",

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -17,7 +17,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+  <script nonce="{{ csp_nonce }}" type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
@@ -325,7 +325,7 @@
     {% include "azure/shared/_latest-blogs-azure.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/utmInheritance.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/utmInheritance.js') }}"></script>
 
   {{ load_form("/azure") | safe }}
   

--- a/templates/azure/shared/_latest-blogs-azure.html
+++ b/templates/azure/shared/_latest-blogs-azure.html
@@ -26,9 +26,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#azure-latest",

--- a/templates/azure/thank-you.html
+++ b/templates/azure/thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -46,7 +46,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1397,7 +1397,7 @@
       {# include "ubuntu/takeovers/_footer_homepage.html" #}
     {% endblock footer_content %}
 
-    <script type="module">
+    <script nonce="{{ csp_nonce }}" type="module">
       const testTakeover = document.getElementById('test-takeover');
       const mainTakeover = document.getElementById('takeover');
 

--- a/templates/blender/thank-you.html
+++ b/templates/blender/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";
@@ -41,7 +41,7 @@
   var google_conversion_value = 0;
   /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
   <div style="display:inline;">

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -30,7 +30,7 @@
   {% if article.group and article.group.id == 2100 %}
   <meta name="robots" content="noindex, follow" />
   {% endif %}
-  <script type="application/ld+json">
+  <script nonce="{{ csp_nonce }}" type="application/ld+json">
     {
       "@context": "http://schema.org",
       "@id": "https://ubuntu.com/#article",
@@ -58,7 +58,7 @@
       }
     }
   </script>
-  <script src="{{ versioned_static('js/dist/prism.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/prism.js') }}" defer></script>
 {% endblock %}
 
 {% block content %}

--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -17,7 +17,7 @@
   </form>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   var select = document.querySelector('.js-submit-on-change');
   select.addEventListener('change', function(e) {
     var form = this.closest('form');

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -148,7 +148,7 @@
   {% endif %}
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Get all loaded cards
   var cards = document.getElementsByClassName('js-product-card');
   if (cards) {

--- a/templates/ceph/install.html
+++ b/templates/ceph/install.html
@@ -123,7 +123,7 @@
     {% include "ceph/shared/_latest-news-ceph.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   {{ load_form("/ceph/install") | safe }}
 

--- a/templates/ceph/pricing-calculator.html
+++ b/templates/ceph/pricing-calculator.html
@@ -244,7 +244,7 @@
       </div>
     </section>
   </div>
-  <script src="{{ versioned_static('js/src/ceph-pricing-calculator.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/ceph-pricing-calculator.js') }}"></script>
 
   {{ load_form("/ceph/pricing-calculator") | safe }}
 

--- a/templates/ceph/shared/_latest-news-ceph.html
+++ b/templates/ceph/shared/_latest-news-ceph.html
@@ -24,9 +24,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-<script>  
+<script nonce="{{ csp_nonce }}">  
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#ceph-install-latest",

--- a/templates/ceph/thank-you.html
+++ b/templates/ceph/thank-you.html
@@ -34,7 +34,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -44,7 +44,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
@@ -56,7 +56,7 @@
     </div>
   </noscript>
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -66,7 +66,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -194,7 +194,7 @@
     {% endwith %}
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const tabs = document.querySelectorAll('.p-tabs__link');
       const panels = document.querySelectorAll('[role="tabpanel"]');

--- a/templates/certified/platforms/platform-details.html
+++ b/templates/certified/platforms/platform-details.html
@@ -139,7 +139,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', () => {
     const table = document.getElementById('configTable');
     const upButton = document.getElementById('upButton');

--- a/templates/certified/search/_search-results-main-block.html
+++ b/templates/certified/search/_search-results-main-block.html
@@ -24,5 +24,5 @@
   </div>
 </div>
 
-<script type="text/javascript"
+<script nonce="{{ csp_nonce }}" type="text/javascript"
         src="/static/js/src/certified-search-results.js"></script>

--- a/templates/certified/search/_search-results-side-filters.html
+++ b/templates/certified/search/_search-results-side-filters.html
@@ -84,5 +84,5 @@
   </div>
 </nav>
 
-<script type="module"
+<script nonce="{{ csp_nonce }}" type="module"
         src="/static/js/src/side-navigation.js"></script>

--- a/templates/cloud/public-cloud-survey.html
+++ b/templates/cloud/public-cloud-survey.html
@@ -35,5 +35,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
+<script nonce="{{ csp_nonce }}">(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
 {% endblock %}

--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -320,7 +320,7 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   {{ load_form("/cloud/public-cloud") | safe }}
 
 {% endblock content %}

--- a/templates/community/circles.html
+++ b/templates/community/circles.html
@@ -167,10 +167,10 @@ meta_copydoc %}
 
   {{ vf_highlighted_cta(cta_text="Are you stuck and need help? <br /> <a href='https://ubuntu.com/community/support'>Take a look at how our community can support you.</a>") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/leaflet.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/leaflet.js') }}"></script>
   {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var mapMarker = {{ map_markers | tojson | e }}
 
     function initMap(mapSelector) {

--- a/templates/community/events.html
+++ b/templates/community/events.html
@@ -217,7 +217,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const sections = Array.from(document.querySelectorAll('.p-equal-height-row--wrap'));
       const perPage = 12;

--- a/templates/community/uwn.html
+++ b/templates/community/uwn.html
@@ -86,8 +86,8 @@
     </div>
   </div>
 
-  <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener("DOMContentLoaded", () => {
       document.querySelector(".js-drawer-toggle").classList.remove("u-hide");
     })

--- a/templates/contact-us/thank-you.html
+++ b/templates/contact-us/thank-you.html
@@ -540,10 +540,10 @@
         </div>
     </template>
 
-    <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+    <script nonce="{{ csp_nonce }}" type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
 
-    <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+    <script nonce="{{ csp_nonce }}">
         canonicalLatestNews.fetchLatestNews({
             imageClasses: ["p-image-container__image"],
             limit: "4",
@@ -555,7 +555,7 @@
         })
     </script>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
         document.addEventListener("DOMContentLoaded", function () {
             var stringifyForm = document.querySelector(".js-stringify-form");
             if (stringifyForm) {
@@ -585,7 +585,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical - contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";
@@ -595,7 +595,7 @@ var google_conversion_label = "utP4CMDOwQMQ4L7f4gM";
 var google_conversion_value = 0;
 /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
 <div style="display:inline;">

--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -591,6 +591,6 @@
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/containers") | safe }}
 
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-  <script src="{{ versioned_static('js/dist/chiseled-chart.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/chiseled-chart.js') }}" defer></script>
 {% endblock %}

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -472,6 +472,6 @@
 
   {{ load_form("/containers") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/containers/shared/_container-portfolio-tabs.html
+++ b/templates/containers/shared/_container-portfolio-tabs.html
@@ -171,4 +171,4 @@
   </div>
 </div>
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -17,7 +17,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";
@@ -27,7 +27,7 @@ var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
 var google_conversion_value = 0;
 /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
 <noscript>
   <div style="display:inline;">
     <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/core/features/index.html
+++ b/templates/core/features/index.html
@@ -398,7 +398,7 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {{ load_form("/core/features") | safe }}
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -23,7 +23,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module"
+  <script nonce="{{ csp_nonce }}" type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>
@@ -765,6 +765,6 @@ items=[
 ],) }}
 {{ load_form("/core") | safe }}
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -32,7 +32,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -42,7 +42,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -459,7 +459,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function setUpDynamicSideNav() {
       const questions = Array.prototype.slice.call(
         document.querySelectorAll(".question-heading")

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -46,7 +46,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/cpu-compatibility/index.html
+++ b/templates/cpu-compatibility/index.html
@@ -252,7 +252,7 @@
   </div>
 </section>
 
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
 
 {% endblock content %}

--- a/templates/dell/thank-you.html
+++ b/templates/dell/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";
@@ -41,7 +41,7 @@
   var google_conversion_value = 0;
   /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
   <div style="display:inline;">

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -636,9 +636,9 @@
 
   {% include "desktop/partial/_desktop-latest-news.html" %}
 
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-  <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
-  <script src="{{ versioned_static('js/dist/developer-chart.js')}}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/developer-chart.js')}}" defer></script>
 
 {% endblock content %}

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -15,7 +15,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+  <script nonce="{{ csp_nonce }}" type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>
 {% endblock extra_metatags %}

--- a/templates/desktop/partial/_desktop-latest-news.html
+++ b/templates/desktop/partial/_desktop-latest-news.html
@@ -25,8 +25,8 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#desktop-latest-articles",

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -365,6 +365,6 @@ meta_copydoc %}
 
   {% include "download/shared/_footer.html" %}
 </section>
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script nonce="{{ csp_nonce }}" type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
 
 {% endblock content %}

--- a/templates/download/amd/index.html
+++ b/templates/download/amd/index.html
@@ -120,5 +120,5 @@
 
   {{ load_form("/download/amd") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 {% endblock content %}

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -176,6 +176,6 @@
     {% include "download/shared/_latest-blogs_download.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   
 {% endblock content %}

--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -238,6 +238,6 @@ meta_copydoc %}
     {% include "download/shared/_latest-blogs_download.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -65,7 +65,7 @@
                 <span class="u-text--muted">{{ releases_yaml.lts.iso_download_size }}</span>
               {% endif %}
 
-              <script>
+              <script nonce="{{ csp_nonce }}">
                 performance.mark("Download (Desktop) button rendered")
               </script>
             </div>
@@ -84,7 +84,7 @@
                 <span class="u-text--muted">{{ releases_yaml.lts.arm_iso_download_size }}</span>
               {% endif %}
 
-              <script>
+              <script nonce="{{ csp_nonce }}">
                 performance.mark("Download (Desktop) button rendered")
               </script>
             </div>
@@ -228,7 +228,7 @@
                   <span class="u-text--muted">{{ releases_yaml.latest.iso_download_size }}</span>
                 {% endif %}
 
-                <script>
+                <script nonce="{{ csp_nonce }}">
                   performance.mark("Download (Desktop) button rendered")
                 </script>
               </div>
@@ -247,7 +247,7 @@
                   <span class="u-text--muted">{{ releases_yaml.latest.arm_iso_download_size }}</span>
                 {% endif %}
 
-                <script>
+                <script nonce="{{ csp_nonce }}">
                   performance.mark("Download (Desktop) button rendered")
                 </script>
               </div>
@@ -420,6 +420,6 @@
     {% include "download/shared/_latest-blogs_download.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -17,7 +17,7 @@
       opacity: 0 !important
     }
   </style>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function(a, s, y, n, c, h, i, d, e) {
       s.className += ' ' + y;
       h.start = 1 * new Date;
@@ -305,11 +305,11 @@
 {% endblock content %}
 
 {% block footer_extra %}
-  <script src="{{ versioned_static('js/dist/contributions.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/contributions.js') }}"></script>
 
   {% if version %}
-    <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+    <script nonce="{{ csp_nonce }}" defer>
       var architecture = '{{ architecture }}';
       var version = '{{ version }}';
 

--- a/templates/download/iot/intel-iot/index.html
+++ b/templates/download/iot/intel-iot/index.html
@@ -1178,7 +1178,7 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   {{ load_form("/download/iot/intel-iot") | safe }}
 
 {% endblock content %}

--- a/templates/download/mediatek-genio/index.html
+++ b/templates/download/mediatek-genio/index.html
@@ -193,6 +193,6 @@
 
   {{ load_form("/download/mediatek-genio") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/nvidia-jetson/index.html
+++ b/templates/download/nvidia-jetson/index.html
@@ -171,6 +171,6 @@
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/download/nvidia-jetson") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/qualcomm-iot/index.html
+++ b/templates/download/qualcomm-iot/index.html
@@ -157,6 +157,6 @@
 
   {{ load_form("/download/qualcomm-iot") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -317,8 +317,8 @@
       </div>
     </template>
   </section>
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -164,8 +164,8 @@
     </template>
   </section>
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",

--- a/templates/download/renesas-iot/index.html
+++ b/templates/download/renesas-iot/index.html
@@ -185,6 +185,6 @@
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/download/renesas-iot") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -204,6 +204,6 @@
 
     {{ load_form("/download/risc-v/canonical-built") | safe }}
 
-    <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   {% endblock content %}

--- a/templates/download/risc-v/partner-built.html
+++ b/templates/download/risc-v/partner-built.html
@@ -153,6 +153,6 @@
 
   {{ load_form("/download/risc-v/partner-built") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -480,9 +480,9 @@
     </template>
   </section>
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -236,8 +236,8 @@
     </template>
   </section>
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",
@@ -250,9 +250,9 @@
 {% endblock content %}
 
 {% block footer_extra %}
-  <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
-  <script defer>
+  <script nonce="{{ csp_nonce }}" defer>
     var architecture = '{{ architecture }}';
     var version = '{{ version }}';
     if (version) {

--- a/templates/download/shared/_everywhere.html
+++ b/templates/download/shared/_everywhere.html
@@ -146,7 +146,7 @@
       </div>
     </section>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       var all = document.querySelectorAll('.js-everywhere');
       var linux = document.querySelectorAll('.js-linux');
       var macos = document.querySelectorAll('.js-macos');

--- a/templates/download/shared/_instructions-resources.html
+++ b/templates/download/shared/_instructions-resources.html
@@ -49,8 +49,8 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/download/shared/_latest-blogs_download.html
+++ b/templates/download/shared/_latest-blogs_download.html
@@ -28,9 +28,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-<script>  
+<script nonce="{{ csp_nonce }}">  
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#ubuntu-desktop-latest",

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -29,7 +29,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   var multipassOScta = document.getElementById('multipass-os-cta');
   var baseInstallURL = multipassOScta.getAttribute('href');
   var ctaSpan = multipassOScta.querySelector('span')

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -132,7 +132,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   /**
     Toggles modal dialog.
     @param {HTMLElement} event modal Modal dialog to show or hide.

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -33,7 +33,7 @@ You can
 </div>
 
 
-<script type="text/javascript">
+<script nonce="{{ csp_nonce }}" type="text/javascript">
   function verifyDownloadContent() {
     var targetControls = document.getElementById("menu-4");
     if (targetControls) {

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -24,7 +24,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";
@@ -34,7 +34,7 @@
   var google_conversion_value = 0;
   /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
   <div style="display:inline;">

--- a/templates/download/wsl.html
+++ b/templates/download/wsl.html
@@ -332,7 +332,7 @@
     items=3)
   -}}
 
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/wsl/thank-you.html
+++ b/templates/download/wsl/thank-you.html
@@ -184,12 +184,12 @@
 
 {% block footer_extra %}
   {% if architecture == 'pro' %}
-    <script defer>
+    <script nonce="{{ csp_nonce }}" defer>
       window.location.href = '{{ pro_download_url }}';
     </script>
   {% elif version %}
-    <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+    <script nonce="{{ csp_nonce }}" defer>
       var architecture = '{{ architecture }}';
       var version = '{{ version }}';
 

--- a/templates/engage/de_why-openstack.html
+++ b/templates/engage/de_why-openstack.html
@@ -197,7 +197,7 @@
 
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/engage/de/warum-openstack") | safe }}
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-  <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
 {% endblock content %}

--- a/templates/engage/es_why-openstack.html
+++ b/templates/engage/es_why-openstack.html
@@ -178,7 +178,7 @@
 
   <!-- Set default Marketo information for contact form below-->
   {{ load_form("/engage/es/por-que-openstack") | safe }}
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-  <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
           defer></script>
 {% endblock content %}

--- a/templates/engage/fr_why-openstack.html
+++ b/templates/engage/fr_why-openstack.html
@@ -156,6 +156,6 @@ https://docs.google.com/document/d/1Nvam2qif5UPjTyUPWxhJo1XPiFDM-Eb5FxfSWCbNX8c
 
 <!-- Set default Marketo information for contact form below-->
 {{ load_form("/engage/fr/pourquoi-openstack") | safe }}
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
 {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -125,7 +125,7 @@
       </div>
     {% endif %}
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function clearFilters() {
       const clearFiltersButton = document.querySelector(".js-clear-filters");
       window.location.assign("/engage");

--- a/templates/engage/shared/_webinar-embed.html
+++ b/templates/engage/shared/_webinar-embed.html
@@ -8,8 +8,8 @@
   <section class="p-strip is-shallow" id="register-section">
     <div class="row" id="brighttalk-webinar">
       <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
-        <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "en-US", "commId" : {{ metadata["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
-        <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+        <script nonce="{{ csp_nonce }}" class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "en-US", "commId" : {{ metadata["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
+        <script nonce="{{ csp_nonce }}" src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>
     </div>
   </section>

--- a/templates/gcp/thank-you.html
+++ b/templates/gcp/thank-you.html
@@ -33,7 +33,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -43,7 +43,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/hpc/thank-you.html
+++ b/templates/hpc/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -41,7 +41,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
       <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/ibm/thank-you.html
+++ b/templates/ibm/thank-you.html
@@ -31,7 +31,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";
@@ -41,7 +41,7 @@
   var google_conversion_value = 0;
   /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
   <div style="display:inline;">

--- a/templates/internet-of-things/contact-us-hannover.html
+++ b/templates/internet-of-things/contact-us-hannover.html
@@ -139,7 +139,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   function createMessage() {
     var message = "";
     var formFields = document.querySelectorAll(".js-formfield");

--- a/templates/internet-of-things/shared/_latest-news-iot.html
+++ b/templates/internet-of-things/shared/_latest-news-iot.html
@@ -29,10 +29,10 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 
 {# djlint:off #}
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#iot-latest",

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -32,7 +32,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";
@@ -42,7 +42,7 @@
   var google_conversion_value = 0;
   /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
   <div style="display:inline;">

--- a/templates/kernel/lifecycle.html
+++ b/templates/kernel/lifecycle.html
@@ -240,6 +240,6 @@
 
   {% include "shared/_kernel-support-schedule.html" %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock %}

--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -42,7 +42,7 @@
              href="/kubernetes/contact-us"
              aria-controls="kubernetes-contact-modal">Contact us</p>
         </div>
-        <script>
+        <script nonce="{{ csp_nonce }}">
           document.addEventListener("DOMContentLoaded", function () {
             var livechatButton = document.querySelector(".js-livechat-open");
             if (livechatButton) {

--- a/templates/kubernetes/charmed-k8s/docs/base_docs.html
+++ b/templates/kubernetes/charmed-k8s/docs/base_docs.html
@@ -18,7 +18,7 @@
         </div>
       </aside>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
       // Select the active navigation item
       var navigation = document.getElementById('docs-navigation');
       var links = navigation.getElementsByTagName('a');
@@ -31,7 +31,7 @@
       };
       </script>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
       // Toggle mobile sidebar nav
       var toggle = document.querySelector('.p-sidebar__toggle');
       var sidebarContent = document.querySelector('.p-sidebar__content');
@@ -57,5 +57,5 @@
 {% endblock %}
 
 {% block footer_extra %}
-<script src="{{ versioned_static('js/dist/prism.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/prism.js') }}"></script>
 {% endblock footer_extra %}

--- a/templates/kubernetes/charmed-k8s/docs/quickstart.md
+++ b/templates/kubernetes/charmed-k8s/docs/quickstart.md
@@ -52,7 +52,7 @@ clouds. It can be installed with a snap:
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block--icon"><code>sudo snap install juju --channel=3.1/stable</code></pre>
           </div>
-          <script id="asciicast-254739" src="https://asciinema.org/a/254739.js" async data-autoplay="true" data-rows="4"></script>
+          <script nonce="{{ csp_nonce }}" id="asciicast-254739" src="https://asciinema.org/a/254739.js" async data-autoplay="true" data-rows="4"></script>
         </div>
       </li>
 
@@ -66,7 +66,7 @@ Google. You can see which ones are ready to use by running this command:
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block--icon"><code>juju clouds</code></pre>
           </div>
-          <script id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
+          <script nonce="{{ csp_nonce }}" id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
 
           <p><a href="https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/clouds/">Find out more about Clouds in Juju</a></p>
         </div>
@@ -82,7 +82,7 @@ Google. You can see which ones are ready to use by running this command:
           </div>
 <p>For a different cloud, just substitute in the name from the previous
   list output by Juju. The data you need to supply will vary depending on the cloud. </p>
-            <script id="asciicast-Wo12W39et3IJzF15rAyVunbbl" src="https://asciinema.org/a/Wo12W39et3IJzF15rAyVunbbl.js" async data-rows="18" ></script>
+            <script nonce="{{ csp_nonce }}" id="asciicast-Wo12W39et3IJzF15rAyVunbbl" src="https://asciinema.org/a/Wo12W39et3IJzF15rAyVunbbl.js" async data-rows="18" ></script>
         </div>
 
       </li>
@@ -94,7 +94,7 @@ Google. You can see which ones are ready to use by running this command:
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block--icon"><code>juju bootstrap aws my-controller</code></pre>
           </div>
-          <script id="asciicast-2FOd2qvaJL0wWqvZqFeVbwUsz" src="https://asciinema.org/a/2FOd2qvaJL0wWqvZqFeVbwUsz.js" async data-rows="18"></script>
+          <script nonce="{{ csp_nonce }}" id="asciicast-2FOd2qvaJL0wWqvZqFeVbwUsz" src="https://asciinema.org/a/2FOd2qvaJL0wWqvZqFeVbwUsz.js" async data-rows="18"></script>
         </div>
       </li>
 
@@ -116,7 +116,7 @@ Google. You can see which ones are ready to use by running this command:
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block--icon"><code>juju deploy charmed-kubernetes</code></pre>
           </div>
-          <script id="asciicast-8YAPb63aB9kfB7j1M9X6COGer" src="https://asciinema.org/a/8YAPb63aB9kfB7j1M9X6COGer.js" async></script>
+          <script nonce="{{ csp_nonce }}" id="asciicast-8YAPb63aB9kfB7j1M9X6COGer" src="https://asciinema.org/a/8YAPb63aB9kfB7j1M9X6COGer.js" async></script>
         </div>
       </li>
       <li class="p-stepped-list__item">

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -612,7 +612,7 @@
 
   {{ load_form("/kubernetes") | safe }}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const switchElement = document.querySelector('.js-discoverer-switch');
       const discovererText = document.querySelector('.js-discoverer-text');

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -261,6 +261,6 @@
 
   {{ load_form("/kubernetes") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -820,6 +820,6 @@
 
   {{ load_form("/kubernetes") | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock %}

--- a/templates/macros/_macro-lite-video.jinja
+++ b/templates/macros/_macro-lite-video.jinja
@@ -17,7 +17,7 @@
     </div>
 
     {% if not lite_youtube_script_loaded %}
-        <script type="module"
+        <script nonce="{{ csp_nonce }}" type="module"
                 src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
         {% set lite_youtube_script_loaded = true %}
     {% endif %}

--- a/templates/macros/_vf-latest-news.jinja
+++ b/templates/macros/_vf-latest-news.jinja
@@ -80,8 +80,8 @@
     </template>
 
     {# djlint: off #}
-    <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews(
         {
           articlesContainerSelector: "#latest-articles-container",

--- a/templates/managed-infrastructure/thank-you.html
+++ b/templates/managed-infrastructure/thank-you.html
@@ -14,7 +14,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";
@@ -24,7 +24,7 @@ var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
 var google_conversion_value = 0;
 /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
 <noscript>
   <div style="display:inline;">
     <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/managed/thank-you.html
+++ b/templates/managed/thank-you.html
@@ -14,7 +14,7 @@
 
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
 /* <![CDATA[ */
 var google_conversion_id = 1012391776;
 var google_conversion_language = "en";
@@ -24,7 +24,7 @@ var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
 var google_conversion_value = 0;
 /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
 <noscript>
   <div style="display:inline;">
     <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -981,8 +981,8 @@
 
   {{ load_form('/openstack') | safe }}
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#latest-articles",
       articleTemplateSelector: "#article-template",
@@ -990,6 +990,6 @@
       tagId: "1959, 4138, 3741, 3739",
     })
   </script>
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -20,7 +20,7 @@
 {% endblock meta_copydoc %}
 
 {% block extra_metatags %}
-  <script type="module"
+  <script nonce="{{ csp_nonce }}" type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
 {% endblock extra_metatags %}
 

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -340,6 +340,6 @@
   </section>
 
   {{ load_form("/openstack") | safe }}
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/openstack/shared/_openstack-aws-pie-chart.html
+++ b/templates/openstack/shared/_openstack-aws-pie-chart.html
@@ -1,8 +1,8 @@
 <figure id="ubuntu-pie" class="ubuntu-pie"></figure>
 
-<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 // FF/Opera does not support offsetWidth for tspan's. If undefined
 // use the getBoundingClientRect method.
 function getObjWidth(obj) {

--- a/templates/openstack/shared/_openstack-pie-chart.html
+++ b/templates/openstack/shared/_openstack-pie-chart.html
@@ -3,9 +3,9 @@
 <p class="u-no-margin--bottom"><small>Ubuntu powers 55% of OpenStack in production. Source: <a href="https://www.openstack.org/assets/survey/April2017SurveyReport.pdf" class="external">OpenStack survey &mdash; April 2017 [PDF 10.6MB]</a></small></p>
 
 
-<script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function drawChart() {
   'use strict';
   document.querySelector('#ubuntu-pie').innerHTML = "";

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -54,7 +54,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -64,7 +64,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -355,9 +355,9 @@ layout='50/50'
 
 </section>
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-<script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   const personalTab = document.getElementById('personal');
   const enterpriseTab = document.getElementById('enterprise');
   const toggleEnterpriseSupport = ()=>{

--- a/templates/pro/activate.html
+++ b/templates/pro/activate.html
@@ -66,7 +66,7 @@
       </div>
     </div>
   </section>
-  <script src="{{ versioned_static('js/dist/activate.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/activate.js') }}" defer></script>
 
   {% endblock %}
 {% endblock %}

--- a/templates/pro/attach/instructions.html
+++ b/templates/pro/attach/instructions.html
@@ -74,7 +74,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     (function () {
         var keys = {
             left: 'ArrowLeft',

--- a/templates/pro/distributor/index.html
+++ b/templates/pro/distributor/index.html
@@ -16,8 +16,8 @@
         </section>
       </div>
     </div>
-    <script src="{{ versioned_static('js/dist/distributor.js') }}" type="module" defer></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/distributor.js') }}" type="module" defer></script>
+    <script nonce="{{ csp_nonce }}">
       window.channelProductList = {{ product_listings | tojson }};
       
       var accountId = "{% if account %}{{ account.id }}{% endif %}";

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -26,11 +26,11 @@
   <p class="chart-legend-lts"><span class="p-heading--5">Packages covered with LTS</span><br/><span class="chart-legend-subtext">Standard security maintenance, packages with CVE fixes available for 5 years</span></p>
   <p class="chart-legend-pro"><span class="p-heading--5">Packages covered with Ubuntu Pro</span><br/><span class="chart-legend-subtext">ESM and Legacy, packages with CVE fixes available for 10+5 years</span></p>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+<script nonce="{{ csp_nonce }}" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
         integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
         crossorigin="anonymous"></script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   const ctx = document.getElementById('myChart');
   Chart.defaults.font.family = "Ubuntu";
   new Chart(ctx, {

--- a/templates/pro/linux-patch-management-with-pro/index.html
+++ b/templates/pro/linux-patch-management-with-pro/index.html
@@ -258,7 +258,7 @@
       {%- endif -%}
     {% endcall -%}
 
-  <script src="{{ versioned_static('js/dist/linux-patch-management.js') }}"
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/linux-patch-management.js') }}"
           type="module"
           defer></script>
 

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -19,7 +19,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -29,7 +29,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
       <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -19,7 +19,7 @@
 {% block body_class %}is-paper{% endblock %}
 
 {% block extra_metatags %}
-  <script type="module"
+  <script nonce="{{ csp_nonce }}" type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -666,7 +666,7 @@
     attrs={"class": "p-image-container__image",}) | safe
   }}
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   function rotateRoboticsHeroImage() {
     const roboticsImages = [
       "https://assets.ubuntu.com/v1/b4316d3f-hero-drone.png",
@@ -714,6 +714,6 @@
     rotateRoboticsHeroImage();
   });
 </script>
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 {{ load_form("/robotics") | safe }}
 {% endblock content %}

--- a/templates/robotics/thank-you.html
+++ b/templates/robotics/thank-you.html
@@ -15,7 +15,7 @@
 {% endblock content %}
 {% block footer_extra %}
 <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
+<script nonce="{{ csp_nonce }}">
   /* <![CDATA[ */
   var google_conversion_id = 1012391776;
   var google_conversion_language = "en";
@@ -25,7 +25,7 @@
   var google_conversion_value = 0;
   /* ]]> */
 </script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+<script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
 </script>
 <noscript>
   <div style="display:inline;">

--- a/templates/robotics/what-is-ros.html
+++ b/templates/robotics/what-is-ros.html
@@ -17,7 +17,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module"
+  <script nonce="{{ csp_nonce }}" type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>

--- a/templates/security/cmmc.html
+++ b/templates/security/cmmc.html
@@ -392,8 +392,8 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 
   {{ load_form('/security-standards', 6310) | safe }}
 

--- a/templates/security/compliance-automation-value-calculator/index.html
+++ b/templates/security/compliance-automation-value-calculator/index.html
@@ -394,8 +394,8 @@
 
   {{ load_form("/security/compliance-automation-value-calculator") | safe }}
 
-  <script src="{{ versioned_static('js/src/slider-base.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/slider-base.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     // Profile definitions based on actual benchmark specifications
     const profiles = {
       1: {

--- a/templates/security/cves/_cve-filters-sidenav.html
+++ b/templates/security/cves/_cve-filters-sidenav.html
@@ -95,4 +95,4 @@
     </nav>
   </div>
 </div>
-<script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>

--- a/templates/security/cves/about.html
+++ b/templates/security/cves/about.html
@@ -388,7 +388,7 @@
       </div>
     </div>
   </section>
-  <script type="text/javascript">
+  <script nonce="{{ csp_nonce }}" type="text/javascript">
     function setUpTogglableSideNav() {
       var navigationDrawer = document.querySelector("#drawer");
       var navigationDrawerToggles = Array.prototype.slice.call(

--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -566,18 +566,18 @@
       </div>
     </div>
 
-    <script src="{{ versioned_static('js/src/resources.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/resources.js') }}"></script>
+    <script nonce="{{ csp_nonce }}">
       fetchAndRenderResources(tag = "vulnerability+patching", resource = "whitepaper");
     </script>
   </section>
 
   {# djlint: off #}
-  <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
-  <script src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
-  <script src="{{ versioned_static('js/dist/cve-detail.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/cve-detail.js') }}" defer></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function handleHiddenReleasesSwitch() {
       const maintainedCount = {{ maintained_count | tojson | safe }};
       const isOnlyUpstream = {{ only_upstream | tojson | safe }};

--- a/templates/security/cves/index.html
+++ b/templates/security/cves/index.html
@@ -50,12 +50,12 @@
   {% endif %}
 
   {# djlint:off #}
-  <script type="text/javascript">
+  <script nonce="{{ csp_nonce }}" type="text/javascript">
     const maintainedReleasesObj = {{maintained_releases | tojson | safe}};
     const ltsReleasesObj = {{lts_releases | tojson | safe}};
     const unmaintainedReleasesObj = {{unmaintained_releases | tojson | safe}};
   </script>
   {# djlint:off #}
-  <script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/cve.js') }}" defer></script>
 
 {% endblock %}

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -21,7 +21,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module"
+  <script nonce="{{ csp_nonce }}" type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>
@@ -548,9 +548,9 @@
   {{ vf_blog(title={"text": "Latest from our blog"}, padding="deep",
     template_config={"enabled": True, "template_container_id": "disa-stig-articles"},) }}
 
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       limit: "4",

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -162,8 +162,8 @@
 
     </div>
   </section>
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
-  <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
 
   <section class="p-section">
     <div class="row--50-50">

--- a/templates/security/fedramp.html
+++ b/templates/security/fedramp.html
@@ -17,7 +17,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module"
+  <script nonce="{{ csp_nonce }}" type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -15,7 +15,7 @@
 {% endblock body_class %}
 
 {% block extra_metatags %}
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+  <script nonce="{{ csp_nonce }}" type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
           crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
@@ -497,8 +497,8 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 
   {{ load_form("/security-standards", 6306) | safe }}
 

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -545,6 +545,6 @@ meta_copydoc %}
 
   {{ load_form('/security/livepatch') | safe }}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/security/nis2/index.html
+++ b/templates/security/nis2/index.html
@@ -540,9 +540,9 @@ is-paper
     ]
 ) -}}
 
-<script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     imageClasses: ["p-image-container__image"],
     limit: "4",

--- a/templates/security/notices/_further-reading.html
+++ b/templates/security/notices/_further-reading.html
@@ -10,8 +10,8 @@
   </li>
 </template>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",

--- a/templates/security/notices/_sidenav-filters-container.html
+++ b/templates/security/notices/_sidenav-filters-container.html
@@ -33,4 +33,4 @@
     </aside>
   </nav>
 </div>
-<script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>

--- a/templates/security/notices/index.html
+++ b/templates/security/notices/index.html
@@ -145,11 +145,11 @@
   </section>
 
 {# djlint:off #}
-<script type="text/javascript">
+<script nonce="{{ csp_nonce }}" type="text/javascript">
   const maintainedReleasesObj = {{maintained_releases | tojson | safe}};
   const ltsReleasesObj = {{lts_releases | tojson | safe}};
   const unmaintainedReleasesObj = {{unmaintained_releases | tojson | safe}};
 </script>
 {# djlint:off #}
-<script src="{{ versioned_static('js/dist/noticesLanding.js') }}" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/noticesLanding.js') }}" defer></script>
 {% endblock %}

--- a/templates/security/notices/lsn.html
+++ b/templates/security/notices/lsn.html
@@ -252,7 +252,7 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
-  <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
 
 {% endblock %}

--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -348,6 +348,6 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
-  <script src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/notices.js') }}" defer></script>
 {% endblock content %}

--- a/templates/security/standards/index.html
+++ b/templates/security/standards/index.html
@@ -542,8 +542,8 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 
   {{ load_form("/security-standards") | safe }}
 

--- a/templates/security/standards/pci-dss.html
+++ b/templates/security/standards/pci-dss.html
@@ -405,7 +405,7 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   {{ load_form("/security-standards", formId=6363) | safe }}
 {% endblock %}

--- a/templates/security/vulnerabilities/view-all.html
+++ b/templates/security/vulnerabilities/view-all.html
@@ -75,5 +75,5 @@
       </div>
     </div>
   </div>
-  <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
 {% endblock content %}

--- a/templates/security/vulnerabilities/vulnerability-detailed.html
+++ b/templates/security/vulnerabilities/vulnerability-detailed.html
@@ -85,5 +85,5 @@
       </div>
     </div>
   </div>
-  <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
 {% endblock content %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -497,7 +497,7 @@
 
   {% include "server/partial/_server-footer.html" %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   {{ load_form("/server/hyperscale") | safe }}
 

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -449,8 +449,8 @@
       </div>
     </div>
   </div>
-  <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
-  <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
 
   <section class="p-section">
     <div class="row--50-50">
@@ -710,6 +710,6 @@
     {% include "server/partial/_latest-blogs-server.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
   {{ load_form("/server") | safe }}
 {% endblock content %}

--- a/templates/server/maas/thank-you.html
+++ b/templates/server/maas/thank-you.html
@@ -9,7 +9,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -19,7 +19,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
       <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/server/partial/_latest-blogs-server.html
+++ b/templates/server/partial/_latest-blogs-server.html
@@ -26,9 +26,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#server-latest",

--- a/templates/server/partial/_server-footer.html
+++ b/templates/server/partial/_server-footer.html
@@ -51,8 +51,8 @@
   </div>
 </div>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -274,7 +274,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -1136,7 +1136,7 @@
     max-width: 100%;
   }
 </style>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 

--- a/templates/shared/_credentials-signup-sme-form.html
+++ b/templates/shared/_credentials-signup-sme-form.html
@@ -737,7 +737,7 @@
     </div>
   {% endif %}
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
   var PROGRESS_COLOUR = '#E95420';

--- a/templates/shared/_credentials-signup-tester-form.html
+++ b/templates/shared/_credentials-signup-tester-form.html
@@ -710,7 +710,7 @@
     </div>
   {% endif %}
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
   var isWebkit =
     /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
   var PROGRESS_COLOUR = '#E95420';

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -599,7 +599,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -107,7 +107,7 @@
     </div>
   </form>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener("DOMContentLoaded", function () {
       var stringifyForm = document.querySelector(".js-stringify-form");
       if (stringifyForm) {

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -8,7 +8,7 @@
   <div class="row">{% include "shared/_kernel-release-diagram.html" %}</div>
 </section>
 
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
         defer></script>
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -82,8 +82,8 @@
   </template>
   {% endif %}
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#horizontal-latest-articles",

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -110,5 +110,5 @@
   </div>
 </div>
 
-<script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>

--- a/templates/shared/_share_this.html
+++ b/templates/shared/_share_this.html
@@ -1,7 +1,7 @@
 <div class="share-this">
 	<iframe title="Share on Facebook" src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20" style="border:none; overflow:hidden; height:21px; padding-right:23px;"></iframe>
 	<div class="g-plusone" data-size="medium"></div>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       window.___gcfg = {lang: 'en-GB'};
 
       (function() {
@@ -11,5 +11,5 @@
       })();
     </script>
     <a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-text="With #Ubuntu, you can do everything you can do with other operating systems. But faster. And for free!" data-count="horizontal">Tweet</a>
-    <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
+    <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
 </div><!-- /.share-this -->

--- a/templates/shared/contextual_footers/_ai_further_reading.html
+++ b/templates/shared/contextual_footers/_ai_further_reading.html
@@ -11,8 +11,8 @@
   </li>
 </template>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#latest-articles",

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -39,8 +39,8 @@
               <input type="hidden" value="{{ level_1 }}" name="MMERGE1" id="MMERGE1">
           </div>
       </form>
-      <script src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
-      <script>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+      <script nonce="{{ csp_nonce }}" src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
+      <script nonce="{{ csp_nonce }}">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
       <!--End mc_embed_signup-->
   </div>
 </div>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -13,8 +13,8 @@
   </li>
 </template>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -65,7 +65,7 @@
   {% include "/shared/forms/form-fields.html" %}
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form[id^="mktoForm_"]').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -165,13 +165,13 @@
     </section>
   </div>
 
-  <script src="/static/js/src/modal.js"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="/static/js/src/modal.js"></script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       initModals('#modal', '[aria-controls=modal]', false)
     })();
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Handles form submissions
     (function() {
       const form = document.querySelector("#subscription-centre");
@@ -209,7 +209,7 @@
       });
     })()
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Setup search
     (function() {
       const subsContainer = document.querySelector("#subscriptions-list");

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -600,9 +600,9 @@
     {% include "/summit/shared/_latest-blogs_summit.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/dist/flickity.pkgd.min.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/flickity.pkgd.min.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     initCarousel('#carousel_target', '#carousel-next', '#carousel-previous');
 
     function initCarousel(carouselSelector, nextSelector, previousSelector) {

--- a/templates/summit/shared/_latest-blogs_summit.html
+++ b/templates/summit/shared/_latest-blogs_summit.html
@@ -22,9 +22,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
 {# djlint:off #}
-  <script>  
+  <script nonce="{{ csp_nonce }}">  
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#ubuntu-summit-latest",

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -26,7 +26,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -36,7 +36,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
       <img height="1"

--- a/templates/templates/_getfeedback.html
+++ b/templates/templates/_getfeedback.html
@@ -1,3 +1,3 @@
 <!-- begin usabilla live embed code -->
-<script defer src="{{ versioned_static('js/src/usabilla-loader.js') }}"></script>
+<script nonce="{{ csp_nonce }}" defer src="{{ versioned_static('js/src/usabilla-loader.js') }}"></script>
 <!-- end usabilla live embed code -->

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{ csp_nonce }}">
   const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
   if (userIDCookie !== null) {
     let idValue = userIDCookie[2];
@@ -10,7 +10,7 @@
   }
 </script>
 <!-- Google Tag Manager -->
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener('DOMContentLoaded', () => {
     /** init gtm after 2 seconds - can be adjusted */
     setTimeout(initGTM, 2000);

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -19,13 +19,13 @@
     <link rel="preconnect" href="https://pagead2.googlesyndication.com" />
     <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
 
-    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
+    <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
             defer></script>
-    <script src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
-    <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
-    <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}"
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/main.js') }}" defer></script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/infer-preferred-language.js')}}"
             defer></script>
-    <script src="{{ versioned_static('js/src/csp-event-handlers.js') }}"
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/src/csp-event-handlers.js') }}"
             defer></script>
 
     <link rel="stylesheet"
@@ -36,7 +36,7 @@
           type="text/css"
           media="print"
           href="{{ versioned_static('css/print.css') }}" />
-    <script>
+    <script nonce="{{ csp_nonce }}">
       performance.mark("Stylesheets finished");
     </script>
 
@@ -130,9 +130,8 @@
           <!-- Cookie policy -->
           <link rel="stylesheet"
                 href="{{ versioned_static('css/cookie-policy.css') }}" />
-          <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
-          <script src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}"
-                  type="module"></script>
+          <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
+          <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/cookie-policy-with-callback.js') }}"></script>
         </head>
 
         <body class="

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -48,7 +48,7 @@
         <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
         <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
 
-        <script>
+        <script nonce="{{ csp_nonce }}">
           var html = document.documentElement
           html.classList.replace("no-js", "js");
         </script>

--- a/templates/templates/docs/markdown.html
+++ b/templates/templates/docs/markdown.html
@@ -55,7 +55,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
     var currentPath = window.location.pathname;
 
@@ -143,6 +143,6 @@
 {% endblock %}
 
 {% block footer_extra %}
-  <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/prism.js') }}"></script>
   {{ load_form("/templates/docs/markdown") | safe }}
 {% endblock footer_extra %}

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -49,7 +49,7 @@
     {% if not disableSearch %}
       {% include "templates/docs/shared/_search-box.html" %}
     {% endif %}
-    <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
   {% endwith %}
 
   <div class="p-strip is-shallow">
@@ -173,9 +173,9 @@
     </div>
   </div>
 
-  <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Allows the 'onchange' listener to be used on a select field, while still being accessible.
     (function initSelect() {
       var selectField = document.querySelector("#version-select");

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -271,7 +271,7 @@
         <a href="#">Back to top</a>
       </p>
 
-      <script>
+      <script nonce="{{ csp_nonce }}">
         /* Add the page to the report a bug link */
         var bugLink = document.querySelector('#report-a-bug');
         bugLink.href += '&reported_from=' + location.href;

--- a/templates/templates/image-testing_base.html
+++ b/templates/templates/image-testing_base.html
@@ -5,7 +5,7 @@
   <meta name="robots" content="noindex" />
   <title>Testing images | Ubuntu</title>
   <link rel="preconnect" href="https://res.cloudinary.com">
-  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
+  <script nonce="{{ csp_nonce }}" src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 </head>
 <body>
   {% block content %}{% endblock %}

--- a/templates/templates/markdown/base.html
+++ b/templates/templates/markdown/base.html
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
     var currentPath = window.location.pathname;
 
@@ -115,6 +115,6 @@
 {% endblock %}
 
 {% block footer_extra %}
-  <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/prism.js') }}"></script>
   {{ load_form("/templates/markdown/base") | safe }}
 {% endblock footer_extra %}

--- a/templates/tests/_thank-you.html
+++ b/templates/tests/_thank-you.html
@@ -36,7 +36,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -46,7 +46,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript"
+  <script nonce="{{ csp_nonce }}" type="text/javascript"
           src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -879,9 +879,9 @@
     </div>
   </div>
   <!-- twitter tracking code -->
-  <script src="https://platform.twitter.com/oct.js"></script>
-  <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="https://platform.twitter.com/oct.js"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/dynamic-toc.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       const tabGroups = document.querySelectorAll('.p-tabs');
 
@@ -912,7 +912,7 @@
       });
     });
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     twttr.conversion.trackPid('l4pwm');
   </script>
   <noscript>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -35,7 +35,7 @@
 {% endblock content %}
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -45,7 +45,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
       <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>

--- a/templates/tutorials/base_tutorials.html
+++ b/templates/tutorials/base_tutorials.html
@@ -1,6 +1,6 @@
 {% extends "templates/base.html" %}
 
 {% block outer_content %}
-<script src="{{ versioned_static('js/dist/tutorials.js') }}" defer></script>
+<script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/tutorials.js') }}" defer></script>
 {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -173,15 +173,15 @@
     </div>
   </div>
 
-  <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     if (window.location.hash == "#0") {
       window.location.hash == "#welcome";
     }
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var polls = document.querySelectorAll('.poll');
 

--- a/templates/workshop/index.html
+++ b/templates/workshop/index.html
@@ -215,8 +215,8 @@
         </template>
     </section>
 
-    <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         articlesContainerSelector: "#ubuntu-latest",
         articleTemplateSelector: "#blog-template",

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -360,8 +360,8 @@
       </template>
     </section>
   
-    <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         articlesContainerSelector: "#ubuntu-wsl-latest",
         articleTemplateSelector: "#blog-template",
@@ -372,8 +372,8 @@
       })
     </script>
   
-    <script src="/static/js/src/render-tutorials.js" type="text/javascript"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}" src="/static/js/src/render-tutorials.js" type="text/javascript"></script>
+    <script nonce="{{ csp_nonce }}">
       document.addEventListener("DOMContentLoaded", function() {
         renderTutorials('wsl');
       });

--- a/templates/wsl/organizations.html
+++ b/templates/wsl/organizations.html
@@ -218,8 +218,8 @@
     padding="deep"
   ) }}
 
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       /*

--- a/templates/wsl/thank-you.html
+++ b/templates/wsl/thank-you.html
@@ -30,7 +30,7 @@
 
 {% block footer_extra %}
   <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* <![CDATA[ */
     var google_conversion_id = 1012391776;
     var google_conversion_language = "en";
@@ -40,7 +40,7 @@
     var google_conversion_value = 0;
     /* ]]> */
   </script>
-  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <script nonce="{{ csp_nonce }}" type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
       <img height="1"

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -1,0 +1,67 @@
+import unittest
+
+from webapp.app import app
+from webapp.constants import CSP, NONCED_DIRECTIVES
+
+
+class TestCSPConstants(unittest.TestCase):
+    """The CSP dict should no longer allow inline scripts."""
+
+    def test_strict_dynamic_in_script_src_elem(self):
+        self.assertIn("'strict-dynamic'", CSP["script-src-elem"])
+
+    def test_no_unsafe_inline_in_script_directives(self):
+        self.assertNotIn("'unsafe-inline'", CSP["script-src"])
+        self.assertNotIn("'unsafe-inline'", CSP["script-src-elem"])
+
+    def test_no_unsafe_hashes_in_script_src(self):
+        self.assertNotIn("'unsafe-hashes'", CSP["script-src"])
+
+    def test_unsafe_eval_kept_in_script_src(self):
+        # 'unsafe-eval' is intentionally out of scope and retained.
+        self.assertIn("'unsafe-eval'", CSP["script-src"])
+
+    def test_nonced_directives(self):
+        self.assertEqual(NONCED_DIRECTIVES, ("script-src", "script-src-elem"))
+
+
+class TestCSPHeader(unittest.TestCase):
+    """The response header should carry a per-request nonce on the script
+    directives and never fall back to 'unsafe-inline'."""
+
+    def setUp(self):
+        self.client = app.test_client()
+
+    @staticmethod
+    def _get_directive(csp_header, directive):
+        for part in csp_header.split(";"):
+            part = part.strip()
+            if part.startswith(directive + " "):
+                return part
+        return None
+
+    def test_script_directives_carry_nonce_not_unsafe_inline(self):
+        # 404 responses still pass through the after_request CSP handler,
+        # which avoids depending on external API calls.
+        response = self.client.get("/non-existent-csp-test-path")
+        csp = response.headers.get("Content-Security-Policy")
+        self.assertIsNotNone(csp)
+
+        for directive in NONCED_DIRECTIVES:
+            value = self._get_directive(csp, directive)
+            self.assertIsNotNone(value, f"{directive} missing from CSP header")
+            self.assertIn("'nonce-", value)
+            self.assertNotIn("'unsafe-inline'", value)
+
+    def test_nonce_is_per_request(self):
+        first = self.client.get("/non-existent-csp-test-path")
+        second = self.client.get("/non-existent-csp-test-path")
+        first_csp = first.headers.get("Content-Security-Policy")
+        second_csp = second.headers.get("Content-Security-Policy")
+        first_script = self._get_directive(first_csp, "script-src")
+        second_script = self._get_directive(second_csp, "script-src")
+        self.assertNotEqual(first_script, second_script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -108,6 +108,7 @@ CSP = {
     ],
     "script-src-elem": [
         "'self'",
+        "'strict-dynamic'",
         "assets.ubuntu.com",
         "www.google-analytics.com",
         "www.googletagmanager.com",
@@ -137,7 +138,6 @@ CSP = {
         "www.redditstatic.com",
         "snap.licdn.com",
         "connect.facebook.net",
-        "jspm.dev",
         "cdn.livechatinc.com",
         "api.livechatinc.com",
         "secure.livechatinc.com",
@@ -148,7 +148,6 @@ CSP = {
         "*.g.doubleclick.net",
         "extend.vimeocdn.com",
         "tracking-api.g2.com",
-        "'unsafe-inline'",
     ],
     "font-src": [
         "'self'",
@@ -165,8 +164,6 @@ CSP = {
         "*.google.com",
         "*.livechat-static.com",
         "'unsafe-eval'",
-        "'unsafe-hashes'",
-        "'unsafe-inline'",
     ],
     "connect-src": [
         "'self'",
@@ -207,6 +204,9 @@ CSP = {
         "*.text.com",
         "*.youtube.com",
         "*.google.com",
+        "cdn.jsdelivr.net",
+        "bat.bing.com",
+        "*.clarity.ms",
     ],
     "frame-src": [
         "'self'",
@@ -290,3 +290,9 @@ CSP = {
         "https://support.stripe.com",
     ],
 }
+
+
+# CSP directives that receive the per-request nonce. With 'strict-dynamic' in
+# script-src-elem, the nonce authorises page scripts (and scripts they load),
+# replacing the removed 'unsafe-inline'.
+NONCED_DIRECTIVES = ("script-src", "script-src-elem")

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -1,3 +1,10 @@
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
 # Centralised UI translations for Engage pages and other shared constants
 
 ENGAGE_UI_TRANSLATIONS = {
@@ -11,6 +18,84 @@ ENGAGE_UI_TRANSLATIONS = {
         "it": "Risorse aggiuntive",
     }
 }
+
+
+# Used if the live fetch from Google fails at startup. Covers the regions
+# we've historically seen in CSP reports.
+_GOOGLE_DOMAINS_FALLBACK = [
+    "www.google.com",
+    # Europe
+    "www.google.at",
+    "www.google.be",
+    "www.google.ch",
+    "www.google.co.uk",
+    "www.google.cz",
+    "www.google.de",
+    "www.google.dk",
+    "www.google.es",
+    "www.google.fi",
+    "www.google.fr",
+    "www.google.gr",
+    "www.google.hu",
+    "www.google.ie",
+    "www.google.it",
+    "www.google.nl",
+    "www.google.no",
+    "www.google.pl",
+    "www.google.pt",
+    "www.google.ro",
+    "www.google.se",
+    # Americas
+    "www.google.ca",
+    "www.google.cl",
+    "www.google.co",
+    "www.google.com.ar",
+    "www.google.com.br",
+    "www.google.com.mx",
+    "www.google.com.pe",
+    # Asia & Pacific
+    "www.google.co.id",
+    "www.google.co.in",
+    "www.google.co.jp",
+    "www.google.co.kr",
+    "www.google.co.nz",
+    "www.google.co.th",
+    "www.google.com.au",
+    "www.google.com.hk",
+    "www.google.com.my",
+    "www.google.com.ph",
+    "www.google.com.sg",
+    "www.google.com.tw",
+    "www.google.com.vn",
+]
+
+
+def _fetch_google_supported_domains():
+    """
+    Fetch Google's published list of regional search domains so GTM can
+    reach the user's local google.<tld>. Falls back to a hardcoded list
+    if the request fails so CSP remains valid.
+    """
+    try:
+        response = requests.get(
+            "https://www.google.com/supported_domains", timeout=5
+        )
+        response.raise_for_status()
+        domains = [
+            "www" + line.strip()
+            for line in response.text.splitlines()
+            if line.strip().startswith(".google.")
+        ]
+        if domains:
+            return domains
+        logger.warning("Google supported_domains response was empty")
+    except requests.RequestException as exc:
+        logger.warning("Failed to fetch Google supported_domains: %s", exc)
+    return _GOOGLE_DOMAINS_FALLBACK
+
+
+GOOGLE_DOMAINS = _fetch_google_supported_domains()
+
 
 # Content Security Policy configuration
 CSP = {
@@ -106,6 +191,10 @@ CSP = {
         "ws.zoominfo.com",
         "youtube.com",
         "google.com",
+        # Regional google.<tld> domains used by GTM's ads / ga-audiences
+        # pixel, sourced live from https://www.google.com/supported_domains
+        # at app startup. Plain *.google.com does NOT cover other TLDs.
+        *GOOGLE_DOMAINS,
         "fonts.google.com",
         "api.text.com",
         "raw.githubusercontent.com",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,10 +1,11 @@
+import secrets
 from typing import List
 
 import flask
 from canonicalwebteam import image_template
 from slugify import slugify
 
-from webapp.constants import CSP
+from webapp.constants import CSP, NONCED_DIRECTIVES
 from webapp.context import (
     current_year,
     date_has_passed,
@@ -188,6 +189,14 @@ def init_handlers(app):
             "get_countries_list": get_countries_list,
         }
 
+    @app.before_request
+    def set_csp_nonce():
+        flask.g.csp_nonce = secrets.token_urlsafe(16)
+
+    @app.context_processor
+    def inject_csp_nonce():
+        return {"csp_nonce": getattr(flask.g, "csp_nonce", "")}
+
     @app.after_request
     def add_headers(response):
         """
@@ -207,14 +216,20 @@ def init_handlers(app):
         - X-Robots-Tag: prevents search engines from indexing the page
         """
 
-        def get_csp_as_str(csp={}):
+        def get_csp_as_str(csp={}, nonce=None):
             csp_str = ""
             for key, values in csp.items():
-                csp_value = " ".join(values)
+                directive_values = list(values)
+                if nonce and key in NONCED_DIRECTIVES:
+                    directive_values.append(f"'nonce-{nonce}'")
+                csp_value = " ".join(directive_values)
                 csp_str += f"{key} {csp_value}; "
             return csp_str.strip()
 
-        response.headers["Content-Security-Policy"] = get_csp_as_str(CSP)
+        nonce = getattr(flask.g, "csp_nonce", None)
+        response.headers["Content-Security-Policy"] = get_csp_as_str(
+            CSP, nonce=nonce
+        )
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8755,6 +8755,11 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+uuid@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
+  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
+
 v8-to-istanbul@^9.0.1:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"


### PR DESCRIPTION
## Done

- GTM's ads / ga-audiences pixel hits the user's local google.<tld>, which a plain *.google.com does not cover. Fetch Google's published list from https://www.google.com/supported_domains at startup (5s timeout) and fall back to a hardcoded regional list on failure, then spread GOOGLE_DOMAINS into the connect-src directive.

## QA

- Open the [DEMO](https://ubuntu-com-16524.demos.haus/)
- check connect-src CSP includes regional google.* domains in Homepage
- check GTM/GA audience requests to local google.<tld> are allowed (no CSP violation) in Homepage

## Issue / Card

Fixes [WD-36594](https://warthogs.atlassian.net/browse/wd-36594)



[WD-36594]: https://warthogs.atlassian.net/browse/WD-36594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ