### PR TITLE
feat: read public Discourse content anonymously to spare the shared API quota

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@feat/optional-anonymous-reads
+canonicalwebteam.discourse==7.7.0
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 canonicalwebteam.markdown-response==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse==7.6.1
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@feat/optional-anonymous-reads
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 canonicalwebteam.markdown-response==0.2.0

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1402,22 +1402,20 @@ class TestRateLimitedErrorHandling(TestCase):
 
         self.assertEqual(render.call_args.kwargs["communities"], [])
 
-    def test_vulnerabilities_list_none_metadata_does_not_crash(self):
-        # get_category_index_metadata / get_topics_in_category return
-        # None when Discourse errors on a cold cache; the vulnerabilities
-        # page must not crash iterating over None
+    def test_vulnerabilities_list_aborts_503_when_unavailable(self):
+        # get_category_index_metadata returns None when Discourse errors
+        # on a cold cache. The vulnerabilities page must surface a 503
+        # rather than crash on None or render a misleading empty list.
+        from werkzeug.exceptions import ServiceUnavailable
+
         security = Mock()
         security.get_topics_in_category.return_value = None
         security.get_category_index_metadata.return_value = None
         view = build_vulnerabilities_list(security)
 
-        with patch(
-            "webapp.views.flask.render_template", return_value=""
-        ) as render:
-            with app.test_request_context("/security/vulnerabilities"):
+        with app.test_request_context("/security/vulnerabilities"):
+            with self.assertRaises(ServiceUnavailable):
                 view()
-
-        self.assertEqual(render.call_args.kwargs["vulnerabilities"], [])
 
     def test_local_communities_none_fallback_does_not_crash(self):
         local_communities = Mock()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,6 +17,7 @@ from webapp.views import (
     build_tutorials_query,
     match_tags,
     build_engage_page,
+    build_vulnerabilities_list,
     community_landing_page,
     enrich_acquisition_url,
     build_engage_page_resources,
@@ -1400,6 +1401,23 @@ class TestRateLimitedErrorHandling(TestCase):
                 view()
 
         self.assertEqual(render.call_args.kwargs["communities"], [])
+
+    def test_vulnerabilities_list_none_metadata_does_not_crash(self):
+        # get_category_index_metadata / get_topics_in_category return
+        # None when Discourse errors on a cold cache; the vulnerabilities
+        # page must not crash iterating over None
+        security = Mock()
+        security.get_topics_in_category.return_value = None
+        security.get_category_index_metadata.return_value = None
+        view = build_vulnerabilities_list(security)
+
+        with patch(
+            "webapp.views.flask.render_template", return_value=""
+        ) as render:
+            with app.test_request_context("/security/vulnerabilities"):
+                view()
+
+        self.assertEqual(render.call_args.kwargs["vulnerabilities"], [])
 
     def test_local_communities_none_fallback_does_not_crash(self):
         local_communities = Mock()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1414,6 +1414,24 @@ class TestRateLimitedErrorHandling(TestCase):
 
         self.assertEqual(render.call_args.kwargs["map_markers"], [])
 
+    def test_discourse_auth_scope_configuration(self):
+        # The shared instance reads public content anonymously (its
+        # requests must not spend the shared admin API quota); the
+        # security instance reads a private category so it must stay
+        # authenticated. They must not share a session object, or the
+        # authenticated instance would stamp credentials on both.
+        from webapp import app as app_module
+
+        self.assertNotIn("Api-Key", app_module.discourse_api.session.headers)
+        self.assertEqual(
+            app_module.security_discourse_api.session.headers.get("Api-Key"),
+            app_module.security_discourse_api.api_key,
+        )
+        self.assertIsNot(
+            app_module.discourse_api.session,
+            app_module.security_discourse_api.session,
+        )
+
     def test_community_newsletter_dict_fallback_does_not_crash(self):
         # get_topics_in_category returns {} when Discourse errors and
         # nothing was fetched before; the page must render without it

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1450,6 +1450,21 @@ class TestRateLimitedErrorHandling(TestCase):
             app_module.security_discourse_api.session,
         )
 
+        # Authenticated Discourse instances must not share the session
+        # used by BlogAPI / search / image clients, or the Discourse
+        # admin key would be sent to those unrelated hosts.
+        self.assertNotIn("Api-Key", app_module.session.headers)
+        self.assertEqual(
+            app_module.engage_pages_discourse_api.session.headers.get(
+                "Api-Key"
+            ),
+            app_module.engage_pages_discourse_api.api_key,
+        )
+        self.assertIsNot(
+            app_module.engage_pages_discourse_api.session,
+            app_module.session,
+        )
+
     def test_community_newsletter_dict_fallback_does_not_crash(self):
         # get_topics_in_category returns {} when Discourse errors and
         # nothing was fetched before; the page must render without it

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -222,10 +222,14 @@ app.jinja_loader = loader
 session = requests.Session()
 charmhub_session = requests.Session()
 security_session = requests.Session()
-# Dedicated session for the anonymous-reads instance below: it must not
-# be shared with any authenticated DiscourseAPI, or that instance would
-# stamp the API credentials onto it and defeat the anonymous reads.
+# Authenticated DiscourseAPI instances get their own sessions: the
+# package stamps the Discourse admin credentials onto the session, so
+# sharing one with the BlogAPI / search / image clients (which talk to
+# other hosts) would leak the key to them. The anonymous instance also
+# needs an isolated session, or an authenticated one would stamp its
+# credentials there and defeat the anonymous reads.
 discourse_session = requests.Session()
+engage_session = requests.Session()
 
 # Each DiscourseAPI gets its own ResponseCache (one cache per API key,
 # i.e. one rate-limit quota): responses are cached per worker, stale data
@@ -720,7 +724,7 @@ app.add_url_rule("/logout", view_func=logout)
 # This section needs to provide takeover data for /
 engage_pages_discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
-    session=session,
+    session=engage_session,
     get_topics_query_id=14,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -221,14 +221,36 @@ app.jinja_loader = loader
 
 session = requests.Session()
 charmhub_session = requests.Session()
+security_session = requests.Session()
+# Dedicated session for the anonymous-reads instance below: it must not
+# be shared with any authenticated DiscourseAPI, or that instance would
+# stamp the API credentials onto it and defeat the anonymous reads.
+discourse_session = requests.Session()
 
 # Each DiscourseAPI gets its own ResponseCache (one cache per API key,
 # i.e. one rate-limit quota): responses are cached per worker, stale data
 # is served while Discourse errors, and a 429 opens that instance's
 # circuit breaker so we stop hammering Discourse until it recovers.
+# authenticated_reads=False: the content this instance serves (community,
+# tutorials, ceph/openstack/livepatch/certs docs) is publicly visible, so
+# plain GETs go out anonymously - they stop counting against the shared
+# admin API quota and can be served by the caching proxy in front of
+# Discourse. Data Explorer queries still authenticate. Security
+# vulnerabilities content is NOT public, so it gets its own
+# authenticated instance below.
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
-    session=session,
+    session=discourse_session,
+    api_key=DISCOURSE_API_KEY,
+    api_username=DISCOURSE_API_USERNAME,
+    get_topics_query_id=2,
+    cache=ResponseCache(ttl=600),
+    authenticated_reads=False,
+)
+
+security_discourse_api = DiscourseAPI(
+    base_url="https://discourse.ubuntu.com/",
+    session=security_session,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
@@ -653,7 +675,7 @@ app.add_url_rule(
 # Security vulnerabilities
 security_vulnerabilities = Category(
     parser=CategoryParser(
-        api=discourse_api,
+        api=security_discourse_api,
         index_topic_id=53193,
         url_prefix="/security/vulnerabilities",
     ),

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -25,7 +25,6 @@ from webapp.security.helpers import (
     get_attention_banner,
 )
 
-
 markdown_parser = Markdown(
     hard_wrap=True, parse_block_html=True, parse_inline_html=True
 )
@@ -104,7 +103,7 @@ def notice(notice_id):
         ).strftime("%-d %B %Y")
 
     processed_instructions = notice["instructions"]
-    (attention_banner, instructions) = get_attention_banner(
+    attention_banner, instructions = get_attention_banner(
         processed_instructions
     )
     if attention_banner:
@@ -812,11 +811,14 @@ def cves_sitemap():
 def vulnerabilities_sitemap(security_vulnerabilities):
 
     def build_vulnerabilities_sitemap():
-        topics_array = security_vulnerabilities.get_topics_in_category()
+        topics_array = security_vulnerabilities.get_topics_in_category() or []
         # Convert array of topic objects to dict for quick lookup
         topics = {str(topic["id"]): topic["slug"] for topic in topics_array}
-        vulnerabilities = security_vulnerabilities.get_category_index_metadata(
-            "vulnerabilities"
+        vulnerabilities = (
+            security_vulnerabilities.get_category_index_metadata(
+                "vulnerabilities"
+            )
+            or []
         )
         for vuln in vulnerabilities:
             # Add slug

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1554,9 +1554,10 @@ def process_active_vulnerabilities(security_vulnerabilities):
                 security_vulnerabilities.get_category_index_metadata(
                     "vulnerabilities"
                 )
+                or []
             )
             vulnerability_topics_array = (
-                security_vulnerabilities.get_topics_in_category()
+                security_vulnerabilities.get_topics_in_category() or []
             )
 
             # Convert array of topic objects to dict for quick lookup
@@ -1599,7 +1600,9 @@ def build_vulnerabilities_list(security_vulnerabilities, path=None):
     def vulnerabilities_list():
         try:
             template_path = "security/vulnerabilities/view-all.html"
-            topics_array = security_vulnerabilities.get_topics_in_category()
+            topics_array = (
+                security_vulnerabilities.get_topics_in_category() or []
+            )
             # Convert array of topic objects to dict for quick lookup
             topics = {
                 str(topic["id"]): topic["slug"] for topic in topics_array
@@ -1608,6 +1611,7 @@ def build_vulnerabilities_list(security_vulnerabilities, path=None):
                 security_vulnerabilities.get_category_index_metadata(
                     "vulnerabilities"
                 )
+                or []
             )
             for vuln in vulnerabilities:
                 # Add slug
@@ -1655,6 +1659,7 @@ def build_vulnerabilities(security_vulnerabilities):
                 security_vulnerabilities.get_category_index_metadata(
                     "vulnerabilities"
                 )
+                or []
             )
 
             for item in metadata_table:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1611,8 +1611,12 @@ def build_vulnerabilities_list(security_vulnerabilities, path=None):
                 security_vulnerabilities.get_category_index_metadata(
                     "vulnerabilities"
                 )
-                or []
             )
+            if vulnerabilities is None:
+                # Couldn't load from Discourse (e.g. rate limited on a
+                # cold cache). Surface a 503 rather than a misleading
+                # empty list that reads as "no vulnerabilities".
+                flask.abort(503)
             for vuln in vulnerabilities:
                 # Add slug
                 vuln_id = str(vuln["id"])


### PR DESCRIPTION
Read public Discourse content anonymously so it stops spending the shared admin API quota (~60/min per instance) that crawler traffic exhausts, causing the engage/community 500s.

- Set `authenticated_reads=False` on the shared `discourse_api` instance: public GET reads (community, tutorials, ceph/openstack/livepatch/certs docs) go out anonymously; Data Explorer queries still authenticate.
- Split security vulnerabilities onto its own authenticated instance — that content isn't public (anonymous `/t/53193.json` / `/c/308.json` both 404).
- Give the anonymous instance a dedicated `requests.Session` so no authenticated instance stamps credentials onto it.
- Add a test for the auth topology; verified every fetched id is anonymously reachable (200).
- **Temporary:** `requirements.txt` points at canonicalwebteam.discourse#229's branch for testing — re-pin to `==7.7.0` before merge.

## QA

- Open the [DEMO](https://ubuntu-com-16554.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- Check the following load normally: `/community`, a tutorial page, and the charmed docs ([/ceph/docs](https://ubuntu-com-16554.demos.haus/ceph/docs), [/openstack/docs](https://ubuntu-com-16554.demos.haus/openstack/docs), [/security/livepatch/docs](https://ubuntu-com-16554.demos.haus/security/livepatch/docs), [/security/certifications/docs](https://ubuntu-com-16554.demos.haus/security/certifications/docs))
- Check [/security/vulnerabilities](https://ubuntu-com-16554.demos.haus/security/vulnerabilities) still loads (authenticated path — must not regress)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

---

**Depends on** canonical/canonicalwebteam.discourse#229. Before merge:
- [x] Merge & release canonicalwebteam.discourse#229, then re-pin `requirements.txt` to `canonicalwebteam.discourse==7.7.0`
