### PR TITLE
feat: dynamically generate ubuntu.com/robotics/docs/sitemap.xml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1251,6 +1251,7 @@ robotics/docs/application-orchestration/?: "https://canonical-robotics.readthedo
 robotics/docs/vcstool-and-rosinstall-file/?: "https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/snaps/vcstool-and-rosinstall-file/"
 robotics/docs/debug-the-build-of-a-snap/?: "https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/snaps/debug-the-build-of-a-snap/"
 robotics/docs/debug-a-snap-application/?: "https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/snaps/debug-a-snap-application/"
+robotics/docs/(?!sitemap\.xml)(?P<path>.*)/?: "https://canonical-robotics.readthedocs-hosted.com/en/latest/{path}"
 
 # Credentials redirects
 credentials/?: "https://canonical.com/academy"

--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -37,6 +37,9 @@
     <loc>https://ubuntu.com/security/livepatch/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://ubuntu.com/robotics/docs/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://ubuntu.com/internet-of-things/appstore/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,7 +1,7 @@
 import unittest
 import re
 import os
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import xml.etree.ElementTree as ET
 from webapp.app import app
 from webapp.views import build_sitemap_tree
@@ -168,6 +168,46 @@ class TestSitemap(unittest.TestCase):
         response = self.client.get("/sitemap_tree.xml")
         self.assertEqual(response.status_code, 503)
         mock_generate.assert_called_once()
+
+    @patch("webapp.views.session.get")
+    def test_robotics_docs_sitemap(self, mock_get):
+        """
+        Check that /robotics/docs/sitemap.xml rewrites the upstream
+        Read the Docs URLs, strips the stylesheet declaration and returns
+        a valid XML response.
+        """
+        upstream_xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<?xml-stylesheet type="text/xsl" href="sitemap.xsl"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            "<url><loc>"
+            "https://canonical-robotics.readthedocs-hosted.com/en/latest/"
+            "getting-started.html"
+            "</loc></url>"
+            "</urlset>"
+        )
+        mock_response = MagicMock()
+        mock_response.text = upstream_xml
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        response = self.client.get("/robotics/docs/sitemap.xml")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/xml")
+
+        body = response.data.decode("utf-8")
+        self.assertIn(
+            "https://ubuntu.com/robotics/docs/getting-started.html", body
+        )
+        self.assertNotIn("canonical-robotics.readthedocs-hosted.com", body)
+        self.assertNotIn("xml-stylesheet", body)
+
+        mock_get.assert_called_once_with(
+            "https://canonical-robotics.readthedocs-hosted.com/"
+            "en/latest/sitemap.xml",
+            timeout=10,
+        )
 
 
 if __name__ == "__main__":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -118,6 +118,7 @@ from webapp.views import (
     BlogRedirects,
     BlogSitemapIndex,
     BlogSitemapPage,
+    RoboticsDocsSitemapIndex,
     account_query,
     append_utms_cookie_to_canonical_links,
     appliance_install,
@@ -1335,6 +1336,10 @@ app.add_url_rule(
     methods=["GET", "POST"],
 )
 
+app.add_url_rule(
+    "/robotics/docs/sitemap.xml",
+    view_func=RoboticsDocsSitemapIndex.as_view("robotics_docs_sitemap"),
+)
 
 # Create endpoints for testing environment only
 if app.config.get("TESTING") or os.getenv("TESTING") or app.debug:

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -15,7 +15,6 @@ import dateutil.parser
 from slugify import slugify
 from canonicalwebteam.http import CachedSession
 
-
 logger = logging.getLogger(__name__)
 
 api_session = CachedSession(fallback_cache_duration=3600)

--- a/webapp/security/helpers.py
+++ b/webapp/security/helpers.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 import re
 
-
 """
 Return the summarized status for a CVE
 """

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -25,7 +25,6 @@ from webapp.security.helpers import (
     get_attention_banner,
 )
 
-
 markdown_parser = Markdown(
     hard_wrap=True, parse_block_html=True, parse_inline_html=True
 )
@@ -104,7 +103,7 @@ def notice(notice_id):
         ).strftime("%-d %B %Y")
 
     processed_instructions = notice["instructions"]
-    (attention_banner, instructions) = get_attention_banner(
+    attention_banner, instructions = get_attention_banner(
         processed_instructions
     )
     if attention_banner:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -39,6 +39,7 @@ from requests import Session
 from requests.exceptions import HTTPError, RequestException
 from werkzeug.exceptions import BadRequest, ServiceUnavailable
 from canonicalwebteam.flask_base.env import get_flask_env
+from flask.views import View
 
 # Local
 from webapp.login import user_info
@@ -936,6 +937,29 @@ class BlogSitemapPage(BlogView):
 
         xml = response.text.replace(
             "https://admin.insights.ubuntu.com/", "https://ubuntu.com/blog/"
+        )
+        xml = re.sub(r"<\?xml-stylesheet.*\?>", "", xml)
+
+        response = flask.make_response(xml)
+        response.headers["Content-Type"] = "application/xml"
+        return response
+
+
+class RoboticsDocsSitemapIndex(View):
+    def dispatch_request(self):
+        try:
+            response = session.get(
+                "https://canonical-robotics.readthedocs-hosted.com/"
+                "en/latest/sitemap.xml",
+                timeout=10,
+            )
+            response.raise_for_status()
+        except RequestException:
+            return flask.abort(502)
+
+        xml = response.text.replace(
+            "https://canonical-robotics.readthedocs-hosted.com/en/latest/",
+            "https://ubuntu.com/robotics/docs/",
         )
         xml = re.sub(r"<\?xml-stylesheet.*\?>", "", xml)
 


### PR DESCRIPTION
## Done

- Added dynamically generated sitemap for `/robotics/docs/sitemap.xml`

## QA

- Open the [DEMO](https://ubuntu-com-16612.demos.haus/robotics/docs/sitemap.xml)
- Alternatively, if the demo doesn't work, checkout the pull request and run locally using `dotrun`
- Visit http://localhost:8001/robotics/docs/sitemap.xml
- Verify the sitemap is loading up as expected
- Verify the redirects work as expected. ([Example](https://ubuntu-com-16612.demos.haus/robotics/docs/explanations/observability/components-explanations/))
- Verify the new entry is present on [sitemap.xml](https://ubuntu-com-16612.demos.haus/sitemap.xml)

## Issue / Card

Fixes [WD-37801](https://warthogs.atlassian.net/browse/WD-37801)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37801]: https://warthogs.atlassian.net/browse/WD-37801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
