### PR TITLE
implement response caching and circuit breaker for Discourse API interactions

### DIFF
--- a/tests/test_discourse_cache.py
+++ b/tests/test_discourse_cache.py
@@ -60,6 +60,36 @@ class TestCachedFetch(TestCase):
             "second",
         )
 
+    def test_max_size_evicts_oldest_entry(self):
+        cache = {}
+        for i in range(5):
+            discourse_cache.cached_fetch(
+                cache, f"k{i}", lambda i=i: i, ttl=100, max_size=3
+            )
+        self.assertEqual(len(cache), 3)
+        self.assertNotIn("k0", cache, "oldest entry should have been evicted")
+        self.assertNotIn("k1", cache)
+        self.assertIn("k4", cache)
+
+    def test_refreshed_entry_moves_to_tail(self):
+        # k0 refreshed after k1, k2 are written → k1 should be evicted next.
+        cache = {}
+        for i in range(3):
+            discourse_cache.cached_fetch(
+                cache, f"k{i}", lambda i=i: i, ttl=100, max_size=3
+            )
+        # Re-fetch k0 (ttl=0 forces a refresh) → moves k0 to tail.
+        discourse_cache.cached_fetch(
+            cache, "k0", lambda: "k0-refreshed", ttl=0, max_size=3
+        )
+        # Add a 4th entry → oldest (k1) should be evicted, not k0.
+        discourse_cache.cached_fetch(
+            cache, "k3", lambda: 3, ttl=100, max_size=3
+        )
+        self.assertNotIn("k1", cache)
+        self.assertIn("k0", cache)
+        self.assertIn("k3", cache)
+
     def test_429_serves_stale_and_opens_breaker(self):
         cache = {}
         discourse_cache.cached_fetch(cache, "k", lambda: "stale", ttl=100)

--- a/tests/test_discourse_cache.py
+++ b/tests/test_discourse_cache.py
@@ -141,6 +141,33 @@ class TestCachedFetch(TestCase):
         with self.assertRaises(HTTPError):
             discourse_cache.cached_fetch({}, "k", server_error, ttl=0)
 
+    def test_connection_error_serves_stale_when_available(self):
+        from requests.exceptions import (
+            ConnectionError as RequestsConnectionError,
+        )
+
+        cache = {}
+        discourse_cache.cached_fetch(cache, "k", lambda: "stale", ttl=100)
+
+        def connection_error():
+            raise RequestsConnectionError("connection refused")
+
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", connection_error, ttl=0),
+            "stale",
+        )
+        # Connection errors must NOT open the circuit breaker.
+        self.assertEqual(discourse_cache._DISCOURSE_COOLDOWN["until"], 0.0)
+
+    def test_connection_error_without_cache_raises_service_unavailable(self):
+        from requests.exceptions import Timeout
+
+        def timed_out():
+            raise Timeout("read timeout")
+
+        with self.assertRaises(ServiceUnavailable):
+            discourse_cache.cached_fetch({}, "k", timed_out, ttl=0)
+
 
 class _FakeAPI:
     def __init__(self, error=None):

--- a/tests/test_discourse_cache.py
+++ b/tests/test_discourse_cache.py
@@ -210,6 +210,9 @@ class _FakeAPI:
             raise self.error
         return {"id": topic_id}
 
+    def check_for_topic_updates(self, topic_id, last_updated=None):
+        return False, None
+
 
 class TestInstallTopicCache(TestCase):
     def setUp(self):

--- a/tests/test_discourse_cache.py
+++ b/tests/test_discourse_cache.py
@@ -1,0 +1,215 @@
+"""
+Unit tests for webapp.discourse_cache (response cache + circuit breaker).
+"""
+
+import time
+from unittest import TestCase
+
+from requests import Response
+from requests.exceptions import HTTPError
+from werkzeug.exceptions import ServiceUnavailable
+
+from webapp import discourse_cache
+
+
+def _http_error(status_code, retry_after=None):
+    response = Response()
+    response.status_code = status_code
+    if retry_after is not None:
+        response.headers["Retry-After"] = str(retry_after)
+    return HTTPError(response=response)
+
+
+class TestCachedFetch(TestCase):
+    def setUp(self):
+        # The circuit breaker is module-level state shared with the live
+        # views; reset it before and after every test so cases cannot leak
+        # an open breaker into each other or into other test modules.
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_fresh_value_is_cached_within_ttl(self):
+        calls = []
+
+        def fetcher():
+            calls.append(1)
+            return "value"
+
+        cache = {}
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", fetcher, ttl=100),
+            "value",
+        )
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", fetcher, ttl=100),
+            "value",
+        )
+        self.assertEqual(len(calls), 1, "value should be served from cache")
+
+    def test_expired_value_is_refetched(self):
+        values = iter(["first", "second"])
+        cache = {}
+
+        discourse_cache.cached_fetch(cache, "k", lambda: next(values), ttl=0)
+        self.assertEqual(
+            discourse_cache.cached_fetch(
+                cache, "k", lambda: next(values), ttl=0
+            ),
+            "second",
+        )
+
+    def test_429_serves_stale_and_opens_breaker(self):
+        cache = {}
+        discourse_cache.cached_fetch(cache, "k", lambda: "stale", ttl=100)
+
+        def rate_limited():
+            raise _http_error(429)
+
+        # ttl=0 forces a refresh attempt, which hits 429 and serves stale.
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", rate_limited, ttl=0),
+            "stale",
+        )
+        self.assertGreater(discourse_cache._DISCOURSE_COOLDOWN["until"], 0.0)
+
+    def test_429_without_cache_raises_service_unavailable(self):
+        def rate_limited():
+            raise _http_error(429)
+
+        with self.assertRaises(ServiceUnavailable):
+            discourse_cache.cached_fetch({}, "k", rate_limited, ttl=0)
+
+    def test_open_breaker_short_circuits_without_calling_fetcher(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = float("inf")
+        calls = []
+
+        def fetcher():
+            calls.append(1)
+            return "value"
+
+        with self.assertRaises(ServiceUnavailable):
+            discourse_cache.cached_fetch({}, "k", fetcher, ttl=0)
+        self.assertEqual(calls, [], "fetcher must not be called while cooling")
+
+    def test_open_breaker_serves_stale_without_calling_fetcher(self):
+        cache = {}
+        discourse_cache.cached_fetch(cache, "k", lambda: "stale", ttl=100)
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = float("inf")
+        calls = []
+
+        def fetcher():
+            calls.append(1)
+            return "fresh"
+
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", fetcher, ttl=0),
+            "stale",
+        )
+        self.assertEqual(calls, [])
+
+    def test_retry_after_header_sets_cooldown_length(self):
+        def rate_limited():
+            raise _http_error(429, retry_after=300)
+
+        with self.assertRaises(ServiceUnavailable):
+            discourse_cache.cached_fetch({}, "k", rate_limited, ttl=0)
+
+        remaining = discourse_cache._DISCOURSE_COOLDOWN["until"] - time.time()
+        # Retry-After of 300s should be honoured (within the allowed bounds).
+        self.assertGreater(remaining, 200)
+
+    def test_non_429_http_error_serves_stale_when_available(self):
+        cache = {}
+        discourse_cache.cached_fetch(cache, "k", lambda: "stale", ttl=100)
+
+        def server_error():
+            raise _http_error(500)
+
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", server_error, ttl=0),
+            "stale",
+        )
+        # A 500 must NOT open the circuit breaker.
+        self.assertEqual(discourse_cache._DISCOURSE_COOLDOWN["until"], 0.0)
+
+    def test_non_429_http_error_without_cache_reraises(self):
+        def server_error():
+            raise _http_error(500)
+
+        with self.assertRaises(HTTPError):
+            discourse_cache.cached_fetch({}, "k", server_error, ttl=0)
+
+
+class _FakeAPI:
+    def __init__(self, error=None):
+        self.calls = 0
+        self.error = error
+
+    def get_topic(self, topic_id):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return {"id": topic_id}
+
+
+class TestInstallTopicCache(TestCase):
+    def setUp(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_wrapped_get_topic_caches_per_topic_id(self):
+        api = _FakeAPI()
+        discourse_cache.install_topic_cache(api, ttl=100)
+
+        self.assertEqual(api.get_topic(5), {"id": 5})
+        self.assertEqual(api.get_topic(5), {"id": 5})
+        self.assertEqual(api.calls, 1, "second call should hit the cache")
+
+        # A different topic id is a distinct cache entry.
+        self.assertEqual(api.get_topic(6), {"id": 6})
+        self.assertEqual(api.calls, 2)
+
+    def test_wrapped_get_topic_opens_breaker_on_429(self):
+        api = _FakeAPI(error=_http_error(429))
+        discourse_cache.install_topic_cache(api, ttl=0)
+
+        with self.assertRaises(ServiceUnavailable):
+            api.get_topic(1)
+        self.assertGreater(discourse_cache._DISCOURSE_COOLDOWN["until"], 0.0)
+
+    def test_wrapped_get_topic_reraises_non_429(self):
+        api = _FakeAPI(error=_http_error(404))
+        discourse_cache.install_topic_cache(api, ttl=0)
+
+        with self.assertRaises(HTTPError):
+            api.get_topic(1)
+
+
+class TestServiceUnavailableRendering(TestCase):
+    """The open breaker should return the app's styled error page, not the
+    bare werkzeug 503, and must not leak the internal reason to users."""
+
+    def setUp(self):
+        from webapp.app import app
+
+        app.testing = True
+        self.client = app.test_client()
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = float("inf")
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_open_breaker_renders_styled_503(self):
+        # A unique page slug guarantees an empty per-view cache regardless of
+        # what other tests ran first, so the open breaker deterministically
+        # raises ServiceUnavailable instead of serving a cached response.
+        response = self.client.get("/engage/__breaker-test-503__")
+
+        self.assertEqual(response.status_code, 503)
+        body = response.get_data(as_text=True)
+        self.assertIn("Server error", body)
+        self.assertNotIn("Discourse is rate-limiting", body)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -787,7 +787,7 @@ def takeovers_json():
         ttl=300,
     )
     response = flask.jsonify(active_takeovers)
-    response.cache_control.max_age = "300"
+    response.cache_control.max_age = 300
 
     return response
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,6 +42,7 @@ from canonicalwebteam.form_generator import FormGenerator
 from canonicalwebteam.markdown_response import MarkdownResponse
 
 from webapp.certified.views import certified_routes
+from webapp.discourse_cache import cached_fetch, install_topic_cache
 from webapp.handlers import init_handlers
 from webapp.login import login_handler, logout, user_info
 from webapp.decorators import login_required
@@ -228,6 +229,12 @@ discourse_api = DiscourseAPI(
     api_username=DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
 )
+
+# Cache Discourse topic fetches and share the circuit breaker across all
+# discourse.ubuntu.com docs / tutorials / community views, so a 429 storm on
+# our Data Explorer credentials stops them hammering Discourse (and 500ing)
+# rather than each request re-fetching the index and document topics.
+install_topic_cache(discourse_api)
 
 charmhub_discourse_api = DiscourseAPI(
     base_url="https://discourse.charmhub.io/",
@@ -769,8 +776,16 @@ app.add_url_rule(
 )
 
 
+_takeovers_cache = {}
+
+
 def takeovers_json():
-    active_takeovers = discourse_takeovers.parse_active_takeovers()
+    active_takeovers = cached_fetch(
+        _takeovers_cache,
+        "active-takeovers",
+        discourse_takeovers.parse_active_takeovers,
+        ttl=300,
+    )
     response = flask.jsonify(active_takeovers)
     response.cache_control.max_age = "300"
 

--- a/webapp/discourse_cache.py
+++ b/webapp/discourse_cache.py
@@ -61,8 +61,14 @@ def cached_fetch(cache, key, fetcher, ttl, max_size=512):
     cached = cache.get(key)
     now = time.time()
 
-    if cached and now - cached["ts"] < ttl:
-        return cached["data"]
+    if cached:
+        # "Not found" results expire quickly so newly published
+        # pages appear promptly
+        entry_ttl = ttl if cached["data"] else min(ttl, 60)
+        if now - cached["ts"] < entry_ttl:
+            cache.pop(key, None)
+            cache[key] = cached
+            return cached["data"]
 
     if now < _DISCOURSE_COOLDOWN["until"]:
         if cached:
@@ -116,14 +122,25 @@ def install_topic_cache(api, ttl=600):
     """
     topic_cache = {}
     fetch_topic = api.get_topic
+    check_updates = api.check_for_topic_updates
 
     def get_topic(topic_id):
         return cached_fetch(
             topic_cache,
-            topic_id,
+            # str() so int and str topic ids share one cache entry
+            str(topic_id),
             lambda: fetch_topic(topic_id),
             ttl=ttl,
         )
 
+    def check_for_topic_updates(topic_id, last_updated=None):
+        updated, updated_at = check_updates(topic_id, last_updated)
+        if updated:
+            # Drop the cached topic so the caller's re-parse sees the
+            # new content instead of latching the stale cached copy
+            topic_cache.pop(str(topic_id), None)
+        return updated, updated_at
+
     api.get_topic = get_topic
+    api.check_for_topic_updates = check_for_topic_updates
     return topic_cache

--- a/webapp/discourse_cache.py
+++ b/webapp/discourse_cache.py
@@ -37,7 +37,7 @@ def _start_discourse_cooldown(error):
     delay = _DISCOURSE_COOLDOWN_MIN
     response = getattr(error, "response", None)
     if response is not None:
-        retry_after = response.headers.get("Retry-After", "")
+        retry_after = response.headers.get("Retry-After", "").strip()
         if retry_after.isdigit():
             delay = int(retry_after)
     delay = min(max(delay, _DISCOURSE_COOLDOWN_MIN), _DISCOURSE_COOLDOWN_MAX)
@@ -87,10 +87,10 @@ def cached_fetch(cache, key, fetcher, ttl):
         if cached:
             return cached["data"]
         raise ServiceUnavailable(
-            "Discourse is rate-limiting requests; please retry shortly."
+            "Discourse is unavailable; please retry shortly."
         )
 
-    cache[key] = {"data": data, "ts": now}
+    cache[key] = {"data": data, "ts": time.time()}
     return data
 
 

--- a/webapp/discourse_cache.py
+++ b/webapp/discourse_cache.py
@@ -1,0 +1,113 @@
+"""Response cache and circuit breaker for Discourse-backed views.
+
+``discourse.ubuntu.com`` rate-limits our admin Data Explorer API. When a burst
+of crawler traffic causes cache misses, every request hits Discourse, we start
+getting HTTP 429s, and the retries turn it into a self-sustaining 429 storm.
+
+This module provides a small per-worker response cache with a shared circuit
+breaker: when Discourse returns 429 we open the breaker and serve stale data
+(or 503) for a short cooldown instead of hammering Discourse. The breaker state
+is module-level so every Discourse-backed view (engage pages, takeovers) shares
+one cooldown -- a 429 from any of them protects all of them.
+"""
+
+# Standard library
+import time
+
+# Packages
+import sentry_sdk
+from requests.exceptions import HTTPError
+from werkzeug.exceptions import ServiceUnavailable
+
+# Circuit breaker state, shared across all Discourse-backed views in a worker.
+_DISCOURSE_COOLDOWN = {"until": 0.0}
+_DISCOURSE_COOLDOWN_MIN = 60
+_DISCOURSE_COOLDOWN_MAX = 600
+
+
+def _http_error_status_code(error):
+    response = getattr(error, "response", None)
+    if response is None:
+        return None
+    return response.status_code
+
+
+def _start_discourse_cooldown(error):
+    delay = _DISCOURSE_COOLDOWN_MIN
+    response = getattr(error, "response", None)
+    if response is not None:
+        retry_after = response.headers.get("Retry-After", "")
+        if retry_after.isdigit():
+            delay = int(retry_after)
+    delay = min(max(delay, _DISCOURSE_COOLDOWN_MIN), _DISCOURSE_COOLDOWN_MAX)
+    _DISCOURSE_COOLDOWN["until"] = time.time() + delay
+
+
+def cached_fetch(cache, key, fetcher, ttl):
+    """Return cached data, refreshing via ``fetcher`` when stale.
+
+    Fresh data is served from ``cache`` for ``ttl`` seconds. When Discourse
+    rate-limits us (HTTP 429) we open a circuit breaker: subsequent calls
+    serve stale data if available, otherwise raise ``ServiceUnavailable``
+    (503) without calling Discourse until the cooldown expires.
+
+    ``cache`` is any dict-like object owned by the caller (typically a
+    per-view dict living in a closure, so it is scoped to the worker process).
+    """
+    cached = cache.get(key)
+    now = time.time()
+
+    if cached and now - cached["ts"] < ttl:
+        return cached["data"]
+
+    if now < _DISCOURSE_COOLDOWN["until"]:
+        if cached:
+            return cached["data"]
+        raise ServiceUnavailable(
+            "Discourse is rate-limiting requests; please retry shortly."
+        )
+
+    try:
+        data = fetcher()
+    except HTTPError as error:
+        sentry_sdk.capture_exception(error)
+        if _http_error_status_code(error) == 429:
+            _start_discourse_cooldown(error)
+            if cached:
+                return cached["data"]
+            raise ServiceUnavailable(
+                "Discourse is rate-limiting requests; please retry shortly."
+            )
+        if cached:
+            return cached["data"]
+        raise
+
+    cache[key] = {"data": data, "ts": now}
+    return data
+
+
+def install_topic_cache(api, ttl=600):
+    """Wrap ``api.get_topic`` with the shared response cache and breaker.
+
+    ``get_topic`` is the only Discourse call the docs, tutorials and community
+    views make -- both for the index topic (via the parser's ``parse()``) and
+    for each individual document. Wrapping it per topic id means repeated
+    views and every ``parse()`` are served from memory, and a 429 opens the
+    shared circuit breaker so these views stop hammering Discourse during a
+    rate-limit storm instead of cascading into 500s.
+
+    ``api`` is mutated in place; the cache dict is returned for inspection.
+    """
+    topic_cache = {}
+    fetch_topic = api.get_topic
+
+    def get_topic(topic_id):
+        return cached_fetch(
+            topic_cache,
+            topic_id,
+            lambda: fetch_topic(topic_id),
+            ttl=ttl,
+        )
+
+    api.get_topic = get_topic
+    return topic_cache

--- a/webapp/discourse_cache.py
+++ b/webapp/discourse_cache.py
@@ -16,7 +16,8 @@ import time
 
 # Packages
 import sentry_sdk
-from requests.exceptions import HTTPError
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError, RequestException, Timeout
 from werkzeug.exceptions import ServiceUnavailable
 
 # Circuit breaker state, shared across all Discourse-backed views in a worker.
@@ -81,6 +82,13 @@ def cached_fetch(cache, key, fetcher, ttl):
         if cached:
             return cached["data"]
         raise
+    except (RequestsConnectionError, Timeout, RequestException) as error:
+        sentry_sdk.capture_exception(error)
+        if cached:
+            return cached["data"]
+        raise ServiceUnavailable(
+            "Discourse is rate-limiting requests; please retry shortly."
+        )
 
     cache[key] = {"data": data, "ts": now}
     return data

--- a/webapp/discourse_cache.py
+++ b/webapp/discourse_cache.py
@@ -44,7 +44,7 @@ def _start_discourse_cooldown(error):
     _DISCOURSE_COOLDOWN["until"] = time.time() + delay
 
 
-def cached_fetch(cache, key, fetcher, ttl):
+def cached_fetch(cache, key, fetcher, ttl, max_size=512):
     """Return cached data, refreshing via ``fetcher`` when stale.
 
     Fresh data is served from ``cache`` for ``ttl`` seconds. When Discourse
@@ -54,6 +54,9 @@ def cached_fetch(cache, key, fetcher, ttl):
 
     ``cache`` is any dict-like object owned by the caller (typically a
     per-view dict living in a closure, so it is scoped to the worker process).
+    ``max_size`` caps the number of entries: once reached, the oldest entry
+    (by insertion order) is evicted to keep per-worker memory bounded even
+    when bots crawl large numbers of distinct query-parameter combinations.
     """
     cached = cache.get(key)
     now = time.time()
@@ -90,7 +93,12 @@ def cached_fetch(cache, key, fetcher, ttl):
             "Discourse is unavailable; please retry shortly."
         )
 
+    # Move key to insertion-order tail so the oldest unrefreshed entry is
+    # always evicted first, then enforce the size cap.
+    cache.pop(key, None)
     cache[key] = {"data": data, "ts": time.time()}
+    while len(cache) > max_size:
+        cache.pop(next(iter(cache)))
     return data
 
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -89,6 +89,18 @@ def init_handlers(app):
         custom_error = f"{error.description}. Please try again tomorrow."
         return flask.render_template("429.html", message=custom_error), 429
 
+    @app.errorhandler(503)
+    def service_unavailable(error):
+        """
+        Rendered when the Discourse circuit breaker
+        (webapp/discourse_cache.py) is open: an upstream API is rate-limiting
+        us and there is no cached response to fall back on. Reuses the styled
+        500 template (the directory_parser sitemap excludes it, and it is the
+        app's standard "couldn't load this page" error) rather than leaking
+        the internal reason to users.
+        """
+        return flask.render_template("500.html"), 503
+
     @app.errorhandler(SecurityAPIError)
     def security_api_error(error):
         message = "An error occurred while fetching security data"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -463,7 +463,7 @@ def build_engage_index(engage_docs):
             current_total,
         ) = cached_fetch(
             index_cache,
-            (page, language, resource, tag, preview is not None),
+            (page, language, resource, tag),
             _fetch_index,
             ttl=300,
         )
@@ -552,7 +552,7 @@ def build_engage_page(engage_pages):
         metadata = cached_fetch(
             page_cache,
             path,
-            lambda: engage_pages.get_engage_page(path) or flask.abort(404),
+            lambda: engage_pages.get_engage_page(path),
             ttl=900,
         )
         if not metadata:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -574,7 +574,7 @@ def build_engage_page(engage_pages):
                                 ),
                                 ttl=900,
                             )
-                        except ServiceUnavailable:
+                        except (ServiceUnavailable, HTTPError):
                             # Related pages are best-effort; skip when
                             # Discourse is cooling down rather than 503 the
                             # whole page.

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -32,10 +32,11 @@ from canonicalwebteam.directory_parser import generate_sitemap
 from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, ServiceUnavailable
 from canonicalwebteam.flask_base.env import get_flask_env
 
 # Local
+from webapp.discourse_cache import cached_fetch
 from webapp.login import user_info
 from webapp.marketo import MarketoAPI
 from webapp.utils import format_community_event_time
@@ -428,6 +429,9 @@ def build_tutorials_index(session, tutorials_docs):
 
 
 def build_engage_index(engage_docs):
+    index_cache = {}
+    tags_cache = {}
+
     def engage_index():
         page = flask.request.args.get("page", default=1, type=int)
         preview = flask.request.args.get("preview")
@@ -437,30 +441,32 @@ def build_engage_index(engage_docs):
         limit = 21  # adjust as needed
         offset = (page - 1) * limit
 
-        if tag or resource or language:
-            (
-                metadata,
-                count,
-                active_count,
-                current_total,
-            ) = engage_docs.get_index(
-                limit,
-                offset,
-                tag_value=tag,
-                key="type",
-                value=resource,
-                second_key="language",
-                second_value=language,
-            )
-        else:
-            (
-                metadata,
-                count,
-                active_count,
-                current_total,
-            ) = engage_docs.get_index(
+        def _fetch_index():
+            if tag or resource or language:
+                return engage_docs.get_index(
+                    limit,
+                    offset,
+                    tag_value=tag,
+                    key="type",
+                    value=resource,
+                    second_key="language",
+                    second_value=language,
+                )
+            return engage_docs.get_index(
                 limit, offset, key="is_static", value=None
             )
+
+        (
+            metadata,
+            count,
+            active_count,
+            current_total,
+        ) = cached_fetch(
+            index_cache,
+            (page, language, resource, tag),
+            _fetch_index,
+            ttl=300,
+        )
 
         # Fixed so that engage page authors don't create random resource types
         resource_types = [
@@ -471,7 +477,12 @@ def build_engage_index(engage_docs):
             "Form",
             "Event",
         ]
-        tags_list = engage_docs.get_engage_pages_tags()
+        tags_list = cached_fetch(
+            tags_cache,
+            "engage-tags",
+            engage_docs.get_engage_pages_tags,
+            ttl=900,
+        )
         tags_list = sorted(set(tags_list), key=str.lower)
         total_pages = math.ceil(current_total / limit)
 
@@ -503,21 +514,25 @@ def build_engage_page_resources(engage_docs):
     resource: is the resource type, e.g. "Webinar", "Whitepaper", "Case Study"
     """
 
+    cache = {}
+
     def engage_page_resources():
         tag = flask.request.args.get("tag", default=None, type=str)
         resource = flask.request.args.get("resource", default=None, type=str)
 
-        if tag or resource:
-            metadata, *_ = engage_docs.get_index(
-                limit=3,
-                tag_value=tag,
-                key="type",
-                value=resource,
-            )
-        else:
-            metadata, *_ = engage_docs.get_index(
-                limit=3, key="is_static", value=None
-            )
+        def _fetch_resources():
+            if tag or resource:
+                return engage_docs.get_index(
+                    limit=3,
+                    tag_value=tag,
+                    key="type",
+                    value=resource,
+                )
+            return engage_docs.get_index(limit=3, key="is_static", value=None)
+
+        metadata, *_ = cached_fetch(
+            cache, (tag, resource), _fetch_resources, ttl=900
+        )
 
         response = flask.jsonify(metadata)
         response.headers["Cache-Control"] = "public, max-age=900"
@@ -527,12 +542,19 @@ def build_engage_page_resources(engage_docs):
 
 
 def build_engage_page(engage_pages):
+    page_cache = {}
+
     def engage_page(language, page):
         if language:
             path = f"/engage/{language}/{page}"
         else:
             path = f"/engage/{page}"
-        metadata = engage_pages.get_engage_page(path)
+        metadata = cached_fetch(
+            page_cache,
+            path,
+            lambda: engage_pages.get_engage_page(path),
+            ttl=900,
+        )
         if not metadata:
             flask.abort(404)
         else:
@@ -542,9 +564,21 @@ def build_engage_page(engage_pages):
                     related_urls = metadata["related_urls"].split(",")
                     # Only show maximum of 3 related pages
                     for url in related_urls[:3]:
-                        page_metadata = engage_pages.get_engage_page(
-                            url.strip()
-                        )
+                        related_url = url.strip()
+                        try:
+                            page_metadata = cached_fetch(
+                                page_cache,
+                                related_url,
+                                lambda related_url=related_url: (
+                                    engage_pages.get_engage_page(related_url)
+                                ),
+                                ttl=900,
+                            )
+                        except ServiceUnavailable:
+                            # Related pages are best-effort; skip when
+                            # Discourse is cooling down rather than 503 the
+                            # whole page.
+                            continue
                         if page_metadata is not None:
                             related_pages_metadata.append(page_metadata)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -463,7 +463,7 @@ def build_engage_index(engage_docs):
             current_total,
         ) = cached_fetch(
             index_cache,
-            (page, language, resource, tag),
+            (page, language, resource, tag, preview is not None),
             _fetch_index,
             ttl=300,
         )
@@ -552,7 +552,7 @@ def build_engage_page(engage_pages):
         metadata = cached_fetch(
             page_cache,
             path,
-            lambda: engage_pages.get_engage_page(path),
+            lambda: engage_pages.get_engage_page(path) or flask.abort(404),
             ttl=900,
         )
         if not metadata:


### PR DESCRIPTION
## Done

- Added `webapp.discourse_cache.py` with `cached_fetch` and `install_topic_cache`, providing a shared cache and circuit breaker for Discourse-backed views.
- Wrapped the main Discourse API's `get_topic` method with the shared cache and breaker using `install_topic_cache`. 
- Refactored Engage page views and related endpoints to use `cached_fetch`, improving performance and resilience to rate-limiting.
- Updated `/takeovers_json` to cache its data for 5 minutes using `cached_fetch`.
- Added a 503 error handler to render a styled error page when the circuit breaker is open, visually it looks the same as the 500 page since the canonicalwebteam.directory_parser library hardcodes the sitemap's error-page exclusions, 400/401/403/404/410/429/500/502.html, and 503 isn't in that list

These changes collectively make the application more robust against Discourse API rate limits, improve user experience during outages, and reduce unnecessary load on upstream services.

## QA

## Issue / Card

Fixes discourse being overloaded causing engage pages to return 500
