### PR TITLE
Add Ubuntu Desktop sitemaps for LTS releases

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -49,6 +49,12 @@
     <loc>https://ubuntu.com/desktop/docs/en/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://ubuntu.com/desktop/docs/en/26.04/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/desktop/docs/en/24.04/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://ubuntu.com/workshop/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
The `templates/sitemap_index.xml` file previously only included the `latest` version of the Ubuntu Desktop docs sitemap. Since the policy is to include all supported releases, I'm also adding the 26.04 and 24.04 sitemaps.