### PR TITLE
fix: reduce replicas for ubuntu.com-discourse from 5 to 2

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -418,7 +418,7 @@ production:
       name: ubuntu-com-discourse
       app_name: ubuntu.com-discourse
       image: prod-comms.ps5.docker-registry.canonical.com/ubuntu.com
-      replicas: 5
+      replicas: 2
       memoryLimit: 512Mi
       env:
         - name: SEARCH_API_KEY


### PR DESCRIPTION
## Done
- Reduce replicas for discourse-ubuntu-com

## QA

- Open the [DEMO](https://ubuntu-com-16562.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

