### PR TITLE
Fix broken Article JSON-LD schema in blog article template

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -32,29 +32,29 @@
   {% endif %}
   <script type="application/ld+json">
     {
-      "@context": "http://schema.org",
-      "@id": "https://ubuntu.com/#article",
+      "@context": "https://schema.org",
+      "@id": "{{ self.canonical_url() }}",
       "@type": "Article",
-      "name": "{{ article.title.renderered|safe }}",
+      "name": "{{ article.title.rendered|safe }}",
       "headline": "{{ article.excerpt.raw }}",
       "author": {
         "@type": "Person",
         "name": "{{ article.author.name }}"
       },
       "datePublished": "{{ article.date_gmt }}",
-      {
-        %
-        if article.image and article.image.source_url %
-      }
+      "dateModified": "{{ article.modified_gmt }}",
+      {% if article.image and article.image.source_url %}
       "image": "{{ article.image.source_url }}",
-      {
-        %
-        endif %
-      }
-      "url": "{{ request.url }}",
+      {% endif %}
+      "url": "{{ self.canonical_url() }}",
       "publisher": {
         "@type": "Organization",
-        "name": "Ubuntu"
+        "@id": "https://ubuntu.com/#organization",
+        "name": "Ubuntu",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://assets.ubuntu.com/v1/c55060fd-COF%20android-chrome-512x512.png"
+        }
       }
     }
   </script>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -48,7 +48,13 @@
       {% endif %}
       "url": "{{ request.url }}",
       "publisher": {
-        "@id": "https://ubuntu.com/#organization"
+        "@type": "Organization",
+        "@id": "https://ubuntu.com/#organization",
+        "name": "Ubuntu",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://assets.ubuntu.com/v1/c55060fd-COF%20android-chrome-512x512.png"
+        }
       }
     }
   </script>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -33,7 +33,7 @@
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@id": "{{ self.canonical_url() }}",
+      "@id": "{{ request.url }}",
       "@type": "Article",
       "name": "{{ article.title.rendered|safe }}",
       "headline": "{{ article.excerpt.raw }}",
@@ -46,15 +46,9 @@
       {% if article.image and article.image.source_url %}
       "image": "{{ article.image.source_url }}",
       {% endif %}
-      "url": "{{ self.canonical_url() }}",
+      "url": "{{ request.url }}",
       "publisher": {
-        "@type": "Organization",
-        "@id": "https://ubuntu.com/#organization",
-        "name": "Ubuntu",
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://assets.ubuntu.com/v1/c55060fd-COF%20android-chrome-512x512.png"
-        }
+        "@id": "https://ubuntu.com/#organization"
       }
     }
   </script>


### PR DESCRIPTION
## Done
- Fix broken json-ld on article pages

## QA
- VIsit the live ubuntu.com/blog/\<article\> pages
- Open console log -> json-ld parsing error
- Visit the demo and go to /blog/\<article\> pages
- No json-ld parsing error

## Issue / Card
https://warthogs.atlassian.net/browse/WD-37776
