### PR TITLE
Add additional sitemaps to sitemap_index.xml

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -84,4 +84,28 @@
   <sitemap>
     <loc>https://ubuntu.com/landscape/docs/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/cloud/public-cloud/docs/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/aws/docs/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/azure/docs/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/gcp/docs/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/ibm/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/oci-registries/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/oracle/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/public-images/doc-sitemap.xml</loc>
+  </sitemap> 
 </sitemapindex>


### PR DESCRIPTION
## Done

Added sitemaps for eight public cloud related documentation sets.

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
