### PR TITLE
fix: improve CVE content readability

### DIFF
--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -250,7 +250,7 @@
             <h2 id="description" class="section-heading">Description</h2>
           {% endif %}
 
-          {% if cve.description %}<p>{{ cve.description }}</p>{% endif %}
+          {% if cve.description %}<p style="white-space: pre-wrap;">{{ cve.description | trim }}</p>{% endif %}
 
           {% if cve.ubuntu_description %}
             <h3>From the Ubuntu Security Team</h3>


### PR DESCRIPTION
## Done

- Improve readability by rendering pre-included new lines.

## QA

### Before
- Visit https://ubuntu.com/security/CVE-2023-52910#description
- Verify description doesn't render pre-included new lines

### After
- Visit https://ubuntu-com-16589.demos.haus/security/CVE-2023-52910
- Verify description renders pre-included new lines

## Issue / Card

Fixes [WD-37432](https://warthogs.atlassian.net/browse/WD-37432)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-37432]: https://warthogs.atlassian.net/browse/WD-37432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ