### PR TITLE
feat: block YisouSpider user agent with 403 response

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -605,6 +605,9 @@ production:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
+    if ($http_user_agent ~* "YisouSpider") {
+      return 403;
+    }
     location ^~ /wp-content/uploads/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
     }


### PR DESCRIPTION
## Done

- Block the YisouSpider crawler with a 403 at the ingress (production `nginxServerSnippet`): across two access-log samples taken 5 hours apart it accounted for ~60% of all requests to Discourse-backed pages (/engage, /community, /takeovers), exhausting the shared Discourse API rate limit and causing the intermittent 500s in production.

## QA

- Not testable locally (production-only ingress config); after deploy, `curl -sI -A "YisouSpider" "https://ubuntu.com/community?cb=1"` should return 403 while a normal browser user agent returns 200, and the "Too Many Requests" count in the ubuntu.com-discourse pod logs should stay near zero.

## Issue / Card

Production incident: Discourse 429s causing 500s on /engage and /community pages (same incident as #16538).

