### PR TITLE
Add main-content skip link

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -181,6 +181,8 @@
           </noscript>
           <!-- end google tag manager -->
 
+          <a href="#main-content" class="p-link--skip">Skip to main content</a>
+
           {% include "templates/_getfeedback.html" %}
           {% include "templates/_notifications.html" %}
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -45,10 +45,19 @@ class TestRoutes(VCRTestCase):
     def test_homepage(self):
         """
         When given the index URL,
-        we should return a 200 status code
+        we should return a 200 status code and provide a main-content bypass
+        link for keyboard users.
         """
 
-        self.assertEqual(self.client.get("/").status_code, 200)
+        response = self.client.get("/")
+
+        self.assertEqual(response.status_code, 200)
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        skip_link = soup.find("a", class_="p-link--skip")
+        self.assertIsNotNone(skip_link)
+        self.assertEqual(skip_link.get("href"), "#main-content")
+        self.assertIsNotNone(soup.find(id="main-content"))
 
     def test_mirrors(self):
         """


### PR DESCRIPTION
## What

- add a keyboard-accessible skip link before the global navigation
- point it at the existing `main-content` landmark
- cover the link and target with a homepage route regression test

## Why

This addresses the missing bypass-link finding in #16572. Keyboard users can now move directly from the start of the page to the primary content.

## Impact

The link uses Vanilla Framework's existing `p-link--skip` component, so it stays visually hidden until focused. No navigation or content structure changes are introduced.

## QA

- `python -m unittest tests.test_routes.TestRoutes.test_homepage`
- `flake8 tests/test_routes.py`
- `black --check --line-length 79 tests/test_routes.py`
- `git diff --check`
- full `tests.test_routes`: 33 pass; the two unrelated `/pro` and `/ceph` 500s also reproduce on the untouched base commit
