### PR TITLE
feat: harden discourse circuit breaker and extend crawler blocklist

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -605,7 +605,7 @@ production:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
-    if ($http_user_agent ~* "YisouSpider") {
+    if ($http_user_agent ~* "(YisouSpider|Bytespider|PetalBot|Amazonbot|MJ12bot|DotBot|DataForSeoBot|BelleaireCrawler|yacybot|jscrawler)") {
       return 403;
     }
     location ^~ /wp-content/uploads/ {

--- a/tests/test_discourse_cache.py
+++ b/tests/test_discourse_cache.py
@@ -273,3 +273,90 @@ class TestServiceUnavailableRendering(TestCase):
         body = response.get_data(as_text=True)
         self.assertIn("Server error", body)
         self.assertNotIn("Discourse is rate-limiting", body)
+
+
+class TestErrorBackoff(TestCase):
+    def setUp(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_stale_serve_backs_off_refetching(self):
+        cache = {}
+        discourse_cache.cached_fetch(cache, "k", lambda: "stale", ttl=100)
+        # Expire the entry so the next call attempts a refresh
+        cache["k"]["ts"] -= 200
+
+        calls = []
+
+        def failing():
+            calls.append(1)
+            raise _http_error(500)
+
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", failing, ttl=100),
+            "stale",
+        )
+        # The stale entry was re-stamped: an immediate retry must be
+        # served from cache without hitting Discourse again
+        self.assertEqual(
+            discourse_cache.cached_fetch(cache, "k", failing, ttl=100),
+            "stale",
+        )
+        self.assertEqual(len(calls), 1)
+
+
+class TestRetryAfter(TestCase):
+    def setUp(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_open_breaker_503_carries_retry_after(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = time.time() + 120
+
+        with self.assertRaises(ServiceUnavailable) as context:
+            discourse_cache.cached_fetch({}, "k", lambda: "x", ttl=0)
+
+        self.assertIsNotNone(context.exception.retry_after)
+        self.assertGreater(int(context.exception.retry_after), 60)
+        self.assertLessEqual(int(context.exception.retry_after), 121)
+
+    def test_429_503_carries_retry_after(self):
+        def rate_limited():
+            raise _http_error(429, retry_after=300)
+
+        with self.assertRaises(ServiceUnavailable) as context:
+            discourse_cache.cached_fetch({}, "k", rate_limited, ttl=0)
+
+        self.assertIsNotNone(context.exception.retry_after)
+        self.assertGreaterEqual(int(context.exception.retry_after), 250)
+
+
+class TestServiceUnavailableResponseHeaders(TestCase):
+    def setUp(self):
+        from webapp.app import app
+
+        app.testing = True
+        self.client = app.test_client()
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = time.time() + 120
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_503_response_has_retry_after_header(self):
+        response = self.client.get("/engage/__breaker-retry-after__")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("Retry-After", response.headers)
+
+    def test_json_endpoint_gets_json_503(self):
+        response = self.client.get("/engage/resources.json?tag=__breaker__")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertTrue(
+            response.content_type.startswith("application/json"),
+            response.content_type,
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch, MagicMock
 
 from werkzeug.exceptions import NotFound, InternalServerError
 
+from webapp import discourse_cache
 from webapp.app import app
 from webapp.views import (
     shorten_acquisition_url,
@@ -17,6 +18,8 @@ from webapp.views import (
     build_tutorials_query,
     match_tags,
     build_engage_page,
+    community_landing_page,
+    engage_thank_you,
     enrich_acquisition_url,
     build_engage_page_resources,
     append_utms_cookie_to_canonical_links,
@@ -1234,3 +1237,106 @@ class TestAppendUtmsCookieToCanonicalLinks(BaseViewTestCase):
             updated_html = response.set_data.call_args[0][0]
             # Verify mailto link is unchanged
             self.assertEqual(updated_html, html)
+
+
+class TestEngageThankYouCaching(TestCase):
+    """
+    Unit tests for `engage_thank_you` Discourse caching.
+    """
+
+    def setUp(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_thank_you_caches_page_lookup(self):
+        engage_pages = Mock()
+        engage_pages.get_engage_page.return_value = None
+        view = engage_thank_you(engage_pages)
+
+        for _ in range(2):
+            with self.assertRaises(NotFound):
+                view(None, "missing-page")
+
+        engage_pages.get_engage_page.assert_called_once()
+
+
+class TestCommunityLandingEvents(TestCase):
+    """
+    The community landing page should degrade to an empty events list
+    when Discourse errors, instead of failing the whole page.
+    """
+
+    def setUp(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def _build_view(self, community_events):
+        local_communities = Mock()
+        local_communities.get_category_index_metadata.return_value = []
+        newsletter = Mock()
+        newsletter.get_topics_in_category.return_value = []
+        return community_landing_page(
+            community_events, local_communities, newsletter
+        )
+
+    def test_events_degrade_when_discourse_errors(self):
+        community_events = Mock()
+        community_events.get_featured_events.side_effect = ValueError(
+            "HTTP error occurred: 429 Client Error: Too Many Requests"
+        )
+        view = self._build_view(community_events)
+
+        with patch(
+            "webapp.views.flask.render_template", return_value=""
+        ) as render:
+            with app.test_request_context("/community"):
+                view()
+
+        self.assertEqual(render.call_args.kwargs["featured_events"], [])
+
+    def test_events_are_cached_across_requests(self):
+        community_events = Mock()
+        community_events.get_featured_events.return_value = []
+        community_events.get_events.return_value = []
+        view = self._build_view(community_events)
+
+        with patch("webapp.views.flask.render_template", return_value=""):
+            with app.test_request_context("/community"):
+                view()
+                view()
+
+        community_events.get_featured_events.assert_called_once()
+
+
+class TestTakeoversIndexCaching(TestCase):
+    """
+    /takeovers should not hit Discourse on every request.
+    """
+
+    def setUp(self):
+        discourse_cache._DISCOURSE_COOLDOWN["until"] = 0.0
+        self.addCleanup(
+            discourse_cache._DISCOURSE_COOLDOWN.__setitem__, "until", 0.0
+        )
+
+    def test_takeovers_index_caches_get_index(self):
+        from webapp import app as app_module
+
+        app.testing = True
+        client = app.test_client()
+
+        with patch.object(
+            app_module.discourse_takeovers,
+            "get_index",
+            return_value=([], 0, 0, 0),
+        ) as get_index:
+            first = client.get("/takeovers")
+            second = client.get("/takeovers")
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        get_index.assert_called_once()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -792,6 +792,9 @@ def takeovers_json():
     return response
 
 
+_takeovers_index_cache = {}
+
+
 def takeovers_index():
     page = flask.request.args.get("page", default=1, type=int)
     limit = 50
@@ -801,7 +804,12 @@ def takeovers_index():
         count,
         active_count,
         total_current,
-    ) = discourse_takeovers.get_index(limit=limit, offset=offset)
+    ) = cached_fetch(
+        _takeovers_index_cache,
+        page,
+        lambda: discourse_takeovers.get_index(limit=limit, offset=offset),
+        ttl=300,
+    )
     total_pages = math.ceil(count / limit)
 
     return flask.render_template(

--- a/webapp/discourse_cache.py
+++ b/webapp/discourse_cache.py
@@ -24,6 +24,8 @@ from werkzeug.exceptions import ServiceUnavailable
 _DISCOURSE_COOLDOWN = {"until": 0.0}
 _DISCOURSE_COOLDOWN_MIN = 60
 _DISCOURSE_COOLDOWN_MAX = 600
+# While Discourse is erroring, retry a stale entry at most this often
+_ERROR_RETRY = 30
 
 
 def _http_error_status_code(error):
@@ -31,6 +33,27 @@ def _http_error_status_code(error):
     if response is None:
         return None
     return response.status_code
+
+
+def _cooldown_retry_after():
+    """Seconds until the breaker closes, for Retry-After headers."""
+    remaining = _DISCOURSE_COOLDOWN["until"] - time.time()
+    if remaining <= 0:
+        return _DISCOURSE_COOLDOWN_MIN
+    # min() before int() so an unbounded cooldown doesn't overflow
+    return max(1, int(min(remaining, _DISCOURSE_COOLDOWN_MAX)))
+
+
+def _serve_stale(cache, key, cached, ttl):
+    """Serve a stale entry, re-stamped so the next retry against a
+    failing Discourse happens after _ERROR_RETRY instead of per request.
+    """
+    entry_ttl = ttl if cached["data"] else min(ttl, 60)
+    cache[key] = {
+        "data": cached["data"],
+        "ts": time.time() - entry_ttl + _ERROR_RETRY,
+    }
+    return cached["data"]
 
 
 def _start_discourse_cooldown(error):
@@ -74,7 +97,8 @@ def cached_fetch(cache, key, fetcher, ttl, max_size=512):
         if cached:
             return cached["data"]
         raise ServiceUnavailable(
-            "Discourse is rate-limiting requests; please retry shortly."
+            "Discourse is rate-limiting requests; please retry shortly.",
+            retry_after=_cooldown_retry_after(),
         )
 
     try:
@@ -84,19 +108,21 @@ def cached_fetch(cache, key, fetcher, ttl, max_size=512):
         if _http_error_status_code(error) == 429:
             _start_discourse_cooldown(error)
             if cached:
-                return cached["data"]
+                return _serve_stale(cache, key, cached, ttl)
             raise ServiceUnavailable(
-                "Discourse is rate-limiting requests; please retry shortly."
+                "Discourse is rate-limiting requests; please retry shortly.",
+                retry_after=_cooldown_retry_after(),
             )
         if cached:
-            return cached["data"]
+            return _serve_stale(cache, key, cached, ttl)
         raise
     except (RequestsConnectionError, Timeout, RequestException) as error:
         sentry_sdk.capture_exception(error)
         if cached:
-            return cached["data"]
+            return _serve_stale(cache, key, cached, ttl)
         raise ServiceUnavailable(
-            "Discourse is unavailable; please retry shortly."
+            "Discourse is unavailable; please retry shortly.",
+            retry_after=_ERROR_RETRY,
         )
 
     # Move key to insertion-order tail so the oldest unrefreshed entry is

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -98,8 +98,24 @@ def init_handlers(app):
         500 template (the directory_parser sitemap excludes it, and it is the
         app's standard "couldn't load this page" error) rather than leaking
         the internal reason to users.
+
+        JSON endpoints get a JSON body so their fetch() consumers don't
+        choke on HTML, and Retry-After tells well-behaved clients and
+        crawlers when to come back.
         """
-        return flask.render_template("500.html"), 503
+        if flask.request.path.endswith(".json"):
+            response = flask.make_response(
+                flask.jsonify(error="Service temporarily unavailable"),
+                503,
+            )
+        else:
+            response = flask.make_response(
+                flask.render_template("500.html"), 503
+            )
+
+        retry_after = getattr(error, "retry_after", None)
+        response.headers["Retry-After"] = str(retry_after or 60)
+        return response
 
     @app.errorhandler(SecurityAPIError)
     def security_api_error(error):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -31,7 +31,7 @@ from canonicalwebteam.search.views import NoAPIKeyError
 from canonicalwebteam.directory_parser import generate_sitemap
 from geolite2 import geolite2
 from requests import Session
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, RequestException
 from werkzeug.exceptions import BadRequest, ServiceUnavailable
 from canonicalwebteam.flask_base.env import get_flask_env
 
@@ -627,13 +627,20 @@ def engage_thank_you(engage_pages):
     @returns: a function that renders a template
     """
 
+    thank_you_cache = {}
+
     def render_template(language, page):
         if language:
             path = f"/engage/{language}/{page}"
         else:
             path = f"/engage/{page}"
 
-        metadata = engage_pages.get_engage_page(path)
+        metadata = cached_fetch(
+            thank_you_cache,
+            path,
+            lambda: engage_pages.get_engage_page(path),
+            ttl=900,
+        )
         if not metadata:
             flask.abort(404)
 
@@ -1847,7 +1854,9 @@ def process_community_events(community_events):
 def community_landing_page(
     community_events, local_communities, ubuntu_weekly_newsletter
 ):
-    def display_community_landing_page():
+    events_cache = {}
+
+    def _fetch_events_to_display():
         featured_events = community_events.get_featured_events()
         events_to_display = []
 
@@ -1872,6 +1881,22 @@ def community_landing_page(
 
         for event in events_to_display:
             format_community_event_time(event)
+
+        return events_to_display
+
+    def display_community_landing_page():
+        try:
+            events_to_display = cached_fetch(
+                events_cache,
+                "events-to-display",
+                _fetch_events_to_display,
+                ttl=300,
+            )
+        except (ServiceUnavailable, RequestException, ValueError):
+            # Events are decorative on this page; the DiscourseAPI wraps
+            # upstream failures (including 429) in ValueError, so degrade
+            # to an empty list rather than failing the whole page
+            events_to_display = []
 
         communities_data = local_communities.get_category_index_metadata(
             "locos"


### PR DESCRIPTION
## Done

- Cover the Discourse-backed views missed by #16538: `engage_thank_you`, the `/takeovers` index, and the `/community` landing page events (which now degrade to an empty list instead of 500ing when Discourse errors, including the ValueError-wrapped 429 from `get_topics_by_tag` seen in the incident tracebacks).
- Add error backoff to `cached_fetch` so a stale entry is retried against a failing Discourse at most every 30s per worker instead of on every request.
- 503 responses now include a `Retry-After` header (derived from the breaker cooldown) and `.json` endpoints return a JSON 503 body instead of HTML.
- Extend the konf crawler blocklist with the aggressive bots identified from ingress access logs during the incident (Bytespider, PetalBot, Amazonbot, MJ12bot, DotBot, DataForSeoBot, BelleaireCrawler, yacybot, jscrawler).

## QA

- Run `SECRET_KEY=insecure_test_key python3 -m pytest tests/test_discourse_cache.py tests/test_views.py` (79 passing; 9 new tests covering each behaviour above).
- After deploy: `curl -sI -A "Bytespider" https://ubuntu.com/ | head -1` should return 403, and a breaker-open 503 (e.g. on a cold engage page during a rate-limit event) should carry a `Retry-After` header.

## Issue / Card

Follow-up to #16538 and #16541 (Discourse 429 incident: remaining unprotected views and review findings).

