### PR TITLE
feat: discourse cache & ciruit breaker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-# TESTING canonicalwebteam.discourse#230 (7.7.1 breaker logging) — re-pin to ==7.7.1 before merge
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@feat/breaker-observability
+canonicalwebteam.discourse==7.7.1
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 canonicalwebteam.markdown-response==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse==7.6.1
+# TESTING canonicalwebteam.discourse#230 (7.7.1 breaker logging) — re-pin to ==7.7.1 before merge
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@feat/breaker-observability
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 canonicalwebteam.markdown-response==0.2.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -221,6 +221,7 @@ app.jinja_loader = loader
 
 session = requests.Session()
 charmhub_session = requests.Session()
+ubuntu_discourse_cache = ResponseCache(ttl=CACHE_TTL)
 
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
@@ -228,7 +229,7 @@ discourse_api = DiscourseAPI(
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
-    cache=ResponseCache(ttl=CACHE_TTL),
+    cache=ubuntu_discourse_cache,
 )
 
 charmhub_discourse_api = DiscourseAPI(
@@ -708,7 +709,7 @@ engage_pages_discourse_api = DiscourseAPI(
     get_topics_query_id=14,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
-    cache=ResponseCache(ttl=CACHE_TTL),
+    cache=ubuntu_discourse_cache,
 )
 takeovers_path = "/takeovers"
 discourse_takeovers = EngagePages(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -22,6 +22,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
     DiscourseAPI,
+    ResponseCache,
     DocParser,
     Docs,
     EngagePages,
@@ -42,6 +43,7 @@ from canonicalwebteam.form_generator import FormGenerator
 from canonicalwebteam.markdown_response import MarkdownResponse
 
 from webapp.certified.views import certified_routes
+from webapp.constants import CACHE_TTL
 from webapp.handlers import init_handlers
 from webapp.login import login_handler, logout, user_info
 from webapp.decorators import login_required
@@ -220,16 +222,13 @@ app.jinja_loader = loader
 session = requests.Session()
 charmhub_session = requests.Session()
 
-# TEST BRANCH: caching and the circuit breaker are disabled (cache=None)
-# so every request hits Discourse directly and every 429 shows in the
-# logs. Do not merge — revert to cache=ResponseCache(...) after testing.
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
     session=session,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
-    cache=None,  # caching disabled for raw-log testing
+    cache=ResponseCache(ttl=CACHE_TTL),
 )
 
 charmhub_discourse_api = DiscourseAPI(
@@ -238,7 +237,7 @@ charmhub_discourse_api = DiscourseAPI(
     api_key=CHARMHUB_DISCOURSE_API_KEY,
     api_username=CHARMHUB_DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
-    cache=None,  # caching disabled for raw-log testing
+    cache=ResponseCache(ttl=CACHE_TTL),
 )
 
 # Anonymous reads for public Docs: no key means these GET /t/{id}.json
@@ -709,7 +708,7 @@ engage_pages_discourse_api = DiscourseAPI(
     get_topics_query_id=14,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
-    cache=None,  # caching disabled for raw-log testing
+    cache=ResponseCache(ttl=CACHE_TTL),
 )
 takeovers_path = "/takeovers"
 discourse_takeovers = EngagePages(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -765,7 +765,7 @@ def openstack_install():
     discourse_api = DiscourseAPI(
         base_url="https://discourse.ubuntu.com/",
         session=session,
-        cache=None,  # caching disabled for raw-log testing
+        cache=None,
     )
     openstack_install_parser = DocParser(
         api=discourse_api,


### PR DESCRIPTION
## Done

- re-enables Discourse response caching across the app (using a shared TTL constant)
This switches the authenticated discourse.ubuntu.com clients back to ResponseCache(ttl=CACHE_TTL)

## QA

- Open the [DEMO](https://ubuntu-com-16574.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

