### PR TITLE
chore: redirect old Landscape tutorial

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1161,6 +1161,7 @@ tutorials/electron-kiosk/?: https://canonical.com/mir/docs/make-a-secure-ubuntu-
 tutorials/get-started-with-edgex-as-snaps?: /internet-of-things
 tutorials/how-to-install-adguard-home-raspberry-pi/?: /appliance/adguard/raspberry-pi
 tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc/?: /appliance/nextcloud/intel-nuc
+tutorials/blocking-software-package-installation-with-landscape/?: /landscape/docs
 
 # Image builder
 build: /core/build

--- a/test-links.yaml
+++ b/test-links.yaml
@@ -24,7 +24,7 @@ links:
   - name: Tutorials
     url: https://ubuntu.com/tutorials
   - name: Specific tutorial
-    url: https://ubuntu.com/tutorials/blocking-software-package-installation-with-landscape#1-overview
+    url: https://ubuntu.com/tutorials/install-and-configure-samba#1-overview
   - name: Download Desktop
     url: https://ubuntu.com/download/desktop
   - name: Pricing Desktop


### PR DESCRIPTION
## Done

- Added a redirect for `tutorials/blocking-software-package-installation-with-landscape` to `https://documentation.ubuntu.com/landscape/`

## QA

- Open the [DEMO](https://ubuntu-com-16590.demos.haus/tutorials/blocking-software-package-installation-with-landscape)
- Verify it gets redirected to https://documentation.ubuntu.com/landscape/


## Issue / Card

Fixes [WD-37401](https://warthogs.atlassian.net/browse/WD-37401)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-37401]: https://warthogs.atlassian.net/browse/WD-37401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ