### PR TITLE
fix: marketo injection tests

### DIFF
--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -379,6 +379,40 @@ class TestMarketoSubmit(unittest.TestCase):
         self.assertEqual(http_response.status_code, 302)
         self.assertIn("contact-form-fail", http_response.headers["Location"])
 
+    def test_thankyoumessage_html_not_blocked(self):
+        """
+        ``thankyoumessage`` is a template-controlled, non user-typed field
+        (listed in MARKETO_NON_LEAD_FIELDS) that legitimately contains HTML
+        markup. Its markup must not be treated as an injection attempt, so
+        the submission is still forwarded to Marketo and succeeds.
+        """
+        with patch(
+            "webapp.views.marketo_api.submit_form"
+        ) as mock_submit, patch(
+            "webapp.views.marketo_sentry_report"
+        ) as mock_sentry:
+            mock_submit.side_effect = [
+                self._mock_response(
+                    {"success": True, "result": [{"status": "created"}]}
+                ),
+                self._mock_response({"success": True}),
+            ]
+            http_response = self.client.post(
+                "/marketo/submit",
+                data={
+                    "formid": "1234",
+                    "email": "test@example.com",
+                    "firstName": "Test",
+                    "thankyoumessage": (
+                        "<p>Thanks for <strong>subscribing</strong>!</p>"
+                    ),
+                },
+            )
+        mock_submit.assert_called()
+        mock_sentry.assert_not_called()
+        self.assertEqual(http_response.status_code, 302)
+        self.assertIn("/thank-you", http_response.headers["Location"])
+
     def test_enrichment_succeeds_payload_skipped_single_alert(self):
         """
         When only the enrichment submission goes through (the payload was

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -48,6 +48,16 @@ MARKETO_INJECTION_PATTERNS = [
     "wordpressbin",
 ]
 
+# Template-controlled fields submitted to /marketo/submit that are not
+# user-typed lead data.
+MARKETO_NON_LEAD_FIELDS = frozenset(
+    {
+        "thankyoumessage",
+        "returnURL",
+        "formid",
+    }
+)
+
 
 # Used if the live fetch from Google fails at startup. Covers the regions
 # we've historically seen in CSP reports.

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -53,7 +53,6 @@ MARKETO_INJECTION_PATTERNS = [
 MARKETO_NON_LEAD_FIELDS = frozenset(
     {
         "thankyoumessage",
-        "returnURL",
         "formid",
     }
 )

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -70,7 +70,7 @@ def empty_session(user_session):
 @open_id.loginhandler
 def login_handler():
     api_url = get_flask_env(
-        "CONTRACTS_API_URL", "https://contracts.canonical.com"
+        "CONTRACTS_API_URL", "https://contracts.canonical.com/"
     )
 
     if user_info(flask.session):

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -70,7 +70,7 @@ def empty_session(user_session):
 @open_id.loginhandler
 def login_handler():
     api_url = get_flask_env(
-        "CONTRACTS_API_URL", "https://contracts.canonical.com/"
+        "CONTRACTS_API_URL", "https://contracts.canonical.com"
     )
 
     if user_info(flask.session):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1060,7 +1060,8 @@ def enrich_acquisition_url(acquisition_url, utm_dict, approved_utms):
 
 def find_injection_attempt(form_fields):
     """
-    Injection checks against fields for non user-typed lead data
+    Checks user-typed fields for injection signatures and explicitly
+    skips fields in MARKETO_NON_LEAD_FIELDS
     """
     for field, value in form_fields.items():
         # Non user-typed fields are skipped to avoid false positives
@@ -1163,7 +1164,7 @@ def marketo_submit():
             "There was an issue submitting the form.",
             "contact-form-fail",
         )
-        return flask.redirect("/#contact-form-fail")
+        return flask.redirect(f"{referrer}#contact-form-fail")
 
     form_fields.pop("thankyoumessage", None)
     return_url = form_fields.pop("returnURL", None)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1065,6 +1065,9 @@ def find_injection_attempt(form_fields):
     in MARKETO_INJECTION_PATTERNS.
     """
     for field, value in form_fields.items():
+        # Not user provided field, may contain HTML markup for formatting
+        if field == "thankyoumessage":
+            continue
         if nh3.is_html(value):
             return field, "html-injection"
         lowered = value.lower()
@@ -1153,13 +1156,12 @@ def marketo_submit():
 
     # Drop submissions that look like script/command injection probes
     # instead of forwarding them to Marketo.
-    # TODO: re-enable this once we have a better way to handle false positives
-    # if find_injection_attempt(form_fields):
-    #     flask.flash(
-    #         "There was an issue submitting the form.",
-    #         "contact-form-fail",
-    #     )
-    #     return flask.redirect("/#contact-form-fail")
+    if find_injection_attempt(form_fields):
+        flask.flash(
+            "There was an issue submitting the form.",
+            "contact-form-fail",
+        )
+        return flask.redirect("/#contact-form-fail")
 
     form_fields.pop("thankyoumessage", None)
     return_url = form_fields.pop("returnURL", None)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -46,7 +46,11 @@ from flask.views import View
 from webapp.login import user_info
 from webapp.marketo import MarketoAPI
 from webapp.utils import format_community_event_time
-from webapp.constants import ENGAGE_UI_TRANSLATIONS, MARKETO_INJECTION_PATTERNS
+from webapp.constants import (
+    ENGAGE_UI_TRANSLATIONS,
+    MARKETO_INJECTION_PATTERNS,
+    MARKETO_NON_LEAD_FIELDS,
+)
 
 ip_reader = geolite2.reader()
 session = Session()
@@ -1056,21 +1060,19 @@ def enrich_acquisition_url(acquisition_url, utm_dict, approved_utms):
 
 def find_injection_attempt(form_fields):
     """
-    Return the (field, pattern) of the first submitted field value that
-    looks like a script/command injection probe rather than genuine lead
-    data, or None if no match is found. Values containing HTML markup are
-    caught structurally via nh3 (robust against tag/attribute/casing
-    variation); everything else (path traversal, command/header injection,
-    known scanner domains, etc.) is matched against the literal substrings
-    in MARKETO_INJECTION_PATTERNS.
+    Injection checks against fields for non user-typed lead data
     """
     for field, value in form_fields.items():
-        # Not user provided field, may contain HTML markup for formatting
-        if field == "thankyoumessage":
+        # Non user-typed fields are skipped to avoid false positives
+        if field in MARKETO_NON_LEAD_FIELDS:
             continue
+
+        # User-typed fields that contain HTML are considered injection attempts
         if nh3.is_html(value):
             return field, "html-injection"
         lowered = value.lower()
+
+        # Check against known Marketo injection patterns
         for pattern in MARKETO_INJECTION_PATTERNS:
             if pattern in lowered:
                 return field, pattern


### PR DESCRIPTION
## Done

- Skip injection check for non user-typed fields such as `thankyoumessage`
  - This is because these fields often include html string for formatting purposes

## QA

- Go to https://ubuntu-com-16646.demos.haus/blog
- Fill up newsletter form, submit and see that it goes through
- Repeat for another form i.e https://ubuntu-com-16646.demos.haus#get-in-touch

## Issue / Card

Fixes [WD-37918](https://warthogs.atlassian.net/browse/WD-37918)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37918]: https://warthogs.atlassian.net/browse/WD-37918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ