### PR TITLE
Add new sitemap entry for landscape documentation

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -75,4 +75,7 @@
   <sitemap>
     <loc>https://ubuntu.com/docs/pebble/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/landscape/docs/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

- Added Landscape

## QA

I verified it's the correct location, sitemap exists at https://ubuntu.com/landscape/docs/doc-sitemap.xml 
