### PR TITLE
Anonymous Discourse reads for tutorials

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -241,6 +241,16 @@ charmhub_discourse_api = DiscourseAPI(
     cache=None,  # caching disabled for raw-log testing
 )
 
+# Anonymous reads for public content. No key means these GET /t/{id}.json
+# reads don't count against the shared 60/min admin API bucket. Own
+# session — DiscourseAPI overwrites session.headers on authenticated
+# instances, which would otherwise leak the key onto a shared session.
+discourse_api_anon = DiscourseAPI(
+    base_url="https://discourse.ubuntu.com/",
+    session=requests.Session(),
+    cache=None,
+)
+
 # Web tribe websites custom search ID
 search_engine_id = "adb2397a224a1fe55"
 
@@ -915,7 +925,7 @@ app.add_url_rule(
 tutorials_path = "/tutorials"
 tutorials_docs = Tutorials(
     parser=TutorialParser(
-        api=discourse_api,
+        api=discourse_api_anon,
         index_topic_id=13611,
         url_prefix=tutorials_path,
     ),


### PR DESCRIPTION
## Done

- Route `tutorials_docs` through a keyless `discourse_api_anon` instance so `/tutorials`, `/tutorials.json`, and `/tutorials/<slug>` read Discourse anonymously and stop counting against the shared 60/min admin API bucket.
- Safe because `TutorialParser` only calls `get_topic` (plain `GET /t/{id}.json`, no Data Explorer) and the index topic 13611 is public.
- Dedicated `requests.Session()` so authenticated instances can't leak the key onto it.

**Testing only:** cache stays `cache=None` to match current prod — this PR isolates the tutorials anonymous-read change so it can be validated on its own.

## QA

- Open the [DEMO](https://ubuntu-com-16569.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- `/tutorials` loads and lists tutorials
- A few individual `/tutorials/<slug>` pages render
- `/tutorials.json` returns the tutorial list
- Tutorials' outbound `GET /t/...json` calls carry no `Api-Key` header and don't show in Discourse admin rate-limit logs

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

