### PR TITLE
BAU: Copyupdate /download/qualcomm-iot

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -72,7 +72,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a
-            href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-252/Integrate-and-flash-software.html?product=1601111740076074&facet=Ubuntu%20quickstart"
+            href="https://dragonwingdocs.qualcomm.com/Ubuntu/devices/iq9075-evk/update-software/overview"
             title="Read image installation instructions of Ubuntu 24.04 for IQ-9075">image installation instructions</a>
         </li>
         <li class="p-list__item">

--- a/templates/download/qualcomm-iot/tabs/evaluation-kit2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit2-tab.html
@@ -72,7 +72,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for Qualcomm IQ-8275 Evaluation Kit (EVK) <a
-          href="https://docs.qualcomm.com/doc/80-90441-351/topic/integrate-and-flash-software.html"
+          href="https://dragonwingdocs.qualcomm.com/Ubuntu/devices/iq8275-evk/update-software/overview"
           title="Read image installation instructions of Ubuntu 24.04 for IQ-8275">image installation instructions</a>.
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

- Updated /download/qualcomm-iot (image installation instruction links for the Qualcomm IQ-9075 and IQ-8275 Evaluation Kits now point to the DragonWing docs).

## QA

- Open the [DEMO](https://ubuntu-com-16592.demos.haus/download/qualcomm-iot)
- [Copydoc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-37732](https://warthogs.atlassian.net/browse/WD-37732) https://warthogs.atlassian.net/browse/WD-37732


[WD-37732]: https://warthogs.atlassian.net/browse/WD-37732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ