### PR TITLE
chore: add charmcraft to sitemap index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -72,4 +72,13 @@
   <sitemap>
     <loc>https://ubuntu.com/docs/launchpad/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/juju/docs/charmcraft/latest/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/juju/docs/charmcraft/3.5/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/juju/docs/charmcraft/4.3/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Add charmcraft to sitemap index

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRAFT-5166

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
