### PR TITLE
csp: make the report-only header opt-in per environment

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -828,6 +828,9 @@ staging:
     - name: FLASK_ENV
       value: "staging"
 
+    - name: CSP_REPORT_ONLY_ENABLED
+      value: true
+
     - name: GITHUB_TOKEN
       secretKeyRef:
         key: GITHUB_TOKEN

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -83,6 +83,15 @@ class TestCSPHeader(unittest.TestCase):
         second_script = self._get_directive(second_csp, "script-src")
         self.assertNotEqual(first_script, second_script)
 
+    def test_report_only_header_absent_unless_enabled(self):
+        # Off by default so the header block stays within the response
+        # header buffer of the proxy in front of production.
+        response = self.client.get("/non-existent-csp-test-path")
+        self.assertIsNone(
+            response.headers.get("Content-Security-Policy-Report-Only")
+        )
+
+    @patch.dict("os.environ", {"CSP_REPORT_ONLY_ENABLED": "true"})
     def test_report_only_header_present_with_nonce_and_report_uri(self):
         response = self.client.get("/non-existent-csp-test-path")
         csp_ro = response.headers.get("Content-Security-Policy-Report-Only")

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -526,9 +526,15 @@ def init_handlers(app):
         response.headers["Content-Security-Policy"] = get_csp_as_str(
             CSP, nonce=nonce
         )
-        response.headers["Content-Security-Policy-Report-Only"] = (
-            get_csp_as_str(CSP_REPORT_ONLY, nonce=nonce)
-        )
+        # Off by default: this doubles the CSP bytes on every response and
+        # the proxy in front of production caps response headers at ~12k,
+        # which /login (2.1k Location + 2k cookie) can't spare. Enable per
+        # environment via CSP_REPORT_ONLY_ENABLED to run the bake-in.
+        report_only = get_flask_env("CSP_REPORT_ONLY_ENABLED", "false")
+        if str(report_only).lower() == "true":
+            response.headers["Content-Security-Policy-Report-Only"] = (
+                get_csp_as_str(CSP_REPORT_ONLY, nonce=nonce)
+            )
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"


### PR DESCRIPTION
## Done

- The `Content-Security-Policy-Report-Only` header is now opt-in via `CSP_REPORT_ONLY_ENABLED`, off by default.
- Enabled on staging in `konf/site.yaml`, so the bake-in keeps collecting data where headers are nowhere near a limit.

## Why

`/login` still 502s for logged-out users after #16648. Measured from inside the cluster, the app returns a valid 302 with **15,154 bytes** of headers:

| Header | Bytes |
|---|---|
| Content-Security-Policy | 6,169 |
| Content-Security-Policy-Report-Only | 4,176 |
| Location (OpenID redirect) | 2,164 |
| Set-Cookie (session) | 2,062 |

The proxy in front of production rejects it. Routes that work today (`/logout` 11,148 B, `/credentials` 11,023 B) put its limit near 12k, not 16k. Dropping this header takes `/login` to **10,978 B** — below routes that demonstrably pass.

## QA

- After deploy: `curl -sI https://ubuntu.com/login` returns 302, not 502. Must be tested logged out (incognito); logged in, `/login` is a short redirect that fits either way.
- `curl -sI https://ubuntu.com/ | grep -ci report-only` → 0 on production, 1 on staging.
- Enforced CSP is unchanged, so nothing new is blocked.

Revert this once the proxy's header buffer is raised (IS request pending).

