### PR TITLE
fix macaroon URL path

### DIFF
--- a/webapp/login.py
+++ b/webapp/login.py
@@ -77,7 +77,7 @@ def login_handler():
         return flask.redirect(open_id.get_next_url())
 
     response = session.request(
-        method="get", url=f"{api_url}/v1/canonical-sso-macaroon"
+        method="get", url=f"{api_url}v1/canonical-sso-macaroon"
     )
     flask.session["macaroon_root"] = response.json()["macaroon"]
 


### PR DESCRIPTION
## Done

- Fix login macaroon path in login handler

## QA

- Open the [DEMO](https://ubuntu-com-16641.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /login
- Should work

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

