### PR TITLE
feat: add dedicated 503 error template

### DIFF
--- a/templates/503.html
+++ b/templates/503.html
@@ -1,0 +1,16 @@
+{% extends 'templates/_error-template.html' %}
+
+{% set error_code = "503" %}
+
+{% set error_message = "We can’t load this page right now" %}
+
+{# Keep the noindex meta in this file literally: the sitemap generator
+   scans raw templates for it to exclude error pages (503 is not in the
+   directory_parser ERROR_PAGES list). #}
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block error_content %}
+  This page relies on a service that is temporarily unavailable, usually because it is briefly overloaded.
+  <br class="u-hide--small" />
+  Please try again in a minute. If it keeps happening, this may be a <a href="https://github.com/canonical/ubuntu.com/issues">known issue</a> we are working on, or you can <a href="https://github.com/canonical/ubuntu.com/issues/new?template=ISSUE_TEMPLATE.yaml">file a bug</a>.
+{% endblock error_content %}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1308,7 +1308,9 @@ class TestRateLimitedErrorHandling(TestCase):
 
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.headers.get("Retry-After"), "88")
-        self.assertIn("Server error", response.get_data(as_text=True))
+        body = response.get_data(as_text=True)
+        self.assertIn("503", body)
+        self.assertIn("temporarily unavailable", body)
 
     def test_community_events_degrade_on_rate_limit(self):
         from canonicalwebteam.discourse import RateLimitedError

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -94,10 +94,9 @@ def init_handlers(app):
     def service_unavailable(error):
         """
         Rendered when an upstream API (e.g. Discourse) is rate-limiting
-        us and there is no cached response to fall back on. Reuses the
-        styled 500 template (the directory_parser sitemap excludes it,
-        and it is the app's standard "couldn't load this page" error)
-        rather than leaking the internal reason to users.
+        us and there is no cached response to fall back on. The 503
+        template tells users the page is temporarily unavailable and to
+        retry, rather than leaking the internal reason.
 
         JSON endpoints get a JSON body so their fetch() consumers don't
         choke on HTML, and Retry-After tells well-behaved clients and
@@ -114,7 +113,7 @@ def init_handlers(app):
             )
         else:
             response = flask.make_response(
-                flask.render_template("500.html"), 503
+                flask.render_template("503.html"), 503
             )
 
         retry_after = getattr(error, "retry_after", None)


### PR DESCRIPTION
## Done

The 503 handler reused `500.html`, so a rate-limited page showed "Server error" — indistinguishable from a real crash. Add a dedicated `503.html` with a message.

- New `templates/503.html`: "We can't load this page right now / …temporarily unavailable… please try again in a minute", styled via the shared `_error-template.html` like the other error pages.
- Point the 503 handler at it (was `500.html`).
- The template keeps a literal `noindex` meta so the `directory_parser` sitemap excludes it — `503.html` is not in the package's `ERROR_PAGES` list, so without this it would leak into the sitemap (verified both ways).
- Update the rate-limit tests to assert the new 503 body.

## QA

- Open the [DEMO](https://ubuntu-com-16556.demos.haus/engage)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Trigger a 503 (e.g. temporarily raise `RateLimitedError` in a view) and confirm the styled 503 page shows with a clear retry message
- [] Check `/sitemap_tree.xml` does **not** contain `/503`
- `pytest tests/test_views.py` — 62 passing

## Issue / Card

Fixes #

## Screenshots
<img width="3248" height="1516" alt="image" src="https://github.com/user-attachments/assets/fa950b1f-fbea-43b7-9595-a22467322cef" />

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

---

Follow-up (optional): add `"503.html"` to `ERROR_PAGES` in `canonicalwebteam.directory-parser` so the `noindex` workaround here becomes unnecessary and 503 is handled like every other error page.

