### PR TITLE
chore: reduce discourse cache TTL from 24h to 1h

### DIFF
--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -7,8 +7,8 @@ logger = logging.getLogger(__name__)
 
 # Centralised UI translations for Engage pages and other shared constants
 
-# Default time-to-live for ResponseCache instances, in seconds (24 hours)
-CACHE_TTL = 60 * 60 * 24
+# Default time-to-live for ResponseCache instances, in seconds (1 hour)
+CACHE_TTL = 60 * 60
 
 ENGAGE_UI_TRANSLATIONS = {
     "additional_resources": {


### PR DESCRIPTION
## Done

- Reduce Discourse cache TTL from 24h > 1h
- Discourse changes are taking a day to update on engage pages
- Reducing it to 1h for now. If the ratel limits are still being hit, we can increase this further to 2-3 hours


## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-37941](https://warthogs.atlassian.net/browse/WD-37941)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37941]: https://warthogs.atlassian.net/browse/WD-37941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ