### PR TITLE
templates/sitemap_index.xml: add kernel docs to sitemaps list

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -107,5 +107,8 @@
   </sitemap>
   <sitemap>
     <loc>https://ubuntu.com/docs/public-images/doc-sitemap.xml</loc>
-  </sitemap> 
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/kernel/docs/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Added sitemaps for kernel docs for ubuntu.com.

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
