### PR TITLE
fix: remove duplicated careers tab

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -62,16 +62,6 @@
                tabindex="0">Support</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle"
-              id="careers"
-              onmouseenter="fetchDropdown('/templates/navigation/careers', 'careers', event); this.onmouseenter = null;">
-            <a class="p-navigation__link"
-               role="menuitem"
-               href="/navigation#careers-navigation"
-               aria-controls="careers-content"
-               tabindex="0"
-               onfocus="fetchDropdown('/templates/navigation/careers', 'careers');">Careers</a>
-          </li>
-          <li class="p-navigation__item--dropdown-toggle"
               id="community"
               data-js-dropdown-url="/templates/navigation/community">
             <a class="p-navigation__link"
@@ -91,13 +81,12 @@
           </li>
           <li class="p-navigation__item--dropdown-toggle"
               id="careers"
-              onmouseenter="fetchDropdown('/templates/navigation/careers', 'careers', event); this.onmouseenter = null;">
+              data-js-dropdown-url="/templates/navigation/careers">
             <a class="p-navigation__link"
                role="menuitem"
                href="/navigation#careers-navigation"
                aria-controls="careers-content"
-               tabindex="0"
-               onfocus="fetchDropdown('/templates/navigation/careers', 'careers');">Careers</a>
+               tabindex="0">Careers</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle global-nav-mobile global-nav"
               role="menuitem"


### PR DESCRIPTION
## Done

- Remove duplicated careers tab
- Fix careers dropdown toggle

## QA

- Open the [DEMO](__DEMO_URL__)
- See that "Careers" tab matches [Design](https://www.figma.com/design/p0y7lHJ7edLIeSXM1qbpRZ/canonical.com---ubuntu.com---Meganav---Sites?node-id=1268-15144&m=dev)
- Click on "Careers" and see that dropdown toggle works

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
