### PR TITLE
[K8s Docs]: Update Charmed K8s redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -706,7 +706,7 @@ kubeflow/contact-us/?: "/ai/contact-us"
 kubeflow/thank-you/?: "/ai/thank-you"
 kubuntu/simple/oneiric/desktop/kubuntu-11\.10-desktop-amd64\.iso\.torrent/?: "https://kubuntu.org/download/"
 kubernetes/docs/?: "/kubernetes/charmed-k8s/docs"
-kubernetes/docs/(?!(latest|(release-|v)\d+\.\d+)?(?:/|$))(.*): /kubernetes/charmed-k8s/docs/\3
+kubernetes/docs/(?!(latest|(release-|v)\d+\.\d+)?(?:/|$))(?P<path>.*): "/kubernetes/charmed-k8s/docs/{path}"
 kubernetes/features/?: "/kubernetes/charmed-k8s"
 kubernetes/partners/?: "/kubernetes"
 kubernetes/cloud-native-kubernetes-usage-report-2021/?: "https://juju.is/cloud-native-kubernetes-usage-report-2021"

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -706,7 +706,7 @@ kubeflow/contact-us/?: "/ai/contact-us"
 kubeflow/thank-you/?: "/ai/thank-you"
 kubuntu/simple/oneiric/desktop/kubuntu-11\.10-desktop-amd64\.iso\.torrent/?: "https://kubuntu.org/download/"
 kubernetes/docs/?: "/kubernetes/charmed-k8s/docs"
-kubernetes/docs/(?P<path>.*)/?: "/kubernetes/charmed-k8s/docs/{path}"
+kubernetes/docs/(?!(latest|(release-|v)\d+\.\d+)?(?:/|$))(.*): /kubernetes/charmed-k8s/docs/\3
 kubernetes/features/?: "/kubernetes/charmed-k8s"
 kubernetes/partners/?: "/kubernetes"
 kubernetes/cloud-native-kubernetes-usage-report-2021/?: "https://juju.is/cloud-native-kubernetes-usage-report-2021"


### PR DESCRIPTION
## Done

We are moving Canonical Kubernetes to kubernetes/docs and therefore need to edit this catchall redirect. For now /kubernetes/docs still redirects to /kubernetes/charmed-k8s/docs. The updated redirect will not redirect any versioned docs i.e. any Canonical Kubernetes links but will continue to redirect unversioned docs to Charmed k8s docs. There should be no change to functionality in this PR. Another PR will follow when Canonical Kubernetes is on ubuntu.com/kubernetes/docs. 

- https://ubuntu.com/kubernetes/docs -> unchanged still redirects to https://ubuntu.com/kubernetes/charmed-k8s/docs
- https://ubuntu.com/kubernetes/docs/how-to-cni -> Does not contain latest/, vX.XX/, or release-XX so will be redirected as normal to https://ubuntu.com/kubernetes/charmed-k8s/docs/how-to-cni 

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

N/A

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
