### PR TITLE
Add Snapcraft and Imagecraft sitemaps

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -118,6 +118,9 @@
     <loc>https://ubuntu.com/kernel/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://ubuntu.com/docs/imagecraft/latest/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://ubuntu.com/docs/snapcraft/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -117,4 +117,16 @@
   <sitemap>
     <loc>https://ubuntu.com/kernel/docs/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/snapcraft/latest/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/snapcraft/9/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/snapcraft/8/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/snapcraft/7/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Add the Snapcraft and Imagecraft documentation sitemaps to the `templates/sitemap_index.xml` file. These docs are now hosted at https://ubuntu.com/docs/snapcraft and https://ubuntu.com/docs/imagecraft, respectively.
