### PR TITLE
feat: cache Discourse-backed pages for 1 hour at the content-cache

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -35,6 +35,53 @@ from webapp.shop.flaskparser import UAContractsValidationError
 from webapp.certified.helpers import convert_markdown_to_html
 from canonicalwebteam.flask_base.env import get_flask_env
 
+# Cache Discourse-backed pages longer than the 60s flask-base default;
+# our after_request runs first so this max-age wins.
+LONG_CACHE_SECONDS = 3600  # 1 hour
+
+# Community pages degrade to an empty 200 on Discourse error, so cache
+# them shorter to avoid freezing a degraded page (docs 503 instead).
+COMMUNITY_CACHE_SECONDS = 300
+
+# Serve the last good copy during an origin outage (flask-base default 300s).
+LONG_CACHE_STALE_IF_ERROR = 3600
+
+# Exact paths (no trailing segment) that should get the longer cache.
+LONG_CACHE_EXACT = frozenset(
+    {
+        "/engage",
+        "/takeovers",
+        "/tutorials",
+        "/tutorials.json",
+        "/community",
+        "/community/docs",
+        "/community/events",
+        "/community/circles",
+        "/community/uwn",
+        "/openstack/install",
+    }
+)
+
+# Path prefixes whose sub-pages should get the longer cache.
+LONG_CACHE_PREFIXES = (
+    "/engage/",
+    "/tutorials/",
+    "/community/docs/",
+    "/community/uwn/",
+)
+
+
+def _should_long_cache(path):
+    return path in LONG_CACHE_EXACT or path.startswith(LONG_CACHE_PREFIXES)
+
+
+def _long_cache_seconds(path):
+    if (
+        path == "/community" or path.startswith("/community/")
+    ) and not path.startswith("/community/docs"):
+        return COMMUNITY_CACHE_SECONDS
+    return LONG_CACHE_SECONDS
+
 
 def init_handlers(app):
     @app.after_request
@@ -57,6 +104,26 @@ def init_handlers(app):
         # Prevent XSS
         if flask.request.path.startswith("/certified"):
             response.headers["X-Frame-Options"] = "DENY"
+
+        # Longer cache for Discourse-backed pages. Skip previews and
+        # thank-you (personalised), and defer to any view's own headers.
+        path = flask.request.path
+        if (
+            response.status_code == 200
+            and flask.request.method == "GET"
+            and not flask.request.args.get("preview")
+            and not path.endswith("/thank-you")
+            and not response.cache_control.no_store
+            and not response.cache_control.no_cache
+            and not response.cache_control.private
+            and response.cache_control.max_age is None
+            and _should_long_cache(path)
+        ):
+            response.cache_control.public = True
+            response.cache_control.max_age = _long_cache_seconds(path)
+            response.cache_control._set_cache_value(
+                "stale-if-error", str(LONG_CACHE_STALE_IF_ERROR), int
+            )
 
         return response
 


### PR DESCRIPTION
## Done

- Cache Discourse-backed pages at the content-cache for 1 hour (max-age=3600) instead of the 60s flask-base default: /engage, /takeovers, /tutorials, /community/*, /openstack/install and their sub-pages. Reduces how often the CDN revalidates against the origin, which cuts Discourse calls.
- Community pages capped at max-age=300 — they degrade to an empty 200 on Discourse error, so a 1h cache would freeze a degraded page. /community/docs keeps the hour (it 503s instead).
- stale-if-error=3600 so a Discourse outage serves the last good copy for an hour, not 5 minutes.
- Guards: 200 + GET only, skips ?preview and /thank-you, defers to any view's own cache headers.

## QA

h() { curl -sD - -o /dev/null "$1" | grep -i '^cache-control:' | tr -d '\r'; }
DEMO=https://ubuntu-com-16567.demos.haus

Use GET (curl -sD -), not curl -I (HEAD) — the guard only applies to GET.
  - h "$DEMO/engage" → max-age=3600, ... stale-if-error=3600
- h "$DEMO/engage/virtualized-android-anbox-cloud" → max-age=3600
- h "$DEMO/community" → max-age=300 (shorter — degrade-safe)
- h "$DEMO/community/docs" → max-age=3600 (kept long)
- h "$DEMO/" → max-age=60 (unchanged default)
- A Discourse-backed page returning 503 must not show max-age=3600 (errors aren't long-cached)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

