### PR TITLE
feat: add alerts and tests for payload failures

### DIFF
--- a/.github/workflows/forms.yaml
+++ b/.github/workflows/forms.yaml
@@ -1,5 +1,7 @@
 name: Form e2e integration tests on ubuntu.com
 on:
+  # TODO: Undo changes on this file before merging
+  pull_request:
   push:
     branches:
       - main
@@ -77,7 +79,7 @@ jobs:
           MARKETO_API_CLIENT: ${{ secrets.MARKETO_API_CLIENT }}
           MARKETO_API_SECRET: ${{ secrets.MARKETO_API_SECRET }}
         run: |
-          python -m unittest tests.test_marketo
+          python -m unittest tests.test_marketo.TestMarketoSubmit
 
       - name: Send message on failure
         env:

--- a/.github/workflows/forms.yaml
+++ b/.github/workflows/forms.yaml
@@ -1,7 +1,5 @@
 name: Form e2e integration tests on ubuntu.com
 on:
-  # TODO: Undo changes on this file before merging
-  pull_request:
   push:
     branches:
       - main
@@ -79,7 +77,7 @@ jobs:
           MARKETO_API_CLIENT: ${{ secrets.MARKETO_API_CLIENT }}
           MARKETO_API_SECRET: ${{ secrets.MARKETO_API_SECRET }}
         run: |
-          python -m unittest tests.test_marketo.TestMarketoSubmit
+          python -m unittest tests.test_marketo
 
       - name: Send message on failure
         env:

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -1,6 +1,8 @@
 import unittest
 import os
 import json
+import sentry_sdk
+from unittest.mock import Mock, patch
 
 from webapp.app import app
 from tests.helpers import MarketoFormTestCase
@@ -196,6 +198,160 @@ class TestStaticContactForms(MarketoFormTestCase):
                             "Template not found in "
                             "contact_us_template_fields: " + template,
                         )
+
+
+class TestMarketoSubmit(unittest.TestCase):
+    """
+    Tests for market_submit()
+    Two form submissions (payload + enrichment) have to go through
+    to be considered successful and avoid a Sentry alert.
+
+    The Marketo API and Sentry reporting are mocked, so these tests do not
+    require live Marketo credentials.
+    """
+
+    def setUp(self):
+        app.testing = True
+        if not app.config.get("SECRET_KEY"):
+            app.config["SECRET_KEY"] = "test-secret-key"
+        self.client = app.test_client()
+
+    @staticmethod
+    def _mock_response(json_body):
+        """Build a fake requests.Response whose .json() returns json_body."""
+        response = Mock()
+        response.json.return_value = json_body
+        return response
+
+    @classmethod
+    def setUpClass(cls):
+        # Drop Sentry client so test alerts do not get sent to Sentry
+        cls._sentry_client = sentry_sdk.get_client()
+        sentry_sdk.get_global_scope().set_client(None)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Reinstantiate Sentry client
+        sentry_sdk.get_global_scope().set_client(cls._sentry_client)
+
+    def _submit(self, payload_response, enrichment_response):
+        """
+        POST a minimal valid form to /marketo/submit with the two Marketo
+        API calls (payload first, then enrichment) mocked to return the given
+        responses. Returns (http_response, mock_sentry_report).
+        """
+        with patch(
+            "webapp.views.marketo_api.submit_form"
+        ) as mock_submit, patch(
+            "webapp.views.marketo_sentry_report"
+        ) as mock_sentry:
+            mock_submit.side_effect = [
+                self._mock_response(payload_response),
+                self._mock_response(enrichment_response),
+            ]
+            http_response = self.client.post(
+                "/marketo/submit",
+                data={
+                    "formid": "1234",
+                    "email": "test@example.com",
+                    "firstName": "Test",
+                },
+            )
+        return http_response, mock_sentry
+
+    @staticmethod
+    def _sentry_messages(mock_sentry):
+        """
+        Return the list of human-readable messages passed to
+        marketo_sentry_report (the first positional argument of each call).
+        """
+        return [
+            call.args[0] if call.args else ""
+            for call in mock_sentry.call_args_list
+        ]
+
+    def test_both_submissions_succeed_no_alert(self):
+        """
+        When both the payload and enrichment submissions succeed, no Sentry
+        alert is raised and the user is redirected to the thank-you page.
+        """
+        http_response, mock_sentry = self._submit(
+            payload_response={
+                "success": True,
+                "result": [{"status": "created"}],
+            },
+            enrichment_response={"success": True},
+        )
+        mock_sentry.assert_not_called()
+        self.assertEqual(http_response.status_code, 302)
+        self.assertIn("/thank-you", http_response.headers["Location"])
+
+    def test_both_submissions_fail_single_alert(self):
+        """
+        When both submissions fail (payload skipped and enrichment
+        unsuccessful), a single combined-failure Sentry alert is raised.
+        """
+        http_response, mock_sentry = self._submit(
+            payload_response={
+                "success": True,
+                "result": [{"status": "skipped"}],
+            },
+            enrichment_response={"success": False},
+        )
+        self.assertEqual(mock_sentry.call_count, 1)
+        self.assertEqual(
+            self._sentry_messages(mock_sentry),
+            ["Marketo form 1234 and enrichment payload failed to submit"],
+        )
+        self.assertEqual(http_response.status_code, 302)
+        self.assertIn(
+            "contact-form-fail", http_response.headers["Location"]
+        )
+
+    def test_payload_succeeds_enrichment_fails_single_alert(self):
+        """
+        When only the payload submission goes through, exactly one Sentry
+        alert is raised, identifying the enrichment submission as the failure.
+        """
+        http_response, mock_sentry = self._submit(
+            payload_response={
+                "success": True,
+                "result": [{"status": "created"}],
+            },
+            enrichment_response={"success": False},
+        )
+        self.assertEqual(mock_sentry.call_count, 1)
+        self.assertEqual(
+            self._sentry_messages(mock_sentry),
+            ["Marketo form 1234 enrichment payload failed"],
+        )
+        self.assertEqual(http_response.status_code, 302)
+        self.assertIn(
+            "contact-form-fail", http_response.headers["Location"]
+        )
+
+    def test_enrichment_succeeds_payload_skipped_single_alert(self):
+        """
+        When only the enrichment submission goes through (the payload was
+        skipped), exactly one Sentry alert is raised, identifying the payload
+        submission as the failure.
+        """
+        http_response, mock_sentry = self._submit(
+            payload_response={
+                "success": True,
+                "result": [{"status": "skipped"}],
+            },
+            enrichment_response={"success": True},
+        )
+        self.assertEqual(mock_sentry.call_count, 1)
+        self.assertEqual(
+            self._sentry_messages(mock_sentry),
+            ["Marketo form 1234 payload failed to submit"],
+        )
+        self.assertEqual(http_response.status_code, 302)
+        self.assertIn(
+            "contact-form-fail", http_response.headers["Location"]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -202,7 +202,7 @@ class TestStaticContactForms(MarketoFormTestCase):
 
 class TestMarketoSubmit(unittest.TestCase):
     """
-    Tests for market_submit()
+    Tests for marketo_submit()
     Two form submissions (payload + enrichment) have to go through
     to be considered successful and avoid a Sentry alert.
 
@@ -304,9 +304,7 @@ class TestMarketoSubmit(unittest.TestCase):
             ["Marketo form 1234 and enrichment payload failed to submit"],
         )
         self.assertEqual(http_response.status_code, 302)
-        self.assertIn(
-            "contact-form-fail", http_response.headers["Location"]
-        )
+        self.assertIn("contact-form-fail", http_response.headers["Location"])
 
     def test_payload_succeeds_enrichment_fails_single_alert(self):
         """
@@ -326,9 +324,7 @@ class TestMarketoSubmit(unittest.TestCase):
             ["Marketo form 1234 enrichment payload failed"],
         )
         self.assertEqual(http_response.status_code, 302)
-        self.assertIn(
-            "contact-form-fail", http_response.headers["Location"]
-        )
+        self.assertIn("contact-form-fail", http_response.headers["Location"])
 
     def test_enrichment_succeeds_payload_skipped_single_alert(self):
         """
@@ -349,9 +345,7 @@ class TestMarketoSubmit(unittest.TestCase):
             ["Marketo form 1234 payload failed to submit"],
         )
         self.assertEqual(http_response.status_code, 302)
-        self.assertIn(
-            "contact-form-fail", http_response.headers["Location"]
-        )
+        self.assertIn("contact-form-fail", http_response.headers["Location"])
 
 
 if __name__ == "__main__":

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1310,17 +1310,17 @@ def marketo_submit():
             payload=payload,
         )
 
-    # Redirect to success page only if both submissions were successful.
-    # A "skipped" payload status means Marketo rejected the main form
-    # submission (e.g. an unexpected field such as a stray hidden input),
-    # even though the top-level API response still reports success. Treat it
-    # as an explicit failure so it can never be silently reported as success.
+    # Skipped payload means Marketo rejected the submission
+    # API-level success does not mean the submission was successful
+    # https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/error-codes#error-types
     payload_status = data["result"][0]["status"]
+    payload_succeeded = data["success"] is True and payload_status != "skipped"
+    enrichment_succeeded = enrichment_submission["success"] is True
 
+    # Verify that both payload and enrichment submissions went through
     if (
-        enrichment_submission["success"] is True
-        and data["success"] is True
-        and payload_status != "skipped"
+        payload_succeeded is True
+        and enrichment_succeeded is True
     ):
         flask.flash(
             "Your form was submitted successfully.", "contact-form-success"
@@ -1349,11 +1349,11 @@ def marketo_submit():
 
             return flask.redirect(return_url)
     else:
-        # Log every failed submission to Sentry with the tried payload, then
-        # display an error notification to the user.
+
+        # Both payload and enrichment submissions failed
         if (
-            payload_status == "skipped"
-            and enrichment_submission["success"] is False
+            enrichment_succeeded is False
+            and payload_succeeded is False
         ):
             sentry_message = (
                 f"Marketo form {payload['formId']} and "
@@ -1363,14 +1363,25 @@ def marketo_submit():
                 "There was an issue submitting the form contact details "
                 "and payload."
             )
-        elif payload_status == "skipped":
+
+        # Payload submission failed only
+        elif payload_succeeded is False:
             sentry_message = (
                 f"Marketo form {payload['formId']} payload failed to submit"
             )
             flash_message = "There was an issue submitting the form payload."
+
+        # Enrichment submission failed only
+        elif enrichment_succeeded is False:
+            sentry_message = (
+                f"Marketo form {payload['formId']} enrichment payload failed"
+            )
+            flash_message = (
+                "There was an issue submitting the form contact details."
+            )
+
+        # API reported failure for another reason.
         else:
-            # Payload was accepted but enrichment failed, or the API
-            # reported failure for another reason.
             sentry_message = (
                 f"Marketo form {payload['formId']} submission failed"
             )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1318,10 +1318,7 @@ def marketo_submit():
     enrichment_succeeded = enrichment_submission["success"] is True
 
     # Verify that both payload and enrichment submissions went through
-    if (
-        payload_succeeded is True
-        and enrichment_succeeded is True
-    ):
+    if payload_succeeded is True and enrichment_succeeded is True:
         flask.flash(
             "Your form was submitted successfully.", "contact-form-success"
         )
@@ -1351,10 +1348,7 @@ def marketo_submit():
     else:
 
         # Both payload and enrichment submissions failed
-        if (
-            enrichment_succeeded is False
-            and payload_succeeded is False
-        ):
+        if enrichment_succeeded is False and payload_succeeded is False:
             sentry_message = (
                 f"Marketo form {payload['formId']} and "
                 "enrichment payload failed to submit"


### PR DESCRIPTION
## Done

- On every form, two submissions are sent. Payload + Enrichment payload
- Create dedicated alerts if at least one form submission fails
- Create mock tests for form submissions



## QA

- See that [`test_marketo`](https://github.com/canonical/ubuntu.com/actions/runs/28854110711/job/85576277297?pr=16550) action passes

## Issue / Card

Fixes [WD-37604](https://warthogs.atlassian.net/browse/WD-37604)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37604]: https://warthogs.atlassian.net/browse/WD-37604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ