### PR TITLE
fix: revert marketo check catching false positives

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1152,15 +1152,14 @@ def marketo_submit():
     )
 
     # Drop submissions that look like script/command injection probes
-    # instead of forwarding them to Marketo. No Sentry report is raised
-    # here, since a public endpoint like this can be hit by scanners
-    # repeatedly and would otherwise bloat alerts with spam attempts.
-    if find_injection_attempt(form_fields):
-        flask.flash(
-            "There was an issue submitting the form.",
-            "contact-form-fail",
-        )
-        return flask.redirect("/#contact-form-fail")
+    # instead of forwarding them to Marketo.
+    # TODO: re-enable this once we have a better way to handle false positives
+    # if find_injection_attempt(form_fields):
+    #     flask.flash(
+    #         "There was an issue submitting the form.",
+    #         "contact-form-fail",
+    #     )
+    #     return flask.redirect("/#contact-form-fail")
 
     form_fields.pop("thankyoumessage", None)
     return_url = form_fields.pop("returnURL", None)


### PR DESCRIPTION
## Done

- Revert Marketo injection check that was catching false positives
- It was incorrectly flagging email submissions as injection attempts

## QA

- Go to /blog
- Submit form, see that it goes through

## Issue / Card

Fixes [WD-37916](https://warthogs.atlassian.net/browse/WD-37916)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37916]: https://warthogs.atlassian.net/browse/WD-37916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ