### PR TITLE
chore: add early careers link in careers nav dropdown

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1080,3 +1080,5 @@ careers:
           url: https://canonical.com/careers/company-culture/diversity
         - title: Sustainability
           url: https://canonical.com/careers/company-culture/sustainability
+        - title: Early careers
+          url: https://canonical.com/careers/early-careers


### PR DESCRIPTION
## Done

- Added Early careers link to careers nav dropdown

## QA

- Open the [DEMO](https://ubuntu-com-16614.demos.haus/)
- Click "Careers" on top nav
- Find "Early careers"
- Verify it takes you to canonical.com/careers/early-careers

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

