### PR TITLE
WD-38130: /training copy update + link wrapping fixes

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1888,11 +1888,11 @@ ol.p-stepped-list.no-full-stop
   }
 }
 
-// Custom styling for training page that ensures
-// CTA buttons/links are stacked on small screens
+// Custom styling for training page CTA link groups.
 .training-cta--stacked {
   display: flex;
   flex-wrap: wrap;
+  column-gap: 1rem;
 }
 
 // Truncates text to two lines with ellipsis

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -139,8 +139,8 @@
               <a class="p-button--positive u-hide--medium u-hide--small"
                  href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
               <div class="p-cta-block u-hide--medium u-hide--small">
-                <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (Charmed OpenStack version)&nbsp;&rsaquo;</a>
-                <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (Sunbeam version)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
               </div>
             </div>
             <div class="col-3">
@@ -165,8 +165,8 @@
               <a class="p-button--positive"
                  href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
               <p class="training-cta--stacked">
-                <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (Charmed OpenStack version)&nbsp;&rsaquo;</a>
-                <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (Sunbeam version)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>
@@ -184,8 +184,8 @@
               <a class="p-button--positive u-hide--medium u-hide--small"
                  href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
               <div class="p-cta-block u-hide--medium u-hide--small">
-                <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (Charmed OpenStack version)&nbsp;&rsaquo;</a>
-                <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (Sunbeam version)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
               </div>
             </div>
             <div class="col-3">
@@ -210,8 +210,8 @@
               <a class="p-button--positive"
                  href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
               <p class="training-cta--stacked">
-                <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (OpenStack version)&nbsp;&rsaquo;</a>
-                <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (Sunbeam version)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
+                <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -528,8 +528,8 @@
                 This is an add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students.
               </p>
               <div class="p-cta-block u-hide--medium u-hide--small">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
+                 <a class="p-button--positive"
+                   href="/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
               </div>
             </div>
             <div class="col-3">
@@ -548,7 +548,7 @@
           </div>
           <div class="p-cta-block u-hide--large">
             <a class="p-button--positive"
-               href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
+              href="/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
           </div>
         </section>
         <hr class="p-rule" />

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -95,10 +95,10 @@
               <p itemprop="description" class="u-sv3">
                 A three-day hands-on course for up to 15 people that focuses on MongoDB. The aim of this training is to educate users on MongoDB, practice deployment, perform operations and optimizations as well as troubleshooting.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive" href="/contact-us">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/5dcac162-Charmed%20MongoDB%20Training_Public%20Module.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -117,13 +117,9 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive" href="/contact-us">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/5dcac162-Charmed%20MongoDB%20Training_Public%20Module.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive" href="/contact-us">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/5dcac162-Charmed%20MongoDB%20Training_Public%20Module.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -138,7 +134,7 @@
               </p>
               <a class="p-button--positive u-hide--medium u-hide--small"
                  href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
-              <div class="p-cta-block u-hide--medium u-hide--small">
+              <div class="training-cta--stacked u-hide--medium u-hide--small">
                 <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
                 <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
               </div>
@@ -160,15 +156,11 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <a class="p-button--positive"
-                 href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
-              <p class="training-cta--stacked">
-                <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
-                <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <a class="p-button--positive u-hide--large"
+             href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
+          <div class="training-cta--stacked u-hide--large">
+            <a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
+            <a href="https://assets.ubuntu.com/v1/5147b2c3-training_curriculum_openstack_fundamentals_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -183,7 +175,7 @@
               </p>
               <a class="p-button--positive u-hide--medium u-hide--small"
                  href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
-              <div class="p-cta-block u-hide--medium u-hide--small">
+              <div class="training-cta--stacked u-hide--medium u-hide--small">
                 <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
                 <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
               </div>
@@ -205,15 +197,11 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <a class="p-button--positive"
-                 href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
-              <p class="training-cta--stacked">
-                <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
-                <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <a class="p-button--positive u-hide--large"
+             href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
+          <div class="training-cta--stacked u-hide--large">
+            <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (gen 1)&nbsp;&rsaquo;</a>
+            <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (gen 2)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -252,14 +240,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <a class="p-button--positive"
-                 href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
-              <p class="training-cta--stacked">
-                <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=openstack-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -346,10 +330,10 @@
                   </div>
                 </div>
               </div>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -374,11 +358,9 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <a class="p-button--positive"
-                 href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
           </div>
         </section>
         <hr class="p-rule is-muted" />
@@ -463,11 +445,11 @@
                   </div>
                 </div>
               </div>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -492,14 +474,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=openstack-training-server-admin">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/987b4fd7-ubuntu_server_advanced_training_curriculum_v3.docx.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -512,11 +490,11 @@
               <p itemprop="description" class="u-sv3">
                 A three-day hands-on course for up to 15 people that guides you through Charmed Kubernetes. You will learn about Kubernetes, how to deploy it and configure it, as well as how to perform operational actions such as live upgrades.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -535,14 +513,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule is-muted" />
@@ -553,10 +527,10 @@
               <p itemprop="description" class="u-sv3">
                 This is an add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -572,11 +546,9 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <a class="p-button--positive"
-                 href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite">Contact us to book</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -589,11 +561,11 @@
               <p itemprop="description" class="u-sv3">
                 A four-day workshop-like course for up to 15 people that guides you through all aspects of performing effective Machine Learning and Deep Learning automation on your Kubeflow cluster. A follow-up course to Kubernetes Explorer, it guides you through common tasks such as creating Pipelines, working with Notebooks, training models, visualizing results, model serving, and troubleshooting, as well as introducing MLOps practices for streamlined data science using containerized frameworks and infrastructure.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=kubeflow-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -612,14 +584,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=kubeflow-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=kubeflow-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -632,11 +600,11 @@
               <p itemprop="description" class="u-sv3">
                 A two-day hands-on course for up to 15 people that guides you through MAAS and how to treat your bare metal estate as a cloud. The aim of this training is to help users understand MAAS components, installing and configuring them, as well on-going MAAS operations for physical and virtual machines (KVM), network configuration and image management.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=maas-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/dc6e1ec3-Canonical_training-MAAS_Deployment_and_Operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -655,14 +623,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=maas-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/dc6e1ec3-Canonical_training-MAAS_Deployment_and_Operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=maas-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/dc6e1ec3-Canonical_training-MAAS_Deployment_and_Operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -675,11 +639,11 @@
               <p itemprop="description" class="u-sv3">
                 A three-day hands-on course for up to 15 people that focuses on Ceph storage. The aim of this training is to educate users on Ceph, practice deployment, perform operations and optimizations of Ceph storage, as well as troubleshooting.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=ceph-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/28ca49c8-Ceph+Operations+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -698,14 +662,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=ceph-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/28ca49c8-Ceph+Operations+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=ceph-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/28ca49c8-Ceph+Operations+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -718,11 +678,11 @@
               <p itemprop="description" class="u-sv3">
                 A three-day hands-on course for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -741,14 +701,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=landscape-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/fa8312b8-landscape_deployment_and_operations_training_curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -759,11 +715,11 @@
               <p itemprop="description" class="u-sv3">
                 A three-day hands-on course for up to 15 people that focuses on Juju. The course is designed to enable administrators to quickly become proficient at managing Juju and deploying, configuring and integrating applications across computing substrates. The course is a blend of theory sessions and hands-on practical labs which see attendees deploying charmed applications on VMs, containers and Kubernetes clusters.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=juju-administrator-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/79354a32-Juju+Administrator+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -782,14 +738,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=juju-administrator-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/79354a32-Juju+Administrator+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=juju-administrator-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/79354a32-Juju+Administrator+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -800,11 +752,11 @@
               <p itemprop="description" class="u-sv3">
                 A two-day hands-on course for up to 15 people that focuses on Charms. This course is an introduction to charmed operator development and covers the development, testing and release of charmed operators for both machines and Kubernetes. The course is delivered as a blend of theory lessons and hands-on practical labs. Upon completion, attendees will feel comfortable developing charms that can manage applications throughout their life, and integrate seamlessly with other applications across computing substrates.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=charm-developer-training-onsite">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/fda645b1-Charm+Developer+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -823,14 +775,10 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=charm-developer-training-onsite">Contact us to book</a>
-                <a href="https://assets.ubuntu.com/v1/fda645b1-Charm+Developer+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=charm-developer-training-onsite">Contact us to book</a>
+            <a href="https://assets.ubuntu.com/v1/fda645b1-Charm+Developer+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
         <hr class="p-rule" />
@@ -841,11 +789,11 @@
               <p itemprop="description" class="u-sv3">
                 A hands-on workshop to learn how to create, build, publish and maintain your own snaps using Snapcraft and deploy them on Ubuntu Core. The workshop alternates short instructor-led discussions with task-focused practical labs. At the end of the two day workshop, your development team will be fully capable of deploying and maintaining your own snaps.
               </p>
-              <p class="u-hide--medium u-hide--small">
+              <div class="p-cta-block u-hide--medium u-hide--small">
                 <a class="p-button--positive"
                    href="/training/contact-us?product=snapcraft-101">Contact us to book</a>
                 <a href="https://assets.ubuntu.com/v1/f44d287e-Snapcraft 101 Outline.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
+              </div>
             </div>
             <div class="col-3">
               <ul class="p-list">
@@ -864,15 +812,11 @@
               </ul>
             </div>
           </div>
-          <div class="row u-hide--large">
-            <div class="col-6">
-              <p class="training-cta--stacked">
-                <a class="p-button--positive"
-                   href="/training/contact-us?product=snapcraft-101">Contact us to book</a>
+          <div class="p-cta-block u-hide--large">
+            <a class="p-button--positive"
+               href="/training/contact-us?product=snapcraft-101">Contact us to book</a>
 
-                <a href="https://assets.ubuntu.com/v1/f44d287e-Snapcraft 101 Outline.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
-              </p>
-            </div>
+            <a href="https://assets.ubuntu.com/v1/f44d287e-Snapcraft 101 Outline.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Done

- Copy update for [WD-38130](https://warthogs.atlassian.net/browse/WD-38130)

### Drive-by
1. The shorter links' text resulted in unexpected wrapping, where two links landed on the same line with no spacing between them. Some sections' CTAs, on the other hand, displayed the link below the primary button, even though the link had enough space to fit next to it. See the screenshots:

<img width="1532" height="416" alt="2026-08-10_12-48-40" src="https://github.com/user-attachments/assets/c2279b05-f79d-4693-abbf-767ba5e91b44" />

<img width="650" height="201" alt="2026-08-10_12-49-15" src="https://github.com/user-attachments/assets/bba94ea8-f48d-41ee-87be-e50ceb751f0d" />

Both issues were fixed by replacing the standard `button` + `link` CTAs with `.p-cta-block` and reusing the already present `.training-cta--stacked` (with an added `column-gap` of `1rem`) as the container for whenever 2 links are present.

<img width="495" height="168" alt="2026-08-10_12-56-34" src="https://github.com/user-attachments/assets/c441fe0c-5555-49ae-8c05-7544112f581a" />

<img width="562" height="172" alt="2026-08-10_12-56-48" src="https://github.com/user-attachments/assets/338392b1-a225-40cd-86e1-d4441585c0f5" />

2. Replace `/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite` links with `/training/contact-us?product=kubernetes-training-onsite`

## QA

- Open the [DEMO](https://ubuntu-com-16667.demos.haus/training)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card
- [WD-38130](https://warthogs.atlassian.net/browse/WD-38130)
- [Copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?tab=t.0)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-38130]: https://warthogs.atlassian.net/browse/WD-38130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-38130]: https://warthogs.atlassian.net/browse/WD-38130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
