### PR TITLE
fix: add products.yaml to rockcraft

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -52,3 +52,4 @@ parts:
       - flask/app/appliances.yaml
       - flask/app/subscriptions.yaml
       - flask/app/dynamic-sitemaps.yaml
+      - flask/app/products.yaml


### PR DESCRIPTION
## Done
- Added `products.yaml` to `rockcraft.yaml`

## QA

- Open the [DEMO](https://ubuntu-com-16617.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

