### PR TITLE
fix: scrub leaked Discourse API key from test cassette

### DIFF
--- a/tests/test_blog_notice.py
+++ b/tests/test_blog_notice.py
@@ -25,7 +25,12 @@ class TestBlogNotice(VCRTestCase):
         return {
             "record_mode": os.environ.get("VCR_RECORD_MODE", "none"),
             "decode_compressed_response": True,
-            "filter_headers": ["Authorization", "Cookie"],
+            "filter_headers": [
+                "Authorization",
+                "Cookie",
+                "Api-Key",
+                "Api-Username",
+            ],
         }
 
     def setUp(self):

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -13,7 +13,12 @@ class TestCertification(VCRTestCase):
         """
         return {
             "decode_compressed_response": True,
-            "filter_headers": ["Authorization", "Cookie"],
+            "filter_headers": [
+                "Authorization",
+                "Cookie",
+                "Api-Key",
+                "Api-Username",
+            ],
         }
 
     def setUp(self):


### PR DESCRIPTION
## Done

Removes a real Discourse API key that was committed in a VCR cassette, and closes the gap that let it leak.

- Replace the hardcoded key value in `TestBlogNotice.test_blog_date_notice.yaml` with `test_api_key`. The key was baked into recorded `Api-Key` request headers.
- Add `Api-Key` / `Api-Username` to `filter_headers` in `test_blog_notice.py` and `test_certification.py` so credentials are stripped on future re-records (`test_routes.py` already did this).

**The key value is not needed by the tests:** vcrpy matches replayed requests on method + URL + query (default `match_on`), not headers, and `record_mode` is `none`. All 10 affected tests pass with the placeholder.

> ⚠️ The leaked key is still in git history and should be **rotated/revoked** regardless of this scrub — this PR only stops it appearing in the current tree and future records.

## QA

- `pytest tests/test_blog_notice.py tests/test_certification.py` — 10 passing
- `flake8` + `black` clean

## Issue / Card

Fixes # [WD-37684](https://warthogs.atlassian.net/browse/WD-37684)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-37684]: https://warthogs.atlassian.net/browse/WD-37684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ