### PR TITLE
Add Ubuntu Core as an alternative to Ubuntu Server under Alt Downloads

### DIFF
--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -254,7 +254,7 @@
             </div>
             <div class="col-6 col-medium-3">
               <p>
-                As an alternative, you may consider running your workloads encapsulated in containers (such as <a href="https://canonical.com/lxd">LXD</a>) inside Ubuntu Core, as a strictly confined and immutable Linux host OS.
+                As an alternative, you may consider running your workloads encapsulated in containers (such as <a href="https://canonical.com/lxd">LXD</a>) inside <a href="https://ubuntu.com/core">Ubuntu Core</a>, as a strictly confined and immutable Linux host OS.
               </p>
             </div>
           </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -245,6 +245,19 @@
               </p>
             </div>
           </div>
+          <hr class="p-rule" />
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">
+                <a href="/download/core">Ubuntu Core&nbsp;&rsaquo;</a>
+              </h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                As an alternative, you may consider running your workloads encapsulated in containers (such as <a href="https://canonical.com/lxd">LXD</a>) inside Ubuntu Core, as a strictly confined and immutable Linux host OS.
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -254,7 +254,7 @@
             </div>
             <div class="col-6 col-medium-3">
               <p>
-                As an alternative, you may consider running your workloads encapsulated in containers (such as <a href="https://canonical.com/lxd">LXD</a>) inside <a href="https://ubuntu.com/core">Ubuntu Core</a>, as a strictly confined and immutable Linux host OS.
+                As an alternative, you may consider running your workloads encapsulated in containers (such as <a href="https://canonical.com/lxd">LXD</a>) inside <a href="/core">Ubuntu Core</a>, as a strictly confined and immutable Linux host OS.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Add Ubuntu Core as an alternative to Ubuntu Server under Alt Downloads ([copydoc](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit?tab=t.0#heading=h.rukg8oj5d0jp).)

## QA

- Open the [DEMO](https://ubuntu-com-16578.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

