### PR TITLE
feat: add RZ/V2H tab to /download/renesas-iot

### DIFF
--- a/templates/download/renesas-iot/index.html
+++ b/templates/download/renesas-iot/index.html
@@ -100,6 +100,12 @@
                     role="tab"
                     aria-controls="renesas-rz-g3s-tab">RZ/G3S</button>
           </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="renesas-rz-v2h"
+                    role="tab"
+                    aria-controls="renesas-rz-v2h-tab">RZ/V2H</button>
+          </li>
         </ul>
         <!-- form dropdown for smaller screens -->
         <form class="u-hide--large u-hide--medium">
@@ -110,6 +116,7 @@
             <option value="renesas-rz-v2l-tab" selected="">RZ/V2L</option>
             <option value="renesas-rz-g3e-tab" selected="">RZ/G3E</option>
             <option value="renesas-rz-g3s-tab" selected="">RZ/G3S</option>
+            <option value="renesas-rz-v2h-tab" selected="">RZ/V2H</option>
           </select>
         </form>
       </div>
@@ -120,6 +127,7 @@
         {% include "download/renesas-iot/tab-4-renesas-rz-v2l.html" %}
         {% include "download/renesas-iot/tab-5-renesas-rz-g3e.html" %}
         {% include "download/renesas-iot/tab-6-renesas-rz-g3s.html" %}
+        {% include "download/renesas-iot/tab-7-renesas-rz-v2h.html" %}
       </div>
     </div>
   </section>

--- a/templates/download/renesas-iot/tab-7-renesas-rz-v2h.html
+++ b/templates/download/renesas-iot/tab-7-renesas-rz-v2h.html
@@ -40,6 +40,44 @@
           </div>
         </div>
       </div>
+    </div><hr class="p-rule--muted" />
+    <div class="row">
+      <div class="col-3">
+        <h3 class="p-heading--5">Ubuntu Server 26.04</h3>
+      </div>
+      <div class="col-6">
+        <p>
+          This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified
+          version is
+          coming soon.
+        </p>
+        <div>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x03/ubuntu-26.04-preinstalled-server-arm64+rz-release.img.xz"
+            class="p-button--positive">Download Ubuntu 26.04</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x03/bootassets-rzv2h.tar.gz"
+            class="p-button">Download boot assets</a>
+        </div>
+        <div class="p-cta-block">
+          Ubuntu 26.04 for RZ/V2H&nbsp;<a
+            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_V2H%20and%20RZ_V2N%20EVKITs%20with%20classic%20Ubuntu%20images.pdf">image
+            installation instructions</a>
+        </div>
+      </div>
+    </div>
+    <hr class="p-rule--muted" />
+    <div class="row">
+      <div class="col-3">
+        <h3 class="p-heading--5">AI Snap Tutorial</h3>
+      </div>
+      <div class="col-6">
+        <p>
+          Build AI applications on Ubuntu for RZ/V2H
+        </p>
+        <div>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Running%20AI%20Applications%20Snap%20on%20RZ_V2H%20with%20Ubuntu%2026.04.pdf"
+            class="p-button--positive">Access AI Snap Tutorial</a>
+        </div>
+      </div>
     </div>
   </div>
   <hr class="p-rule--muted" />
@@ -58,7 +96,7 @@
         <li class="p-list__item">
           Ubuntu for RZ/V2H
           <a
-            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3E-G3S%20Release%20Notes-x02.pdf"
+            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_V2H%20Release%20Notes-x03.pdf"
             >release notes</a
           >
         </li>

--- a/templates/download/renesas-iot/tab-7-renesas-rz-v2h.html
+++ b/templates/download/renesas-iot/tab-7-renesas-rz-v2h.html
@@ -1,0 +1,80 @@
+<div
+  tabindex="3"
+  role="tabpanel"
+  id="renesas-rz-v2h-tab"
+  aria-labelledby="renesas-rz-v2h"
+  aria-hidden="true"
+>
+  <div class="p-section--shallow">
+    <div class="row">
+      <div class="col-6">
+        <h2 class="u-hide--small">Renesas RZ/V2H</h2>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Desktop 26.04</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is
+            coming soon.
+          </p>
+          <div>
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x03/ubuntu-26.04-preinstalled-desktop-arm64+rz-release.img.xz"
+              class="p-button--positive"
+              >Download Ubuntu 26.04</a
+            >
+            <a
+              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x03/bootassets-rzv2h.tar.gz"
+              class="p-button"
+              >Download boot assets</a
+            >
+          </div>
+          <div class="p-cta-block">
+            Ubuntu 26.04 for RZ/V2H&nbsp;<a
+              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_V2H%20and%20RZ_V2N%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
+              >image installation instructions</a
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="p-rule--muted" />
+  <div class="row">
+    <div class="col-3">
+      <h3 class="p-heading--5">Get started</h3>
+    </div>
+    <div class="col-6">
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 26.04 for&nbsp;<a
+            href="https://www.renesas.com/en/products/rz-v2h"
+            >RZ/V2H</a
+          >
+        </li>
+        <li class="p-list__item">
+          Ubuntu for RZ/V2H
+          <a
+            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3E-G3S%20Release%20Notes-x02.pdf"
+            >release notes</a
+          >
+        </li>
+        <hr class="p-rule--muted" />
+      </ul>
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the
+            <a
+              href="https://www.renesas.com/en/design-resources/boards-kits/rz-v2h-evk"
+              >RZ/V2H-EVKIT</a
+            >
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Added a RZ/V2H tab to the Renesas IOT download page.

## QA

- Open [/download/renesas-iot](https://ubuntu-com-16527.demos.haus/download/renesas-iot)
- Check that the RZ/V2H tab matches the [copy doc](https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?tab=t.0)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37542

## Screenshots

<img width="1141" height="775" alt="Screenshot 2026-07-02 at 9 50 12 am" src="https://github.com/user-attachments/assets/2641c038-43b4-4f77-9751-5c5f657bbb31" />


