### PR TITLE
feat: update /pro/linux-patch-management-with-pro with data for 26.04

### DIFF
--- a/static/js/src/advantage/linux-patch-management/components/CVETable.test.tsx
+++ b/static/js/src/advantage/linux-patch-management/components/CVETable.test.tsx
@@ -80,8 +80,8 @@ describe("CVETable", () => {
     const options = getByTestId("table-status-filter").querySelectorAll(
       "option",
     );
-    expect(options).toHaveLength(6); // Only one option for the test data
-    expect(options[0].textContent).toBe("24.04 LTS");
+    expect(options).toHaveLength(7); // Only one option for the test data
+    expect(options[0].textContent).toBe("26.04 LTS");
     expect(getByTestId("table-package-filter")).toHaveValue("");
     const packageOptions = getByTestId("table-package-filter").querySelectorAll(
       "option",

--- a/static/js/src/advantage/linux-patch-management/utils/constants.ts
+++ b/static/js/src/advantage/linux-patch-management/utils/constants.ts
@@ -1,4 +1,5 @@
 export const LTSReleases = [
+  { value: "resolute", label: "26.04" },
   { value: "noble", label: "24.04" },
   { value: "jammy", label: "22.04" },
   { value: "focal", label: "20.04" },

--- a/static/js/src/advantage/linux-patch-management/utils/helpers.ts
+++ b/static/js/src/advantage/linux-patch-management/utils/helpers.ts
@@ -17,6 +17,8 @@ export const useFetchCVEData = (release: string) => {
 
 export const LTSReleasesFromName = (release: string): string => {
   switch (release) {
+    case "resolute":
+      return "26.04";
     case "noble":
       return "24.04";
     case "jammy":
@@ -36,6 +38,8 @@ export const LTSReleasesFromName = (release: string): string => {
 
 export const releaseToLTSEndYear = (release: string): number => {
   switch (release) {
+    case "resolute":
+      return 2031;
     case "noble":
       return 2029;
     case "jammy":
@@ -55,6 +59,8 @@ export const releaseToLTSEndYear = (release: string): number => {
 
 export const releaseToProEndYear = (release: string): string => {
   switch (release) {
+    case "resolute":
+      return "2036";
     case "noble":
       return "2034";
     case "jammy":

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -1,6 +1,7 @@
 <style>
-  .chart-legend-lts::before, .chart-legend-pro::before {
-    content:"";
+  .chart-legend-lts::before,
+  .chart-legend-pro::before {
+    content: "";
     display: inline-block;
     width: 24px;
     height: 24px;
@@ -13,7 +14,7 @@
   .chart-legend-lts::before {
     background-color: #656565;
   }
-  .chart-legend-subtext{
+  .chart-legend-subtext {
     margin-left: 32px;
   }
   #myChart {
@@ -23,15 +24,29 @@
 
 <canvas id="myChart"></canvas>
 <div class="chart-legend">
-  <p class="chart-legend-lts"><span class="p-heading--5">Packages covered with LTS</span><br/><span class="chart-legend-subtext">Standard security maintenance, packages with CVE fixes available for 5 years</span></p>
-  <p class="chart-legend-pro"><span class="p-heading--5">Packages covered with Ubuntu Pro</span><br/><span class="chart-legend-subtext">ESM and Legacy, packages with CVE fixes available for 10+5 years</span></p>
+  <p class="chart-legend-lts">
+    <span class="p-heading--5">Packages covered with LTS</span><br /><span
+      class="chart-legend-subtext"
+      >Standard security maintenance, packages with CVE fixes available for 5
+      years</span
+    >
+  </p>
+  <p class="chart-legend-pro">
+    <span class="p-heading--5">Packages covered with Ubuntu Pro</span
+    ><br /><span class="chart-legend-subtext"
+      >ESM and Legacy, packages with CVE fixes available for 10+5 years</span
+    >
+  </p>
 </div>
-<script nonce="{{ csp_nonce }}" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
-        integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
-        crossorigin="anonymous"></script>
+<script
+  nonce="{{ csp_nonce }}"
+  src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+  integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+  crossorigin="anonymous"
+></script>
 
 <script nonce="{{ csp_nonce }}">
-  const ctx = document.getElementById('myChart');
+  const ctx = document.getElementById("myChart");
   Chart.defaults.font.family = "Ubuntu";
   new Chart(ctx, {
     options: {
@@ -39,17 +54,17 @@
       scales: {
         y: {
           beginAtZero: false,
-          ticks:{
+          ticks: {
             callback: (value, index, values) => {
-              return value%1000 === 0 ? value : null;
-            }
-          }
+              return value % 1000 === 0 ? value : null;
+            },
+          },
         },
         x: {
           grid: {
             display: false,
-          }
-        }
+          },
+        },
       },
       plugins: {
         legend: {
@@ -57,21 +72,29 @@
         },
       },
     },
-    type: 'bar',
+    type: "bar",
     data: {
-      labels: ['14.04 LTS','16.04 LTS', '18.04 LTS', '20.04 LTS', '22.04 LTS', '24.04 LTS'],
+      labels: [
+        "14.04 LTS",
+        "16.04 LTS",
+        "18.04 LTS",
+        "20.04 LTS",
+        "22.04 LTS",
+        "24.04 LTS",
+        "26.04 LTS",
+      ],
       datasets: [
         {
-          label: 'Packages covered with LTS',
-          data: [0, 0, 0, 0, 2372, 2390],
-          backgroundColor: '#656565',
+          label: "Packages covered with LTS",
+          data: [0, 0, 0, 0, 2623, 2580, 2414],
+          backgroundColor: "#656565",
         },
         {
-          label: 'Packages covered with Ubuntu Pro',
-          data: [1627, 25063, 28540, 30287, 33728, 36777],
-          backgroundColor: '#e95420',
-        }
-      ]
-    }
+          label: "Packages covered with Ubuntu Pro",
+          data: [21890, 25175, 28734, 30682, 34070, 37029, 39745],
+          backgroundColor: "#e95420",
+        },
+      ],
+    },
   });
 </script>

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -1,7 +1,6 @@
 <style>
-  .chart-legend-lts::before,
-  .chart-legend-pro::before {
-    content: "";
+  .chart-legend-lts::before, .chart-legend-pro::before {
+    content:"";
     display: inline-block;
     width: 24px;
     height: 24px;
@@ -14,7 +13,7 @@
   .chart-legend-lts::before {
     background-color: #656565;
   }
-  .chart-legend-subtext {
+  .chart-legend-subtext{
     margin-left: 32px;
   }
   #myChart {
@@ -24,29 +23,15 @@
 
 <canvas id="myChart"></canvas>
 <div class="chart-legend">
-  <p class="chart-legend-lts">
-    <span class="p-heading--5">Packages covered with LTS</span><br /><span
-      class="chart-legend-subtext"
-      >Standard security maintenance, packages with CVE fixes available for 5
-      years</span
-    >
-  </p>
-  <p class="chart-legend-pro">
-    <span class="p-heading--5">Packages covered with Ubuntu Pro</span
-    ><br /><span class="chart-legend-subtext"
-      >ESM and Legacy, packages with CVE fixes available for 10+5 years</span
-    >
-  </p>
+  <p class="chart-legend-lts"><span class="p-heading--5">Packages covered with LTS</span><br/><span class="chart-legend-subtext">Standard security maintenance, packages with CVE fixes available for 5 years</span></p>
+  <p class="chart-legend-pro"><span class="p-heading--5">Packages covered with Ubuntu Pro</span><br/><span class="chart-legend-subtext">ESM and Legacy, packages with CVE fixes available for 10+5 years</span></p>
 </div>
-<script
-  nonce="{{ csp_nonce }}"
-  src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
-  integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
-  crossorigin="anonymous"
-></script>
+<script nonce="{{ csp_nonce }}" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+        integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+        crossorigin="anonymous"></script>
 
 <script nonce="{{ csp_nonce }}">
-  const ctx = document.getElementById("myChart");
+  const ctx = document.getElementById('myChart');
   Chart.defaults.font.family = "Ubuntu";
   new Chart(ctx, {
     options: {
@@ -54,17 +39,17 @@
       scales: {
         y: {
           beginAtZero: false,
-          ticks: {
+          ticks:{
             callback: (value, index, values) => {
-              return value % 1000 === 0 ? value : null;
-            },
-          },
+              return value%1000 === 0 ? value : null;
+            }
+          }
         },
         x: {
           grid: {
             display: false,
-          },
-        },
+          }
+        }
       },
       plugins: {
         legend: {
@@ -72,29 +57,21 @@
         },
       },
     },
-    type: "bar",
+    type: 'bar',
     data: {
-      labels: [
-        "14.04 LTS",
-        "16.04 LTS",
-        "18.04 LTS",
-        "20.04 LTS",
-        "22.04 LTS",
-        "24.04 LTS",
-        "26.04 LTS",
-      ],
+      labels: ['14.04 LTS','16.04 LTS', '18.04 LTS', '20.04 LTS', '22.04 LTS', '24.04 LTS', '26.04 LTS'],
       datasets: [
         {
-          label: "Packages covered with LTS",
-          data: [0, 0, 0, 0, 2623, 2580, 2414],
-          backgroundColor: "#656565",
+          label: 'Packages covered with LTS',
+          data: [0, 0, 0, 0, 2372, 2390, 2406],
+          backgroundColor: '#656565',
         },
         {
-          label: "Packages covered with Ubuntu Pro",
-          data: [21890, 25175, 28734, 30682, 34070, 37029, 39745],
-          backgroundColor: "#e95420",
-        },
-      ],
-    },
+          label: 'Packages covered with Ubuntu Pro',
+          data: [1627, 25063, 28540, 30287, 33728, 36777, 39736],
+          backgroundColor: '#e95420',
+        }
+      ]
+    }
   });
 </script>


### PR DESCRIPTION
## Done

- Add 26.04 to the list of LTS in /pro/linux-patch-management-with-pro
- Also update the figure in the page with data for 26.04

## QA

- Open the [DEMO](https://ubuntu-com-16623.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit https://ubuntu-com-16623.demos.haus/pro/linux-patch-management-with-pro
- Check if the 26.04 option is available in the options
- Check the figure has the 26.04 LTS in the bar chart 

## Issue / Card

Fixes [#SUPPDM-457](https://warthogs.atlassian.net/browse/SUPPDM-457)

## Screenshots

<img width="1852" height="1048" alt="Screenshot from 2026-07-23 14-06-55" src="https://github.com/user-attachments/assets/69d87f28-0bdb-4047-8d6d-668a61144585" />
<img width="1852" height="1048" alt="Screenshot from 2026-07-23 14-06-48" src="https://github.com/user-attachments/assets/35d77a05-c81f-445f-808c-c6c5e5c6cbf9" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

