### PR TITLE
fix: restore Discourse response caching and cut engage tag-query load

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,6 +31,7 @@ from canonicalwebteam.discourse import (
     Category,
     EventsParser,
     Events,
+    ResponseCache,
 )
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.flask_base.env import get_flask_env
@@ -220,16 +221,17 @@ app.jinja_loader = loader
 session = requests.Session()
 charmhub_session = requests.Session()
 
-# TEST BRANCH: caching and the circuit breaker are disabled (cache=None)
-# so every request hits Discourse directly and every 429 shows in the
-# logs. Do not merge — revert to cache=ResponseCache(...) after testing.
+# Each DiscourseAPI gets its own ResponseCache (one cache per API key,
+# i.e. one rate-limit quota): responses are cached per worker, stale data
+# is served while Discourse errors, and a 429 opens that instance's
+# circuit breaker so we stop hammering Discourse until it recovers.
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
     session=session,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
-    cache=None,  # caching disabled for raw-log testing
+    cache=ResponseCache(ttl=600),
 )
 
 charmhub_discourse_api = DiscourseAPI(
@@ -238,7 +240,7 @@ charmhub_discourse_api = DiscourseAPI(
     api_key=CHARMHUB_DISCOURSE_API_KEY,
     api_username=CHARMHUB_DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
-    cache=None,  # caching disabled for raw-log testing
+    cache=ResponseCache(ttl=600),
 )
 
 # Anonymous reads for public Docs: no key means these GET /t/{id}.json
@@ -709,7 +711,7 @@ engage_pages_discourse_api = DiscourseAPI(
     get_topics_query_id=14,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
-    cache=None,  # caching disabled for raw-log testing
+    cache=ResponseCache(ttl=300),
 )
 takeovers_path = "/takeovers"
 discourse_takeovers = EngagePages(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -432,6 +432,38 @@ def build_tutorials_index(session, tutorials_docs):
     return tutorials_index
 
 
+_engage_tags_cache = {}
+_ENGAGE_TAGS_TTL = 3600
+
+
+def _get_cached_engage_tags(engage_docs):
+    """
+    engage_docs.get_engage_pages_tags() is a full, unpaginated Discourse
+    query (the client's own docstring calls it "not performant") used
+    only to populate the tag filter dropdown. Tag lists change rarely,
+    so cache it far longer than the per-request listing data to avoid
+    doubling the Discourse calls made by every /engage request.
+    """
+    now = time.monotonic()
+    cached = _engage_tags_cache.get(engage_docs.category_id)
+    if cached and now - cached[0] < _ENGAGE_TAGS_TTL:
+        return cached[1]
+
+    try:
+        tags_list = engage_docs.get_engage_pages_tags()
+    except (RateLimitedError, ServiceUnavailable, RequestException):
+        if cached:
+            # Discourse is unavailable and the tag list is stale but
+            # harmless to keep showing; re-stamp so we don't retry on
+            # every request while the outage continues.
+            _engage_tags_cache[engage_docs.category_id] = (now, cached[1])
+            return cached[1]
+        raise
+
+    _engage_tags_cache[engage_docs.category_id] = (now, tags_list)
+    return tags_list
+
+
 def build_engage_index(engage_docs):
     def engage_index():
         page = flask.request.args.get("page", default=1, type=int)
@@ -476,7 +508,7 @@ def build_engage_index(engage_docs):
             "Form",
             "Event",
         ]
-        tags_list = engage_docs.get_engage_pages_tags()
+        tags_list = _get_cached_engage_tags(engage_docs)
         tags_list = sorted(set(tags_list), key=str.lower)
         total_pages = math.ceil(current_total / limit)
 


### PR DESCRIPTION
## Done

- Restored `cache=ResponseCache(...)` on the `DiscourseAPI` instances in `webapp/app.py`. A prior "do not merge" debug commit (#16564) left `cache=None` on all of them on `main`, which disabled the caching/circuit-breaker layer and turned any Discourse 429 into an unhandled 500 (e.g. `/engage?page=4`). With the cache restored, a 429 is now routed through the existing global `RateLimitedError` handler and returns a clean 503 with `Retry-After` instead.
- Added a longer-lived (1 hour) cache for the `/engage` tag-filter list in `webapp/views.py`. `get_engage_pages_tags()` is a separate, unpaginated Discourse query — the client library's own docstring calls it "not performant" — and it was being refetched on every single `/engage` request alongside the main paginated listing, roughly doubling Discourse calls on the highest-traffic engage view. Tag lists change rarely, so a much longer TTL is safe, and it falls back to the last known list on a Discourse outage rather than failing the page.

## QA

- Run the site with `dotrun`
- Visit `http://0.0.0.0:8001/engage`, a paginated view (`/engage?page=2`), and a single engage page (e.g. `/engage/<slug>`) — all should load normally
- To exercise the failure path: simulate a Discourse 429 (or just hammer `/engage` a few times in quick succession against the real Discourse instance) and confirm you get a styled 503 page with a `Retry-After` header instead of a raw 500 traceback

## Issue / Card

Fixes the regression introduced by #16564 leaving debug `cache=None` on `main`.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)