### PR TITLE
fix: correct the Ubuntu Cinnamon desktop description

### DIFF
--- a/templates/desktop/flavors.html
+++ b/templates/desktop/flavors.html
@@ -208,7 +208,7 @@
       </div>
       <div class="col">
         <p>
-          Ubuntu Cinnamon combines Ubuntu with the Cinnamon desktop, built upon GNOME 2 to provide a traditionally modern experience. It is made for all home users alike, with intuitive software, and a simpler, customisable desktop suited with many personalization options and addons for some extra spice.
+          Ubuntu Cinnamon combines Ubuntu with the Cinnamon desktop, built upon GNOME to provide a traditionally modern experience. It is made for all home users alike, with intuitive software, and a simpler, customisable desktop suited with many personalization options and addons for some extra spice.
         </p>
         <a href="https://ubuntucinnamon.org/" class="p-button--positive">Get Ubuntu Cinnamon</a>
         <ul class="p-list--divided">


### PR DESCRIPTION
## Done

- Corrected the Ubuntu Cinnamon flavor description on `/desktop/flavors`. It stated the desktop is "built upon GNOME 2", which is inaccurate — Cinnamon is forked from GNOME Shell and based on GNOME 3 and Mutter. Dropped the incorrect version reference so the description is accurate rather than swapping in another debatable number.

## QA

- Run the site with `task start`
- Go to http://0.0.0.0:8001/desktop/flavors and scroll to the "Ubuntu Cinnamon" section
- Confirm the description now reads "...built upon GNOME to provide a traditionally modern experience." and no longer says "GNOME 2"

## Issue / Card

Fixes #16537
