### PR TITLE
konf/site.yaml: raise ingress proxy buffer size to 16k for large CSP headers

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -540,7 +540,17 @@ production:
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_live_68aXqowUeX574aGsVck8eiIE
 
+  # Raise nginx's response-header buffer above the 4k default. The app emits a
+  # large Content-Security-Policy header (built from the CSP dict in
+  # webapp/constants.py, whose connect-src is expanded by the live-fetched
+  # Google supported-domains list). Combined with the other security headers
+  # and the /login session cookie it overflows the default proxy_buffer_size,
+  # so nginx returns 502 with "upstream sent too big header". proxy_buffers
+  # must be raised alongside proxy_buffer_size to keep the implicit
+  # proxy_busy_buffers_size within nginx's limits.
   nginxConfigurationSnippet: |
+    proxy_buffer_size 16k;
+    proxy_buffers 4 16k;
     if ($host = 'apps.ubuntu.com' ) {
       rewrite ^ https://snapcraft.io/ permanent;
     }
@@ -1165,6 +1175,8 @@ staging:
           value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
   nginxConfigurationSnippet: |
+    proxy_buffer_size 16k;
+    proxy_buffers 4 16k;
     if ($host = 'staging.cloud.ubuntu.com' ) {
       rewrite ^ https://staging.ubuntu.com/public-cloud$request_uri? permanent;
     }

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1217,15 +1217,6 @@ staging:
 
 demo:
   useProxy: false
-
-  # Demos hit the same 4k proxy_buffer_size overflow as production (see the
-  # production snippet above). konf strips the inherited staging snippets for
-  # demos (they contain staging host redirects), so the buffer directives must
-  # be declared here explicitly.
-  nginxConfigurationSnippet: |
-    proxy_buffer_size 16k;
-    proxy_buffers 4 16k;
-
   env:
     - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -178,15 +178,11 @@ env:
 
 memoryLimit: 512Mi
 
-# Raise nginx's response-header buffer above the 4k default: the app's
-# Content-Security-Policy header (webapp/constants.py, ~190 Google domains in
-# connect-src) plus the /login session cookie overflows it, causing 502s
-# ("upstream sent too big header"). Top-level so it applies to production,
-# staging and demos. Requires konf >= the release with
+# Our CSP header (~4KB, webapp/constants.py) plus /login's session cookie
+# overflows nginx's 4k header buffer → 502. Needs konf with
 # https://github.com/canonical/konf/pull/53; older konf ignores the key.
-# Do NOT set proxy_buffer_size via the nginx snippets instead — ingress-nginx
-# already renders that directive per location, so a snippet copy is a
-# duplicate-directive error that blocks all config reloads on the cluster.
+# Never set proxy_buffer_size via the snippets below: ingress-nginx already
+# renders it per location, and the duplicate blocks all ingress reloads.
 nginxProxyBufferSize: 16k
 
 extraHosts:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1217,6 +1217,15 @@ staging:
 
 demo:
   useProxy: false
+
+  # Demos hit the same 4k proxy_buffer_size overflow as production (see the
+  # production snippet above). konf strips the inherited staging snippets for
+  # demos (they contain staging host redirects), so the buffer directives must
+  # be declared here explicitly.
+  nginxConfigurationSnippet: |
+    proxy_buffer_size 16k;
+    proxy_buffers 4 16k;
+
   env:
     - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -540,17 +540,7 @@ production:
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_live_68aXqowUeX574aGsVck8eiIE
 
-  # Raise nginx's response-header buffer above the 4k default. The app emits a
-  # large Content-Security-Policy header (built from the CSP dict in
-  # webapp/constants.py, whose connect-src is expanded by the live-fetched
-  # Google supported-domains list). Combined with the other security headers
-  # and the /login session cookie it overflows the default proxy_buffer_size,
-  # so nginx returns 502 with "upstream sent too big header". proxy_buffers
-  # must be raised alongside proxy_buffer_size to keep the implicit
-  # proxy_busy_buffers_size within nginx's limits.
   nginxConfigurationSnippet: |
-    proxy_buffer_size 16k;
-    proxy_buffers 4 16k;
     if ($host = 'apps.ubuntu.com' ) {
       rewrite ^ https://snapcraft.io/ permanent;
     }
@@ -1175,8 +1165,6 @@ staging:
           value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
   nginxConfigurationSnippet: |
-    proxy_buffer_size 16k;
-    proxy_buffers 4 16k;
     if ($host = 'staging.cloud.ubuntu.com' ) {
       rewrite ^ https://staging.ubuntu.com/public-cloud$request_uri? permanent;
     }

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -178,6 +178,17 @@ env:
 
 memoryLimit: 512Mi
 
+# Raise nginx's response-header buffer above the 4k default: the app's
+# Content-Security-Policy header (webapp/constants.py, ~190 Google domains in
+# connect-src) plus the /login session cookie overflows it, causing 502s
+# ("upstream sent too big header"). Top-level so it applies to production,
+# staging and demos. Requires konf >= the release with
+# https://github.com/canonical/konf/pull/53; older konf ignores the key.
+# Do NOT set proxy_buffer_size via the nginx snippets instead — ingress-nginx
+# already renders that directive per location, so a snippet copy is a
+# duplicate-directive error that blocks all config reloads on the cluster.
+nginxProxyBufferSize: 16k
+
 extraHosts:
   - domain: ubuntu.net
   - domain: tutorials.ubuntu.com


### PR DESCRIPTION
## Done

- Set top-level `nginxProxyBufferSize: 16k` in `konf/site.yaml`, rendered by konf as the `nginx.ingress.kubernetes.io/proxy-buffer-size` annotation for production, staging and demos.
- Why: the app's Content-Security-Policy header (built from `webapp/constants.py`, ~190 Google domains in `connect-src`) plus the `/login` session cookie exceeds nginx's default 4k buffer, so `/login` returned 502 ("upstream sent too big header") on production and on PR demos. Production is currently kept alive by a manual `kubectl annotate`; this puts the same annotation in code.
- ⚠️ Depends on canonical/konf#53 (adds the key) reaching the konf snap.
- The annotation is the only per-ingress mechanism: putting `proxy_buffer_size` in the nginx snippets duplicates the directive ingress-nginx already renders per location, which is a fatal nginx error that blocks all ingress config reloads on the cluster (verified the hard way on the demos cluster — since reverted).

## QA

- CI `validate-deploy` passes with current konf (key ignored) — no rendering change yet.
- With patched konf: `konf production konf/site.yaml` shows `nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"` on the Ingress.
- Check that https://ubuntu-com-16603.demos.haus/login works

## Issue / Card

Fixes # [WD-37800](https://warthogs.atlassian.net/browse/WD-37800)

## Screenshots

N/A — infrastructure config only.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37800]: https://warthogs.atlassian.net/browse/WD-37800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ