### PR TITLE
fix: show the correct device name on Ubuntu Core login step

### DIFF
--- a/templates/download/intel-iei-tank-870.html
+++ b/templates/download/intel-iei-tank-870.html
@@ -76,7 +76,9 @@
         </div>
       </li>
       {% include "download/shared/_first-boot-setup.html" %}
-      {% include "download/shared/_login.html" %}
+      {% with device_name="Intel IEI TANK 870" %}
+        {% include "download/shared/_login.html" %}
+      {% endwith %}
     </ol>
   </div>
 </section>
@@ -100,7 +102,7 @@
           </ol>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Get started with snaps</h3>

--- a/templates/download/intel-nuc.html
+++ b/templates/download/intel-nuc.html
@@ -143,7 +143,9 @@
           </div>
         </li>
         {% include "download/shared/_first-boot-setup.html" %}
-        {% include "download/shared/_login.html" %}
+        {% with device_name="Intel NUC" %}
+          {% include "download/shared/_login.html" %}
+        {% endwith %}
       </ol>
     </div>
   </section>

--- a/templates/download/qualcomm-dragonboard-410c.html
+++ b/templates/download/qualcomm-dragonboard-410c.html
@@ -70,7 +70,9 @@
         </div>
       </li>
       {% include "download/shared/_first-boot-setup.html" %}
-      {% include "download/shared/_login.html" %}
+      {% with device_name="Qualcomm DragonBoard 410c" %}
+        {% include "download/shared/_login.html" %}
+      {% endwith %}
     </ol>
   </div>
 </section>
@@ -94,7 +96,7 @@
           </ol>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Get started with snaps</h3>

--- a/templates/download/shared/_login.html
+++ b/templates/download/shared/_login.html
@@ -4,6 +4,6 @@
   <div class="p-stepped-list__content">
     <p>Once setup is done, you can login with SSH into Ubuntu Core, from a machine on the same network, using the following command:</p>
     <p><pre><code>ssh &lt;Ubuntu SSO user name&gt;@&lt;device IP address&gt;</code></pre></p>
-    <p>Your user name is your Ubuntu SSO user name, and the command should be displayed on the RPi.</p>
+    <p>Your user name is your Ubuntu SSO user name, and the command should be displayed on the {{ device_name | default("device") }}.</p>
   </div>
 </li>


### PR DESCRIPTION
## Done

- The "Connect to the device" step on the Ubuntu Core download pages told users the SSH command would be "displayed on the RPi". That step lives in a shared template (`templates/download/shared/_login.html`) that is included by three non-Raspberry-Pi pages, so the reference was wrong on all of them.
- Passed the device name into the shared template from each page — Intel NUC, Qualcomm DragonBoard 410c and Intel IEI TANK 870 — with a generic `"device"` default, instead of hard-coding it.
- While touching the Qualcomm and IEI TANK templates, self-closed the two `p-rule` `<hr>` tags that djlint flags, so the `lint-jinja` check stays green.

## QA

- Run the site with `task start`
- On each page below, scroll to the "Connect to the device" step and confirm the last line names the correct hardware and no longer says "RPi":
  - http://0.0.0.0:8001/download/intel-nuc → "displayed on the Intel NUC"
  - http://0.0.0.0:8001/download/qualcomm-dragonboard-410c → "displayed on the Qualcomm DragonBoard 410c"
  - http://0.0.0.0:8001/download/intel-iei-tank-870 → "displayed on the Intel IEI TANK 870"
- Checked on desktop, tablet and mobile widths.

## Issue / Card

Fixes #13142
