### PR TITLE
fix: refine Discourse content-cache TTLs (follow-up to #16558)

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1268,6 +1268,52 @@ class TestCommunityLandingEvents(TestCase):
         self.assertEqual(render.call_args.kwargs["featured_events"], [])
 
 
+class TestDiscourseCacheControl(TestCase):
+    """
+    Discourse-backed pages are cached longer at the content-cache, but
+    community pages (which degrade to an empty 200 on Discourse error)
+    get a shorter window, and all get a long stale-if-error.
+    """
+
+    def test_community_pages_get_shorter_cache(self):
+        from webapp.handlers import (
+            _long_cache_seconds,
+            LONG_CACHE_SECONDS,
+            COMMUNITY_CACHE_SECONDS,
+        )
+
+        for path in ("/community", "/community/events", "/community/circles"):
+            self.assertEqual(
+                _long_cache_seconds(path), COMMUNITY_CACHE_SECONDS, path
+            )
+
+        # docs 503 on error rather than degrading, so keep the long cache
+        self.assertEqual(
+            _long_cache_seconds("/community/docs"), LONG_CACHE_SECONDS
+        )
+        self.assertEqual(_long_cache_seconds("/engage"), LONG_CACHE_SECONDS)
+
+    def test_long_cache_page_sets_stale_if_error(self):
+        from webapp import app as app_module
+
+        app.testing = True
+        client = app.test_client()
+
+        with patch.object(
+            app_module.discourse_takeovers,
+            "get_index",
+            return_value=([], 0, 0, 0),
+        ):
+            response = client.get("/takeovers")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.cache_control.max_age, 1800)
+        self.assertEqual(
+            response.headers["Cache-Control"].count("stale-if-error=3600"),
+            1,
+        )
+
+
 class TestRateLimitedErrorHandling(TestCase):
     """
     RateLimitedError from the discourse package must surface as a

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -43,6 +43,19 @@ from canonicalwebteam.flask_base.env import get_flask_env
 
 LONG_CACHE_SECONDS = 1800  # 30 minutes
 
+# The community landing and its Discourse-backed sub-pages degrade to
+# an empty (but still 200) render when Discourse errors, instead of
+# raising. A long cache would freeze that empty page at the CDN for the
+# full window, so they get a shorter max-age. /community/docs is not
+# included: it 503s on error rather than rendering empty, so it keeps
+# the longer cache.
+COMMUNITY_CACHE_SECONDS = 300
+
+# Serve the last good copy for up to an hour when the origin errors,
+# rather than the flask-base default (300s), so a prolonged Discourse
+# outage doesn't surface errors while a cached copy exists.
+LONG_CACHE_STALE_IF_ERROR = 3600
+
 # Exact paths (no trailing segment) that should get the longer cache.
 LONG_CACHE_EXACT = frozenset(
     {
@@ -70,6 +83,14 @@ LONG_CACHE_PREFIXES = (
 
 def _should_long_cache(path):
     return path in LONG_CACHE_EXACT or path.startswith(LONG_CACHE_PREFIXES)
+
+
+def _long_cache_seconds(path):
+    if (
+        path == "/community" or path.startswith("/community/")
+    ) and not path.startswith("/community/docs"):
+        return COMMUNITY_CACHE_SECONDS
+    return LONG_CACHE_SECONDS
 
 
 def init_handlers(app):
@@ -112,7 +133,10 @@ def init_handlers(app):
             and _should_long_cache(path)
         ):
             response.cache_control.public = True
-            response.cache_control.max_age = LONG_CACHE_SECONDS
+            response.cache_control.max_age = _long_cache_seconds(path)
+            response.cache_control._set_cache_value(
+                "stale-if-error", str(LONG_CACHE_STALE_IF_ERROR), int
+            )
 
         return response
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -43,17 +43,11 @@ from canonicalwebteam.flask_base.env import get_flask_env
 
 LONG_CACHE_SECONDS = 1800  # 30 minutes
 
-# The community landing and its Discourse-backed sub-pages degrade to
-# an empty (but still 200) render when Discourse errors, instead of
-# raising. A long cache would freeze that empty page at the CDN for the
-# full window, so they get a shorter max-age. /community/docs is not
-# included: it 503s on error rather than rendering empty, so it keeps
-# the longer cache.
+# Community pages degrade to an empty 200 on Discourse error, so cache
+# them shorter to avoid freezing a degraded render (docs 503 instead).
 COMMUNITY_CACHE_SECONDS = 300
 
-# Serve the last good copy for up to an hour when the origin errors,
-# rather than the flask-base default (300s), so a prolonged Discourse
-# outage doesn't surface errors while a cached copy exists.
+# Serve the last good copy during an origin outage (flask-base default 300s).
 LONG_CACHE_STALE_IF_ERROR = 3600
 
 # Exact paths (no trailing segment) that should get the longer cache.


### PR DESCRIPTION
## Done

Follow-up to #16558 (now merged), addressing two things it didn't cover:

- **Shorter cache for community pages.** `/community`, `/community/events`, `/community/circles`, `/community/uwn` degrade to an **empty but still 200** render when Discourse errors (they don't raise). At `max-age=1800` a degraded render is frozen at the CDN for 30 min during an incident, showing an empty community/events section long after Discourse recovers. These now use `max-age=300`. `/community/docs` is excluded — it 503s on error rather than rendering empty, so it keeps the long cache.
- **Longer `stale-if-error` (3600s).** #16558 relied on the flask-base default (300s). For the Discourse-backed long-cache pages, serve the last good copy for up to an hour when the origin errors, so a prolonged Discourse outage doesn't surface errors while a cached copy exists.

Net headers on a healthy Discourse page: `public, max-age=1800, stale-while-revalidate=86400, stale-if-error=3600`; on community pages: `max-age=300, ... stale-if-error=3600`.

## QA

- Open the [DEMO](__DEMO_URL__)
- `curl -sD - -o /dev/null https://<demo>/takeovers` → `max-age=1800, ... stale-if-error=3600`
- `curl -sD - -o /dev/null https://<demo>/community` → `max-age=300, ... stale-if-error=3600`
- `curl -sD - -o /dev/null https://<demo>/community/docs` → `max-age=1800` (kept long)
- Use GET (`-sD -`), not HEAD (`-I`) — the merged guard only applies to GET
- `pytest tests/test_views.py::TestDiscourseCacheControl` — 2 passing

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)