### PR TITLE
feat: add cronjob to verify dynamically generated sitemaps

### DIFF
--- a/.github/workflows/dynamic-sitemaps.yml
+++ b/.github/workflows/dynamic-sitemaps.yml
@@ -44,3 +44,9 @@ jobs:
             --retry 3 \
             --retry-delay 10 \
             --retry-all-errors
+
+      - name: Send message on failure
+        env:
+          BOT_URL: ${{ secrets.BOT_URL }}
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" $BOT_URL?room=web-alerts

--- a/.github/workflows/dynamic-sitemaps.yml
+++ b/.github/workflows/dynamic-sitemaps.yml
@@ -1,10 +1,10 @@
 name: Verify dynamically generated sitemaps for ubuntu.com
 
 on:
-  # schedule:
-  #   - cron: "0 7 * * 1" # every Monday at 07:00 UTC
+  schedule:
+    - cron: "0 7 * * 1" # every Monday at 07:00 UTC
 
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/dynamic-sitemaps.yml
+++ b/.github/workflows/dynamic-sitemaps.yml
@@ -1,0 +1,46 @@
+name: Verify dynamically generated sitemaps for ubuntu.com
+
+on:
+  # schedule:
+  #   - cron: "0 7 * * 1" # every Monday at 07:00 UTC
+
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.extract_targets.outputs.targets }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Extract targets
+        id: extract_targets
+        run: |
+          echo "targets=$(yq -o=json -I=0 '.' dynamic-sitemaps.yaml)" >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.setup.outputs.targets) }}
+    steps:
+      - name: Verify sitemap for ${{ env.TARGET }}
+        env:
+          TARGET: ${{ matrix.target }}
+        if: env.TARGET != 'templates'
+        run: |
+          curl --fail-with-body -X GET "https://ubuntu.com/$TARGET/sitemap.xml" \
+            --connect-timeout 30 \
+            --max-time 300 \
+            --retry 3 \
+            --retry-delay 10 \
+            --retry-all-errors

--- a/dynamic-sitemaps.yaml
+++ b/dynamic-sitemaps.yaml
@@ -1,0 +1,15 @@
+# Sitemaps that are already generated and don't need to be updated.
+# Can be seen on sitemap_index.xml
+- templates
+- tutorials
+- engage
+- ceph/docs
+- community/docs
+- openstack/docs
+- blog
+- security/notices
+- security/cves
+- security/vulnerabilities
+- security/certifications/docs
+- security/livepatch/docs
+- robotics/docs

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -51,3 +51,4 @@ parts:
       - flask/app/secondary-navigation.yaml
       - flask/app/appliances.yaml
       - flask/app/subscriptions.yaml
+      - flask/app/dynamic-sitemaps.yaml

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -173,21 +173,8 @@ WORDPRESS_APPLICATION_PASSWORD = get_flask_env(
 
 # Sitemaps that are already generated and don't need to be updated.
 # Can be seen on sitemap_index.xml
-DYNAMIC_SITEMAPS = [
-    "templates",
-    "tutorials",
-    "engage",
-    "ceph/docs",
-    "community/docs",
-    "openstack/docs",
-    "blog",
-    "security/notices",
-    "security/cves",
-    "security/vulnerabilities",
-    "security/certifications/docs",
-    "security/livepatch/docs",
-    "robotics/docs",
-]
+with open("dynamic-sitemaps.yaml") as sitemaps_file:
+    DYNAMIC_SITEMAPS = yaml.load(sitemaps_file.read(), Loader=yaml.FullLoader)
 
 # Set up application
 # ===


### PR DESCRIPTION
## Done

- Added workflow that runs weekly to verify dynamically generated sitemaps

## QA

- Verify all [sitemap checks](https://github.com/canonical/ubuntu.com/actions/runs/29480426607/job/87562702596?pr=16596) are passed!

<img width="320" height="482" alt="image" src="https://github.com/user-attachments/assets/98963baf-17e9-4b6a-99b8-c39f4a5abb46" />


## Issue / Card

Fixes [WD-37362](https://warthogs.atlassian.net/browse/WD-37362)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-37362]: https://warthogs.atlassian.net/browse/WD-37362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ