### PR TITLE
fix: filter inactive takeovers from /takeovers.json

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1284,7 +1284,13 @@ class TestTakeoversJson(TestCase):
 
         mixed = [
             {"title": "Active one", "active": "true"},
-            {"title": "Leaks via equal_cols", "active": "false"},
+            # active=false but another boolean key is true: this is the
+            # record that leaked through query #16's loose matching.
+            {
+                "title": "Leaks via equal_cols",
+                "active": "false",
+                "equal_cols": "true",
+            },
             {"title": "Active upper/space", "active": " True "},
             {"title": "Inactive", "active": "false"},
         ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1268,6 +1268,39 @@ class TestCommunityLandingEvents(TestCase):
         self.assertEqual(render.call_args.kwargs["featured_events"], [])
 
 
+class TestTakeoversJson(TestCase):
+    """
+    /takeovers.json must only return takeovers whose metadata is
+    active=true. The upstream data-explorer query matches the active
+    value loosely, so active=false takeovers with another boolean
+    metadata key set to true leak through and must be filtered out.
+    """
+
+    def test_inactive_takeovers_are_filtered_out(self):
+        from webapp import app as app_module
+
+        app.testing = True
+        client = app.test_client()
+
+        mixed = [
+            {"title": "Active one", "active": "true"},
+            {"title": "Leaks via equal_cols", "active": "false"},
+            {"title": "Active upper/space", "active": " True "},
+            {"title": "Inactive", "active": "false"},
+        ]
+
+        with patch.object(
+            app_module.discourse_takeovers,
+            "parse_active_takeovers",
+            return_value=mixed,
+        ):
+            response = client.get("/takeovers.json")
+
+        self.assertEqual(response.status_code, 200)
+        titles = [t["title"] for t in response.get_json()]
+        self.assertEqual(titles, ["Active one", "Active upper/space"])
+
+
 class TestRateLimitedErrorHandling(TestCase):
     """
     RateLimitedError from the discourse package must surface as a

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -775,6 +775,15 @@ app.add_url_rule(
 
 def takeovers_json():
     active_takeovers = discourse_takeovers.parse_active_takeovers()
+    # Defence-in-depth: the upstream data-explorer query matches the
+    # "active" value loosely (any metadata cell equal to "true"), so
+    # takeovers with active=false but another boolean key set to true
+    # leak through. Filter on the parsed metadata value here.
+    active_takeovers = [
+        takeover
+        for takeover in active_takeovers
+        if str(takeover.get("active", "")).strip().lower() == "true"
+    ]
     response = flask.jsonify(active_takeovers)
     response.cache_control.max_age = 300
 


### PR DESCRIPTION
## Done

- Filter `/takeovers.json` to only return takeovers whose metadata is `active: true`.
- **Why:** the homepage carousel showed inactive takeovers. The upstream data-explorer query (`#16`) matches the `active` value loosely — it matches any metadata cell equal to `true`, so an `active: false` takeover that also has e.g. `equal_cols: true` or `contact_form_only: true` leaked through. The endpoint returned 50 rows (mostly inactive) instead of only the active ones.

## QA

- Check out this feature branch
- Run the site using the command `task start`
- View the site locally at http://0.0.0.0:8001/
- Confirm the homepage takeover carousel only shows current (active) takeovers
- `GET /takeovers.json` should return only entries with `"active": "true"`

## Issue / Card

Fixes #

## Screenshots

N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

