### PR TITLE
feat: raise timeout errors as SecurityAPIError

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -390,7 +390,9 @@ def init_handlers(app):
             pass
 
         # A missing response is a gateway timeout rather than an internal error
-        status_code = 504 if error.response is None else 500
+        status_code = (
+            504 if error.response is None else error.response.status_code
+        )
 
         return (
             flask.render_template(

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -389,12 +389,15 @@ def init_handlers(app):
         except (ValueError, AttributeError):
             pass
 
+        # A missing response is a gateway timeout rather than an internal error
+        status_code = 504 if error.response is None else 500
+
         return (
             flask.render_template(
                 "security-error-500.html",
                 message=message,
             ),
-            500,
+            status_code,
         )
 
     @app.errorhandler(UAContractsValidationError)

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -1,5 +1,10 @@
 from requests import Session
-from requests.exceptions import HTTPError
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    RequestException,
+    Timeout,
+)
 from urllib.parse import urlencode
 from canonicalwebteam.flask_base.env import get_flask_env
 
@@ -8,8 +13,8 @@ SECURITY_API_URL = get_flask_env(
 )
 
 
-class SecurityAPIError(HTTPError):
-    def __init__(self, error: HTTPError):
+class SecurityAPIError(RequestException):
+    def __init__(self, error: RequestException):
         super().__init__(request=error.request, response=error.response)
 
 
@@ -25,12 +30,15 @@ class SecurityAPI:
     def _get(self, path: str, params={}):
         """
         Defines get request set up, returns data if successful,
-        raises HTTP errors if not
+        raises SecurityAPI errors if not
         """
 
         uri = f"{self.base_url}{path}"
 
-        response = self.session.get(uri, params=params, timeout=10)
+        try:
+            response = self.session.get(uri, params=params, timeout=30)
+        except (ConnectionError, Timeout) as error:
+            raise SecurityAPIError(error)
 
         response.raise_for_status()
 


### PR DESCRIPTION
## Done

- Security API timeout errors are being raised as generic errors, causing spam to Sentry for unrelated error logs
- This PR catches SecAPI timeout/connection errors, and raise the appropriate SecurityAPIError

## QA

- Branch off this PR and run locally with `dotrun` 
- Go to /security/cves?q=ruby
- Check that logs are not throwing uncaught generic errors

## Issue / Card

Fixes [WD-37938](https://warthogs.atlassian.net/browse/WD-37938)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37938]: https://warthogs.atlassian.net/browse/WD-37938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ