### PR TITLE
Add sitemaps for certification documentation sets

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -141,4 +141,16 @@
   <sitemap>
     <loc>https://ubuntu.com/docs/snapcraft/7/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/checkbox/main/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/hardware-api/latest/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/testflinger/latest/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://ubuntu.com/docs/yarf/latest/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
This pull request updates the `sitemap_index.xml` file to include documentation sitemaps for Certification team's open-source projects.

## Done

Documentation sitemap additions:

* Added new sitemap entries for `checkbox`, `hardware-api`, `testflinger`, and `yarf` documentation to the `sitemap_index.xml` file. The documentation sets are hosted under https://ubuntu.com/docs/  domain

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes Jira CDOC-394

## Screenshots

N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
