### PR TITLE
csp: trim report-only policy to the directives under test

### DIFF
--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -410,12 +410,32 @@ _CSP_REPORT_ONLY_REMOVALS = {
 }
 
 
+# CSP directives that receive the per-request nonce. With 'strict-dynamic' in
+# script-src-elem, the nonce authorises page scripts (and scripts they load),
+# replacing the removed 'unsafe-inline'.
+NONCED_DIRECTIVES = ("script-src", "script-src-elem")
+
+
 def _build_csp_report_only(csp):
-    stricter = {directive: list(values) for directive, values in csp.items()}
-    for directive, stale_values in _CSP_REPORT_ONLY_REMOVALS.items():
+    """
+    Carry only the directives the bake-in needs: the ones with suspected
+    stale sources removed, the nonced script directives, and report-uri.
+    A directive absent from a policy is unrestricted and reports nothing,
+    so the rest cost bytes without adding signal — and these bytes are
+    duplicated on every response. The enforced + report-only pair already
+    overflowed a 16k response-header buffer at the edge proxy in front of
+    the cluster, 502-ing /login for logged-out users.
+    """
+    keep = set(_CSP_REPORT_ONLY_REMOVALS) | set(NONCED_DIRECTIVES)
+    stricter = {}
+    for directive, values in csp.items():
+        if directive not in keep:
+            continue
+        stale_values = _CSP_REPORT_ONLY_REMOVALS.get(directive, ())
         stricter[directive] = [
-            value for value in stricter[directive] if value not in stale_values
+            value for value in values if value not in stale_values
         ]
+    stricter["report-uri"] = list(csp["report-uri"])
     return stricter
 
 
@@ -432,9 +452,3 @@ CSP_REPORT_DEDUP_WINDOW = 3600  # seconds (1 hour)
 # Real CSP violation reports are a few hundred bytes; /csp-report is
 # unauthenticated, so reject anything wildly larger before parsing it.
 CSP_REPORT_MAX_BYTES = 8192
-
-
-# CSP directives that receive the per-request nonce. With 'strict-dynamic' in
-# script-src-elem, the nonce authorises page scripts (and scripts they load),
-# replacing the removed 'unsafe-inline'.
-NONCED_DIRECTIVES = ("script-src", "script-src-elem")

--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -418,13 +418,9 @@ NONCED_DIRECTIVES = ("script-src", "script-src-elem")
 
 def _build_csp_report_only(csp):
     """
-    Carry only the directives the bake-in needs: the ones with suspected
-    stale sources removed, the nonced script directives, and report-uri.
-    A directive absent from a policy is unrestricted and reports nothing,
-    so the rest cost bytes without adding signal — and these bytes are
-    duplicated on every response. The enforced + report-only pair already
-    overflowed a 16k response-header buffer at the edge proxy in front of
-    the cluster, 502-ing /login for logged-out users.
+    Only the directives under test, plus the nonced ones and report-uri:
+    absent directives report nothing, so the rest were duplicated bytes
+    that pushed /login past the edge proxy's 16k header buffer.
     """
     keep = set(_CSP_REPORT_ONLY_REMOVALS) | set(NONCED_DIRECTIVES)
     stricter = {}


### PR DESCRIPTION
## Done

- `CSP_REPORT_ONLY` was a full copy of the enforced policy. It now carries only the directives under test (`script-src-elem`, `connect-src`), the nonced ones, and `report-uri`.
- Saves **1.6 kb on every response** (report-only: 5kB → 4kB). Enforced policy unchanged.

## Why

`/login` is 502-ing on production for logged-out users. The app returns a valid 302, but the response headers total 16,773 B and the IS-managed edge nginx in front of the cluster buffers 16k. The ingress is already at 32k, so it isn't the constraint.

Directives absent from a CSP policy are unrestricted and report nothing, so the 9 untested ones were duplicated bytes with no added signal.

## QA

- `/login` headers: 16 kB → ~15 kB, under the 16,384 limit.
- Report-only still drops every source in `_CSP_REPORT_ONLY_REMOVALS` and still carries the nonce; `tests/test_csp.py` needs no changes.
- After deploy: `curl -sI https://ubuntu.com/login` returns 302, not 502.

Leaves ~1.2 KB of headroom. If more is ever needed, dropping `connect-src` from the report-only policy frees a further 3.4 KB.

## Issue / Card

Fixes #

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
