### PR TITLE
WD-37571: Add Ubuntu Pro chip to hero sections of Pro-connected pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
     "uuid": "^14.0.1",
-    "vanilla-framework": "4.50.0",
+    "vanilla-framework": "4.56.0",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -15,29 +15,41 @@
 {% endblock body_class %}
 
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
 
 {% block content %}
 
-  <section class="p-section--hero">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
-        <div class="p-section--shallow">
-          <h1>
-            Securely designed, minimal Docker images
-            <br class="u-hide--small" />
-            from your trusted distro
-          </h1>
-        </div>
-        <p>
-          Build enterprise-grade applications on your preferred platform &ndash; cloud, on-premises, or hybrid. Improve your resource efficiency with ultra-small, OCI-compliant, production-ready containers, supported by Canonical, or use our open source tooling to create your own.
-        </p>
-        <div class="p-cta-block">
-          <a class="p-button--positive" href="https://hub.docker.com/_/ubuntu">Deploy our base image</a>
-          <a href="/containers/contact-us" class="js-invoke-modal">Get a securely designed, custom-built container&nbsp;&rsaquo;</a>
-        </div>
-      </div>
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text='Securely designed, minimal Docker images <br class="u-hide--small" />from your trusted distro',
+    chip_text='Secured with Ubuntu Pro',
+    layout='25/75',
+    display_blank_signpost_image_space=true,
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": 'Build enterprise-grade applications on your preferred platform &ndash; cloud, on-premises, or hybrid. Improve your resource efficiency with ultra-small, OCI-compliant, production-ready containers, supported by Canonical, or use our open source tooling to create your own.'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Deploy our base image",
+            "attrs": {"href": "https://hub.docker.com/_/ubuntu"}
+          },
+          "link": {
+            "content_html": "Get a securely designed, custom-built container&nbsp;&rsaquo;",
+            "attrs": {"href": "/containers/contact-us", "class": "js-invoke-modal"}
+          }
+        }
+      },
+    ]
+    ) -%}
+  {% endcall -%}
 
   <section class="p-section">
     <div class="row--25-75">

--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -22,10 +22,15 @@
   {% call(slot) vf_hero(
     title_text='Take control <br />of your infrastructure',
     subtitle_text='',
-    layout='50/50-full-width-image'
-    ) -%}
-    {%- if slot == 'description' -%}
-      <p>
+    chip_text='Available with Ubuntu Pro',
+    layout='50/50-full-width-image',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": '<p>
         Landscape is a systems management tool that can be used as a web-based service or through an API. Landscape Server is available through Canonical either as a managed solution or Software-as-a-Service model, or it can be self-hosted. Landscape Client is installed on Ubuntu to enroll with Landscape Server.
       </p>
       <p>
@@ -33,26 +38,41 @@
       </p>
       <p>
         Landscape is available with an <a href="/pro">Ubuntu Pro</a> subscription.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/landscape/pricing" class="p-button--positive">Get Landscape</a>
-      <a href="/contact-us"
-         class="p-button js-invoke-modal"
-         aria-controls="landscape-modal">Contact us</a>
-    {%- endif -%}
-    {%- if slot == 'image' -%}
-      <div class="p-image-container--cinematic is-cover">
-        {{ image(url="https://assets.ubuntu.com/v1/8776d218-hero-img-iot.png",
-                alt="",
-                width="3696",
-                height="1541",
-                hi_def=True,
-                loading="auto",
-                attrs={"class": "p-image-container__image"}) | safe
-        }}
-      </div>
-    {% endif -%}
+      </p>'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Get Landscape",
+            "attrs": {"href": "/landscape/pricing"}
+          },
+          "secondaries": [
+            {
+              "content_html": "Contact us",
+              "attrs": {"href": "/contact-us", "class": "js-invoke-modal", "aria-controls": "landscape-modal"}
+            }
+          ]
+        }
+      },
+      {
+        "type": "image",
+        "item": {
+          "aspect_ratio": "cinematic",
+          "is_cover": true,
+          "attrs": {
+            "src": "https://assets.ubuntu.com/v1/8776d218-hero-img-iot.png",
+            "alt": "",
+            "width": "3696",
+            "height": "1541",
+            "loading": "auto"
+          }
+        }
+      },
+    ]
+  ) -%}
   {% endcall -%}
 
   <section class="p-section">
@@ -322,9 +342,9 @@
   </section>
 
   {{ vf_basic_section(
-    title={"text": "Discover Landscape
-            <br class='u-hide--small' />
-            for IoT device management"},
+    title={"text": 'Discover Landscape
+            <br class="u-hide--small" />
+            for IoT device management'},
     items=[
         {
         "type": "description",
@@ -360,7 +380,6 @@
       },
     ],
   ) }}
-
 
   <section class="p-section">
     <div class="row--50-50">

--- a/templates/landscape/managed/index.html
+++ b/templates/landscape/managed/index.html
@@ -21,33 +21,48 @@
   <section class="p-section--hero u-no-padding--bottom">
     {% call(slot) vf_hero(
       title_text='Managed Landscape',
+      chip_text='Available with Ubuntu Pro',
       layout='50/50',
-      is_split_on_medium=true
-      ) -%}
-      {%- if slot == 'description' -%}
-        <p class="u-no-padding--top">
+      is_split_on_medium=true,
+      blocks=[
+        {
+          "type": "description",
+        "padding": "shallow",
+          "item": {
+            "type": "html",
+            "content": '<p class="u-no-padding--top">
           <b>Software as a service convenience, in an environment you control.</b>
           <br />
-          Manage machines at scale without worrying about tooling. Let Canonical handle Landscape's installation, patching, scaling and maintenance.
-        </p>
-      {%- endif -%}
-      {%- if slot == 'cta' -%}
-        <a href="/contact-us"
-           class="p-button--positive js-invoke-modal"
-           aria-controls="landscape-managed-modal">Contact us</a>
-      {%- endif -%}
-      {%- if slot == 'image' -%}
-        <div class="p-image-container--3-2 is-cover">
-          {{ image(url="https://assets.ubuntu.com/v1/798a1063-hero-img.png",
-                    alt="",
-                    width="1200",
-                    height="752",
-                    hi_def=True,
-                    loading="auto",
-                    attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-      {%- endif -%}
+          Manage machines at scale without worrying about tooling. Let Canonical handle Landscape\'s installation, patching, scaling and maintenance.
+        </p>'
+          }
+        },
+        {
+          "type": "cta-block",
+        "padding": "shallow",
+          "item": {
+            "primary": {
+              "content_html": "Contact us",
+              "attrs": {"href": "/contact-us", "class": "js-invoke-modal", "aria-controls": "landscape-managed-modal"}
+            }
+          }
+        },
+        {
+          "type": "image",
+          "item": {
+            "aspect_ratio": "3-2",
+            "is_cover": true,
+            "attrs": {
+              "src": "https://assets.ubuntu.com/v1/798a1063-hero-img.png",
+              "alt": "",
+              "width": "1200",
+              "height": "752",
+              "loading": "auto"
+            }
+          }
+        },
+      ]
+      ) -%}
     {% endcall -%}
   </section>
 

--- a/templates/pro/devices.html
+++ b/templates/pro/devices.html
@@ -27,6 +27,10 @@ meta_copydoc %}
             <br />
             get up to 15 years of security maintenance.
           </h2>
+          <span class="p-chip--branded">
+            <i class="p-icon--circle-of-friends"></i>
+            <span class="p-chip__value">Ubuntu Pro</span>
+          </span>
           <p>
             In a single subscription, benefit from patching for thousands of popular software packages, and harness automation tools for compliance with multiple standards, including the Cyber Resilience Act.
           </p>

--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -31,36 +31,58 @@
 {% block outer_content %}
 
   {%- call(slot) vf_hero(
-    title_text='Expanded Security Maintenance <br class="u-hide--small u-hide--medium">for the Robot Operating System',
-    layout='50/50-full-width-image'
-    ) -%}
-    {%- if slot == 'description' -%}
-      <h2>
+    title_text='Expanded Security Maintenance <br class="u-hide--small u-hide--medium" />for the Robot Operating System',
+    chip_text='Available with Ubuntu Pro',
+    layout='50/50-full-width-image',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": '<h2>
         ROS security updates 
         <br class="u-hide--small u-hide--medium" />
         for your entire product lifecycle.
-      </h2>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/internet-of-things/contact-us?product=robotics"
-         class="js-invoke-modal p-button--positive"
-         aria-controls="robotics-modal"
-         aria-expanded="false">Get in touch</a>
-      <a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/security/what-is-ros-esm/"
-        class="p-button">Read the docs</a>
-      <a href="https://assets.ubuntu.com/v1/4dedff79-ROS%20ESM%20datasheet.pdf">Read the datasheet&nbsp;&rsaquo;</a>
-    {%- endif -%}
-    {%- if slot == 'image' -%}
-      <div class="p-image-container--cinematic is-cover">
-        {{ image(url="https://assets.ubuntu.com/v1/cd562538-hero.png", alt="",
-                width="1848",
-                height="771",
-                hi_def=True,
-                loading="auto",
-                attrs={"class":"p-image-container__image"}) | safe
-        }}
-      </div>
-    {%- endif -%}
+      </h2>'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding" : "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Get in touch",
+            "attrs": {"href": "/internet-of-things/contact-us?product=robotics", "class": "js-invoke-modal", "aria-controls": "robotics-modal", "aria-expanded": "false"}
+          },
+          "secondaries": [
+            {
+              "content_html": "Read the docs",
+              "attrs": {"href": "https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/security/what-is-ros-esm/"}
+            }
+          ],
+          "link": {
+            "content_html": "Read the datasheet&nbsp;&rsaquo;",
+            "attrs": {"href": "https://assets.ubuntu.com/v1/4dedff79-ROS%20ESM%20datasheet.pdf"}
+          }
+        }
+      },
+      {
+        "type": "image",
+        "item": {
+          "aspect_ratio": "cinematic",
+          "is_cover": true,
+          "attrs": {
+            "src": "https://assets.ubuntu.com/v1/cd562538-hero.png",
+            "alt": "",
+            "width": "1848",
+            "height": "771",
+            "loading": "auto"
+          }
+        }
+      },
+    ]
+    ) -%}
   {%- endcall -%}
 
   {%- call(slot) vf_tiered_list(

--- a/templates/security/cis.html
+++ b/templates/security/cis.html
@@ -19,28 +19,48 @@
   {% call(slot) vf_hero(
     title_text='CIS Benchmark on Ubuntu',
     subtitle_text='Comply with the most widely accepted Linux baseline',
-    layout='25/75'
-    ) -%}
-    {%- if slot == 'signpost_image' -%}
-      {{ image(url="https://assets.ubuntu.com/v1/f98af83d-cis-logo-removebg-preview.png",
-            alt="",
-            width="144",
-            height="144",
-            hi_def=True,
-            loading="auto") | safe
-      }}
-    {%- endif -%}
-    {%- if slot == 'description' -%}
-      <p>
+    chip_text='Available with Ubuntu Pro',
+    layout='25/75',
+    blocks=[
+      {
+        "type": "signpost_image",
+        "item": {
+          "is_highlighted": false,
+          "attrs": {
+            "src": "https://assets.ubuntu.com/v1/f98af83d-cis-logo-removebg-preview.png",
+            "alt": "",
+            "width": "144",
+            "height": "144",
+            "loading": "auto"
+          }
+        }
+      },
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": '<p>
         The CIS benchmark has hundreds of configuration recommendations, so hardening and auditing a Linux system or a kubernetes cluster manually can be very tedious. To drastically improve this process for enterprises, Canonical provides Ubuntu Security Guide (USG) for automated audit and compliance with the CIS benchmarks. Available with <a href="/pro">Ubuntu Pro on-premise</a> or on <a href="/public-cloud">public clouds</a>.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/security/contact-us"
-         class="p-button--positive js-invoke-modal"
-         aria-controls="security-standards-modal">Contact us</a>
-      <a href="/pro">Get Ubuntu Pro&nbsp;&rsaquo;</a>
-    {%- endif -%}
+      </p>'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-standards-modal"}
+          },
+          "link": {
+            "content_html": "Get Ubuntu Pro&nbsp;&rsaquo;",
+            "attrs": {"href": "/pro"}
+          }
+        }
+      },
+    ]
+    ) -%}
   {%- endcall -%}
 
   <section class="p-section">

--- a/templates/security/cmmc.html
+++ b/templates/security/cmmc.html
@@ -17,44 +17,53 @@
 
 {% block content %}
 
-  <section class="p-section--hero">
-    <div class="row--50-50-on-large">
-      <div class="col">
-        <div class="p-section--shallow">
-          <h1>
-            Enable CMMC 2.0 compliance
-            <br class="u-hide u-show--large" />
-            with Ubuntu Pro
-          </h1>
-        </div>
-        <div class="p-section--shallow">
-          <p>
-            Meet CMMC compliance requirements and improve vulnerability management with Ubuntu Pro. Strengthen your security posture to protect Controlled Unclassified Information.
-          </p>
-        </div>
-        <div class="p-cta-block">
-          <p>
-            <a href="/security/contact-us"
-               class="p-button--positive js-invoke-modal"
-               aria-controls="security-standards-modal">Contact us</a>
-            <a class="p-button" href="/pro/free-trial">Access a 30-day free trial</a>
-          </p>
-        </div>
-      </div>
-      <div class="col">
-        <div class="p-image-container--3-2 is-cover">
-          {{ image(url="https://assets.ubuntu.com/v1/0a4cf754-hero-img.jpg",
-                    alt="",
-                    width="600",
-                    height="400",
-                    hi_def=True,
-                    loading="auto",
-                    attrs={"class": "p-image-container__image"},) | safe
-          }}
-        </div>
-      </div>
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text='Enable CMMC 2.0 compliance <br class="u-hide u-show--large" />with Ubuntu Pro',
+    chip_text='Supported with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": '
+            Meet CMMC compliance requirements and improve vulnerability management with Ubuntu Pro. Strengthen your security posture to protect Controlled Unclassified Information.'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-standards-modal"}
+          },
+          "secondaries": [
+            {
+              "content_html": "Access a 30-day free trial",
+              "attrs": {"href": "/pro/free-trial"}
+            }
+          ]
+        }
+      },
+      {
+        "type": "image",
+        "item": {
+          "aspect_ratio": "3-2",
+          "is_cover": true,
+          "attrs": {
+            "src": "https://assets.ubuntu.com/v1/0a4cf754-hero-img.jpg",
+            "alt": "",
+            "width": "600",
+            "height": "400",
+            "loading": "auto"
+          }
+        }
+      },
+    ]
+    ) -%}
+  {% endcall -%}
 
   <section class="p-section--shallow">
     <div class="row--50-50">

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -31,19 +31,36 @@
 
   {% call(slot) vf_hero(
     title_text='Enable DISA STIG compliance with Ubuntu Pro',
-    layout='50/50'
+    chip_text='Available with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": '
+        Simplify and speed up STIG compliance to achieve ATO for your DOD workloads with Ubuntu Pro. Get access to the Ubuntu Security Guide (USG), an automation tool that hardens and audits systems at scale on-prem, on the cloud, and in air-gapped environments.'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-standards-modal"}
+          },
+          "secondaries": [
+            {
+              "content_html": "Get Ubuntu Pro",
+              "attrs": {"href": "/pro"}
+            }
+          ]
+        }
+      },
+    ]
     ) -%}
-    {%- if slot == 'description' -%}
-      <p>
-        Simplify and speed up STIG compliance to achieve ATO for your DOD workloads with Ubuntu Pro. Get access to the Ubuntu Security Guide (USG), an automation tool that hardens and audits systems at scale on-prem, on the cloud, and in air-gapped environments.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/security/contact-us"
-         class="p-button--positive js-invoke-modal"
-         aria-controls="security-standards-modal">Contact us</a>
-      <a href="/pro" class="p-button">Get Ubuntu Pro</a>
-    {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="u-embedded-media">
         <lite-youtube videoid="dWJFBuEn6y4" width="560" height="315" posterquality="maxresdefault" videotitle="STIG hardening on Ubuntu 22.04 with Ubuntu Security Guide" class="u-embedded-media__element">

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -22,17 +22,29 @@
 {% block content %}
   {% call(slot) vf_hero(
     title_text='Expanded Security Maintenance <br />for Ubuntu and open source',
-    layout='50/50'
+    chip_text='Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": 'Extend the lifetime of your favorite Linux and the open source you use on top with reliable security maintenance for up to 15 years.'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Speak to an expert",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-modal"}
+          }
+        }
+      },
+    ]
     ) -%}
-    {%- if slot == 'description' -%}
-      <p>
-        Extend the lifetime of your favorite Linux and the open source you use on top with reliable security maintenance for up to 15 years.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/security/contact-us" aria-controls="security-modal"
-         class="js-invoke-modal p-button--positive">Speak to an expert</a>
-    {%- endif -%}
   {% endcall -%}
 
   <section class="p-section">

--- a/templates/security/fedramp.html
+++ b/templates/security/fedramp.html
@@ -27,20 +27,38 @@
 
   {% call(slot) vf_hero(
     title_text='Enable FedRAMP compliance with Ubuntu Pro',
-    layout='50/50'
-    ) -%}
-    {%- if slot == 'description' -%}
-      <p>
+    chip_text='Supported with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": '
         Achieve FedRAMP Authority to Operate and bring your cloud service offerings to the US Federal Government marketplace with the help of Ubuntu Pro. Meet the most demanding security baseline controls within your technology stack.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/security/contact-us"
-         class="p-button--positive js-invoke-modal"
-         aria-controls="security-standards-modal">Contact us</a>
-      <a href="/pro/subscribe" class="p-button">Get Ubuntu Pro</a>
-    {%- endif -%}
-    {%- if slot == 'image' -%}`
+      '
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-standards-modal"}
+          },
+          "secondaries": [
+            {
+              "content_html": "Get Ubuntu Pro",
+              "attrs": {"href": "/pro/subscribe"}
+            }
+          ]
+        }
+      },
+    ]
+    ) -%}
+    {%- if slot == 'image' -%}
       <div class="u-embedded-media">
         <lite-youtube videoid="vK0bC8jtz3o" width="560" height="315" posterquality="maxresdefault" videotitle="Bridging DevSecOps and compliance I Snyk's FedRAMP success with Canonical on AWS" class="u-embedded-media__element">
         <a href="https://www.youtube.com/watch?v=vK0bC8jtz3o" title="Play Video">

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -27,19 +27,34 @@
 {% block content %}
   {% call(slot) vf_hero(
     title_text='Enable FIPS compliance with Ubuntu Pro',
-    layout='50/50'
+    chip_text='Available with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": '
+        Get easy access to FIPS 140-3 certified modules, required by US federal standards. Run Ubuntu workloads in high-security environments on-prem, in the cloud, and at the edge. Enjoy 1-step access with an Ubuntu Pro subscription.'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-standards-modal"}
+          },
+          "link": {
+            "content_html": "Access a 30-day free trial&nbsp;&rsaquo;",
+            "attrs": {"href": "/pro/free-trial"}
+          }
+        }
+      },
+    ]
     ) -%}
-    {%- if slot == 'description' -%}
-      <p>
-        Get easy access to FIPS 140-3 certified modules, required by US federal standards. Run Ubuntu workloads in high-security environments on-prem, in the cloud, and at the edge. Enjoy 1-step access with an Ubuntu Pro subscription.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/security/contact-us"
-         class="p-button--positive js-invoke-modal"
-         aria-controls="security-standards-modal">Contact us</a>
-      <a href="/pro/free-trial" class="p-link">Access a 30-day free trial&nbsp;&rsaquo;</a>
-    {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="u-embedded-media">
         <lite-youtube
@@ -483,7 +498,7 @@
           <a href="https://documentation.ubuntu.com/security/docs/compliance/fips/fips-overview/">Read the documentation about FIPS for Ubuntu</a>
         </p>
 
-        <hr class="p-rule--muted">
+        <hr class="p-rule--muted" />
 
         <p class="p-section--shallow">
           Ubuntu Pro provides an easy pathway to FIPS compliance in addition to vulnerability patching for Ubuntu OS and Applications. Get automated, unattended, and restartless security updates; and the best tools needed to securely manage your Ubuntu infrastructure, and simplify FIPS and FedRAMP compliance.

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -7,7 +7,6 @@
 {% from "_macros/vf_divided-section.jinja" import vf_divided_section %}
 {% from "macros/_macros-faq-schema.jinja" import faqpage_schema %}
 
-
 {% block title %}Livepatch | Security{% endblock %}
 
 {% block meta_description %}
@@ -28,20 +27,35 @@ meta_copydoc %}
   {% call(slot) vf_hero(
     title_text='Linux Kernel Livepatch',
     subtitle_text='Mitigate Linux kernel exploits<br /> with Livepatch',
-    layout='50/50'
-    ) -%}
-    {%- if slot == 'description' -%}
-      <p>
+    chip_text='Available with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": ' <p>
         Livepatch shrinks the exploit window for critical and high severity Linux kernel vulnerabilities, by patching the Linux kernel between security maintenance windows, while the system runs.
       </p>
       <p>
-        Livepatch provides security coverage for 10 years with <a href="/pro">Ubuntu Pro</a>, and an additional five years with Ubuntu Pro's Legacy add-on, for a total of 15 years.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/pro/subscribe" class="p-button--positive">Get Ubuntu Pro</a>
-    {%- endif -%}
-    {%- if slot == 'image' -%}
+        Livepatch provides security coverage for 10 years with <a href="/pro">Ubuntu Pro</a>, and an additional five years with Ubuntu Pro\'s Legacy add-on, for a total of 15 years.
+      </p>'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Get Ubuntu Pro",
+            "attrs": {"href": "/pro/subscribe"}
+          }
+        }
+      },
+    ]
+  ) -%}
+{%- if slot == 'image' -%}
       <div class="u-embedded-media">
         <iframe class="u-embedded-media__element"
                 width="560"
@@ -491,6 +505,7 @@ meta_copydoc %}
     ) 
   }}
 
+  {# djlint:off #}
   {% set faq_items = [
     ["Should every vulnerability be Livepatched?",
     "<p>Canonical Livepatch patches kernel vulnerabilities with critical and high Common Vulnerability Scoring System (CVSS) and <a href=\"/security/cves/about#priority\">Ubuntu Priority</a> ratings. Canonical targets vulnerabilities that have security implications, such as privilege escalation or remote code execution, and are practical to patch safely in-memory.</p><p>Canonical Livepatch does not patch userspace libraries like OpenSSL or glibc, because that is the responsibility of <a href=\"https://manpages.ubuntu.com/manpages/man8/unattended-upgrade.8.html\">unattended-upgrades</a> or a systems management tool, like <a href=\"/landscape\">Canonical Landscape</a>.</p>"],
@@ -499,6 +514,7 @@ meta_copydoc %}
     ["Is Livepatch a substitute for upgrade and reboot?",
     "<p>Canonical Livepatch is not a replacement for rebooting. It is a tool that gives you more control by preventing unscheduled reboots. Reboots cleanly flush accumulated state inconsistencies from memory leaks, hung file handles, and other problems that could fester with long uptime. Eliminating reboots would expose any operating system to these inefficiencies over time. Trying to avoid all reboots results in incomplete security patching coverage, and leads to fragile patching strategies that involve service restarts and error prone dependency tracing. Scheduling reboots ensures a guaranteed clean slate.</p>"]
   ] %}
+  {# djlint:on #}
 
   {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
 

--- a/templates/security/standards/index.html
+++ b/templates/security/standards/index.html
@@ -21,47 +21,58 @@
 
 {% block content %}
 
-  <section class="p-section--hero">
-    <div class="row--50-50-on-large">
-      <div class="col">
-        <div class="p-section--shallow">
-          <h1>Security standards</h1>
-        </div>
-        <div class="p-section--shallow">
-          <p>
+  {% call(slot) vf_hero(
+    title_text='Security standards',
+    chip_text='Available with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": '<p>
             <strong>Run Ubuntu in high-security environments</strong>. Confidently deploy critical workloads while meeting rigorous cybersecurity standards like NIST 800-53, FedRAMP, and CMMC with Ubuntu Pro. As the publishers of Ubuntu, we’ve also developed automated hardening solutions enabling you to run Ubuntu in any environment.
-          </p>
-        </div>
-        <div class="p-cta-block">
-          <p>
-            <a href="/security/contact-us"
-               class="p-button--positive js-invoke-modal"
-               aria-controls="security-standards-modal">Contact us</a>
-            <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
-          </p>
-        </div>
+          </p>'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {"href": "/security/contact-us", "class": "js-invoke-modal", "aria-controls": "security-standards-modal"}
+          },
+          "link": {
+            "content_html": "Learn more about Ubuntu Pro&nbsp;&rsaquo;",
+            "attrs": {"href": "/pro"}
+          }
+        }
+      },
+    ]
+    ) -%}
+    {%- if slot == 'image' -%}
+      <div class="u-embedded-media">
+        <iframe title="Navigating Compliance and Agility | LaunchDarkly's FedRAMP Journey with Ubuntu Pro FIPS"
+                class="u-embedded-media__element"
+                src="https://www.youtube.com/embed/3pGy8KIt78k?si=b6cEk2OZek1p91LC"
+                allowfullscreen=""
+                frameborder="0"></iframe>
       </div>
-      <div class="col">
-        <div class="u-embedded-media">
-          <iframe title="Navigating Compliance and Agility | LaunchDarkly's FedRAMP Journey with Ubuntu Pro FIPS"
-                  class="u-embedded-media__element"
-                  src="https://www.youtube.com/embed/3pGy8KIt78k?si=b6cEk2OZek1p91LC"
-                  allowfullscreen=""
-                  frameborder="0"></iframe>
-        </div>
-      </div>
-    </div>
-    <div class="u-fixed-width">
-      <div class="p-notification--information is-light">
-        <div class="p-notification__content">
-          <div class="p-notification__message">
-            FIPS 140-3 is now available for Ubuntu 22.04 LTS. Learn more <a href="/blog/fips-140-3-for-ubuntu-22-04lts"
+    {%- endif -%}
+  {% endcall -%}
+
+  <div class="u-fixed-width">
+    <div class="p-notification--information is-light">
+      <div class="p-notification__content">
+        <div class="p-notification__message">
+          FIPS 140-3 is now available for Ubuntu 22.04 LTS. Learn more <a href="/blog/fips-140-3-for-ubuntu-22-04lts"
     aria-label="Learn more about FIPS 140-3 for Ubuntu 22.04 LTS">here</a>.
-          </div>
         </div>
       </div>
     </div>
-  </section>
+  </div>
 
   <div class="u-fixed-width">
     <hr class="p-rule" />

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -21,11 +21,15 @@
     <div class="row--25-75">
       <div class="col">
         <div class="p-section--shallow">
-          <h1 class="u-no-margin--bottom">
+          <h1>
             Enterprise support
             <br />
             for your full open source stack
           </h1>
+          <span class="p-chip--branded">
+            <i class="p-icon--circle-of-friends"></i>
+            <span class="p-chip__value">Available with Ubuntu Pro</span>
+          </span>
         </div>
         <div class="p-section--shallow u-no-margin--bottom">
           <p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8774,10 +8774,10 @@ vanilla-framework@4.35.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.35.0.tgz#b01bbb525ad3211690c9f10580ca2e00a37a8ab1"
   integrity sha512-vF8M9vsXiOpJEonFXiTVhY0rXOzNtoWpkhBcCVpyPb4+oHBx0/FaNcX5GAiQpfdT6Q/AAeRYyWwRUDObq6R8uw==
 
-vanilla-framework@4.50.0:
-  version "4.50.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.50.0.tgz#510a56d73b876eb357deb95a6495a8eef5113c9b"
-  integrity sha512-eDGesUKYO0v+uIsRNHvg8XWcb+do0n6SYsLt/P7XVZSneUFvGbAx702mZXma/BliOI4tygB0EGZ/6bXuTsTTPA==
+vanilla-framework@4.56.0:
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.56.0.tgz#237625da8eded879af803a51ae707d43d6f2bc66"
+  integrity sha512-FyMKeYePuhEEXeuvZj18qqZN6u4eHgTvclwCfLBh01OF9dsIroTklP2GGVdlGbJZHZSlbRRbVGIRcVhyjY0NBg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Added the branded **Ubuntu Pro chip** to the hero of every in-repo page listed in the [WD-37571 sheet](https://docs.google.com/spreadsheets/d/1LsN8r_BGN7PDRU9Eo9o-cUHkZgRANMAT-HIwssdNxdI/edit?gid=0#gid=0). Where a hero used `vf_hero`, the affected calls were migrated from the deprecated **slots** to **blocks**. The two `p-suru` background heroes that can't be reproduced by `vf_hero` got the same chip added via **plain HTML** instead.

| Page | Chip text | Hero change |
| --- | --- | --- |
| Livepatch | Available with Ubuntu Pro | reference/example |
| Landscape | Available with Ubuntu Pro | slots → blocks |
| Managed Landscape | Available with Ubuntu Pro | slots → blocks |
| Security standards | Available with Ubuntu Pro | custom hero → `vf_hero` |
| FIPS | Available with Ubuntu Pro | slots → blocks (video kept in slot) |
| DISA-STIG | Available with Ubuntu Pro | slots → blocks (video kept in slot) |
| CIS | Available with Ubuntu Pro | slots → blocks |
| ROS ESM | Available with Ubuntu Pro | slots → blocks |
| FedRAMP | Supported with Ubuntu Pro | slots → blocks (video kept in slot) |
| CMMC | Supported with Ubuntu Pro | custom hero → `vf_hero` |
| Containers | Secured with Ubuntu Pro | custom hero → `vf_hero` |
| Ubuntu ESM | Ubuntu Pro | slots → blocks |
| Enterprise support | Available with Ubuntu Pro | chip added via plain HTML (`p-suru` hero) |
| Ubuntu Pro for Devices | Ubuntu Pro | chip added via plain HTML (`p-suru` hero) |

> **Note on videos** — Where a hero contains a video (FIPS, DISA-STIG, FedRAMP, Security standards, Livepatch), the video is intentionally left in the deprecated `image` slot rather than converted to a block. Converting videos into `vf_hero` blocks is blocked by **[WD-38111](https://warthogs.atlassian.net/browse/WD-38111)**.

## QA

The base demo link is posted by **webbot** in a comment on this PR. Per-page links (demo = `pull/16661`, live = production):

- Livepatch — [demo](https://ubuntu-com-16661.demos.haus/security/livepatch) · [live](https://ubuntu.com/security/livepatch)
- Landscape — [demo](https://ubuntu-com-16661.demos.haus/landscape) · [live](https://ubuntu.com/landscape)
- Managed Landscape — [demo](https://ubuntu-com-16661.demos.haus/landscape/managed) · [live](https://ubuntu.com/landscape/managed)
- Security standards — [demo](https://ubuntu-com-16661.demos.haus/security/security-standards) · [live](https://ubuntu.com/security/security-standards)
- FIPS — [demo](https://ubuntu-com-16661.demos.haus/security/fips) · [live](https://ubuntu.com/security/fips)
- DISA-STIG — [demo](https://ubuntu-com-16661.demos.haus/security/disa-stig) · [live](https://ubuntu.com/security/disa-stig)
- CIS — [demo](https://ubuntu-com-16661.demos.haus/security/cis) · [live](https://ubuntu.com/security/cis)
- ROS ESM — [demo](https://ubuntu-com-16661.demos.haus/robotics/ros-esm) · [live](https://ubuntu.com/robotics/ros-esm)
- FedRAMP — [demo](https://ubuntu-com-16661.demos.haus/security/fedramp) · [live](https://ubuntu.com/security/fedramp)
- CMMC — [demo](https://ubuntu-com-16661.demos.haus/security/cmmc) · [live](https://ubuntu.com/security/cmmc)
- Containers — [demo](https://ubuntu-com-16661.demos.haus/containers) · [live](https://ubuntu.com/containers)
- Ubuntu ESM — [demo](https://ubuntu-com-16661.demos.haus/security/esm) · [live](https://ubuntu.com/security/esm)
- Enterprise support — [demo](https://ubuntu-com-16661.demos.haus/support) · [live](https://ubuntu.com/support)
- Ubuntu Pro for Devices — [demo](https://ubuntu-com-16661.demos.haus/pro/devices) · [live](https://ubuntu.com/pro/devices)

For each page: confirm the Ubuntu Pro chip renders in the hero with the correct label, and that the hero layout/content is unchanged from production. Run through the standard [QA steps](https://discourse.canonical.com/t/qa-steps/152).

## Not done (and why)

- **`… | Canonical` pages** (enterprise PostgreSQL, MySQL, MongoDB, Apache Kafka, OpenSearch, Valkey, Apache Spark on Kubernetes, Kubeflow, Charmed MLflow, Feast) — these live in the **canonical.com** repository, not ubuntu.com, so they are out of scope here. The sheet also notes several "Will be included in the new webpages".
- **Rows marked "None" in the sheet** (Enable PCI-DSS compliance, Cyber Resilience Act, `/real-time`) — no chip was requested.

## Issue / Card

Fixes [WD-37571](https://warthogs.atlassian.net/browse/WD-37571)

Related: [WD-38111](https://warthogs.atlassian.net/browse/WD-38111) (videos in `vf_hero` blocks)


[WD-38111]: https://warthogs.atlassian.net/browse/WD-38111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ