### PR TITLE
chore: remove marketo mandatory field check

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1175,29 +1175,6 @@ def marketo_submit():
         "userAgentString": flask.request.headers.get("User-Agent"),
     }
 
-    # Reject submissions missing Marketo required fields.
-    # Calls cached Marketo API to get required fields for the form ID
-    # check if any fields are missing.
-    form_id = form_fields.get("formid")
-    if form_id:
-        required_fields = get_marketo_required_fields(form_id)
-        form_fields_lower = {
-            key.lower(): value for key, value in form_fields.items()
-        }
-        missing_required = [
-            label
-            for field, label in required_fields.items()
-            if not form_fields_lower.get(field.lower(), "").strip()
-        ]
-        if missing_required:
-            flask.flash(
-                "There was a problem submitting your form. Please complete "
-                "the following required fields: "
-                f"{', '.join(missing_required)}.",
-                "contact-form-fail",
-            )
-            return flask.redirect(f"{referrer}#contact-form-fail")
-
     client_ip = flask.request.headers.get(
         "X-Real-IP", flask.request.remote_addr
     )


### PR DESCRIPTION
## Done

- Remove Marketo mandatory field check
- Request came from Marketing as the mandatory fields on Marketo are not up-to-date, causing unintended form submissions failures

## QA

- Go to any form page, e.g https://ubuntu-com-16634.demos.haus/engage/canonical-day-toronto-26
- Inspect page, pick a required field and remove `is-required` from label and `required` from input
- Submit form with the removed required field, see that it goes through as expected

## Issue / Card

Fixes [WD-37920](https://warthogs.atlassian.net/browse/WD-37920)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37920]: https://warthogs.atlassian.net/browse/WD-37920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ