### PR TITLE
feat: Discourse API 429 fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@discourse-retry-429
+canonicalwebteam.discourse==7.8.0
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 canonicalwebteam.markdown-response==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse==7.7.1
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@discourse-retry-429
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10
 canonicalwebteam.markdown-response==0.2.0


### PR DESCRIPTION
## Done
- Added 10 retries when the discourse API returns 429
- Increment wait time by 1s each retry to prevent overload.

## QA
- Run this branch locally.
- Place `Discourse API` from Bitwarden in `.env.local`
- Run `curl -H 'Cache-Control: no-cache' localhost:8001/engage` and wait and see if you get a 500 error (we are testing if it will work when there's no caching)
- Do this for a few other pages that use the discourse API as well. (refer to /engage on the u.com prod site)
  - `curl -H 'Cache-Control: no-cache' localhost:8001/engage?page=35`
  - `curl -H 'Cache-Control: no-cache' localhost:8001/engage?page=20`
- Randomly sample and redo the above step for a few different pages.
- They should return 200s

