### PR TITLE
feat(WD-37741): add framework logo with custom style properties

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1424,6 +1424,28 @@ $color-link-dark: #69c !default;
   }
 }
 
+// Override height for very wide logos to prevent horizontal overflow
+.p-logo-section__item.is-wide {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 4.5rem;
+  vertical-align: bottom;
+  width: fit-content;
+
+  @media (min-width: $breakpoint-small) {
+    height: 6.5rem;
+  }
+
+  .p-logo-section__logo {
+    height: 0.8rem;
+
+    @media (min-width: $breakpoint-small) {
+      height: 1rem;
+    }
+  }
+}
+
 // XXX: pete f: vanilla issue here -
 // https://github.com/canonical/vanilla-framework/issues/4877
 .p-divider {

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -292,11 +292,21 @@
                             attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
-            <div class="p-logo-section__item u-no-margin--right">
+            <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/3b24973b-lenovo-logo.png",
                             alt="Lenovo",
                             width="169",
                             height="256",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"}) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item is-wide u-no-margin--right">
+              {{ image(url="https://assets.ubuntu.com/v1/c77b39e1-framework_logo_black.png",
+                            alt="Framework",
+                            width="228",
+                            height="30",
                             hi_def=True,
                             loading="lazy",
                             attrs={"class": "p-logo-section__logo"}) | safe

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -409,6 +409,16 @@
                             attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
+            <div class="p-logo-section__item is-wide u-no-margin--right">
+              {{ image(url="https://assets.ubuntu.com/v1/c77b39e1-framework_logo_black.png",
+                            alt="Framework",
+                            width="228",
+                            height="30",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"}) | safe
+              }}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Added Framework logo
- Added custom class for super-wide logos. Without it the logo inherits forced height property that results in it being super long and outgrowing parent component

## QA

- Open the [DEMO](https://ubuntu-com-16595.demos.haus//desktop)
- Validate that in the "High performance on your favourite hardware" section, there is Framework logo, it fits well and behaves well on window resize

## Issue / Card

[WD-37741](https://warthogs.atlassian.net/browse/WD-37741)

## Screenshots
<img width="959" height="419" alt="image" src="https://github.com/user-attachments/assets/385d009c-5e0c-4c12-917c-8f87df6b580e" />






[WD-37741]: https://warthogs.atlassian.net/browse/WD-37741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
