### PR TITLE
fix: extend cache TTL for Discourse-backed content pages

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -37,7 +37,7 @@ from canonicalwebteam.flask_base.env import get_flask_env
 
 # Cache Discourse-backed pages longer than the 60s flask-base default;
 # our after_request runs first so this max-age wins.
-LONG_CACHE_SECONDS = 3600  # 1 hour
+LONG_CACHE_SECONDS = 10800  # 3 hours
 
 # Community pages degrade to an empty 200 on Discourse error, so cache
 # them shorter to avoid freezing a degraded page (docs 503 instead).
@@ -59,6 +59,10 @@ LONG_CACHE_EXACT = frozenset(
         "/community/circles",
         "/community/uwn",
         "/openstack/install",
+        "/ceph/docs",
+        "/openstack/docs",
+        "/security/livepatch/docs",
+        "/security/certifications/docs",
     }
 )
 
@@ -68,6 +72,10 @@ LONG_CACHE_PREFIXES = (
     "/tutorials/",
     "/community/docs/",
     "/community/uwn/",
+    "/ceph/docs/",
+    "/openstack/docs/",
+    "/security/livepatch/docs/",
+    "/security/certifications/docs/",
 )
 
 
@@ -87,7 +95,7 @@ def init_handlers(app):
     @app.after_request
     def cache_headers(response):
         """
-        Set cache expiry to 60 seconds for homepage and blog page
+        Adjust Cache-Control for specific routes
         """
 
         disable_cache_on = (
@@ -113,6 +121,9 @@ def init_handlers(app):
             and flask.request.method == "GET"
             and not flask.request.args.get("preview")
             and not path.endswith("/thank-you")
+            # Docs blueprints expose Google-backed search under their
+            # prefix (e.g. /ceph/docs/search); those are not Discourse.
+            and not path.endswith("/search")
             and not response.cache_control.no_store
             and not response.cache_control.no_cache
             and not response.cache_control.private


### PR DESCRIPTION
## Done
- Extended the discourse content-cache max-age to 3 hours
- Added additional discourse routes

## QA
- This can only be QAed after the PR is merged

