### PR TITLE
Wd 38188 Copy Update Task -  Update https://ubuntu.com/download/renesas-iot

### DIFF
--- a/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
+++ b/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
@@ -1,10 +1,8 @@
-<div
-  tabindex="3"
-  role="tabpanel"
-  id="renesas-rz-g3e-tab"
-  aria-labelledby="renesas-rz-g3e"
-  aria-hidden="true"
->
+<div tabindex="3"
+     role="tabpanel"
+     id="renesas-rz-g3e-tab"
+     aria-labelledby="renesas-rz-g3e"
+     aria-hidden="true">
   <div class="p-section--shallow">
     <div class="row">
       <div class="col-6">
@@ -21,22 +19,13 @@
             coming soon.
           </p>
           <div>
-            <a
-              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-desktop-2604-release-20260507.img.xz"
-              class="p-button--positive"
-              >Download Ubuntu 26.04</a
-            >
-            <a
-              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3e.tar.gz"
-              class="p-button"
-              >Download boot assets</a
-            >
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-desktop-2604-release-20260507.img.xz"
+               class="p-button--positive">Download Ubuntu 26.04</a>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3e.tar.gz"
+               class="p-button">Download boot assets</a>
           </div>
           <div class="p-cta-block">
-            Ubuntu 26.04 for RZ/G3E&nbsp;<a
-              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
-              >image installation instructions</a
-            >
+            Ubuntu 26.04 for RZ/G3E&nbsp;<a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf">image installation instructions</a>
           </div>
         </div>
       </div>
@@ -51,25 +40,36 @@
             coming soon.
           </p>
           <div>
-            <a
-              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-server-2604-release-20260507.img.xz"
-              class="p-button--positive"
-              >Download Ubuntu 26.04</a
-            >
-            <a
-              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3e.tar.gz"
-              class="p-button"
-              >Download boot assets</a
-            >
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-server-2604-release-20260507.img.xz"
+               class="p-button--positive">Download Ubuntu 26.04</a>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3e.tar.gz"
+               class="p-button">Download boot assets</a>
           </div>
           <div class="p-cta-block">
-            Ubuntu 26.04 for RZ/G3E&nbsp;<a
-              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
-              >image installation instructions</a
-            >
+            Ubuntu 26.04 for RZ/G3E&nbsp;<a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf">image installation instructions</a>
           </div>
         </div>
       </div>
+
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Core 26</h3>
+        </div>
+        <div class="col-6">
+          <p>This is the Ubuntu Core 26 Certified release on Renesas IoT Platforms for the Renesas RZ family.</p>
+          <div>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuCoreQuickStartGuide_uc26_rzg_x03.pdf"
+               class="p-button--positive">Build your Core 26</a>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/uc26/x03/bootassets-rzg3e.tar.gz"
+               class="p-button">Download boot assets</a>
+          </div>
+          <div class="p-cta-block">
+            Try Core 26&nbsp;<a href="https://people.canonical.com/~platform/images/renesas-iot/uc26/x03/iot-renesas-rz-core26-x03-release.img.xz">pre-built image</a>&nbsp;and follow&nbsp;<a href="https://documentation.ubuntu.com/core/how-to-guides/deploy-an-image/install-on-renesas/index.html">installation instructions</a>
+          </div>
+        </div>
+      </div>
+
     </div>
   </div>
   <hr class="p-rule--muted" />
@@ -80,17 +80,11 @@
     <div class="col-6">
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu 26.04 for&nbsp;<a
-            href="https://www.renesas.com/en/products/rz-g3e"
-            >RZ/G3E</a
-          >
+          Get started with Ubuntu 26.04 for&nbsp;<a href="https://www.renesas.com/en/products/rz-g3e">RZ/G3E</a>
         </li>
         <li class="p-list__item">
           Ubuntu for RZ/G3E
-          <a
-            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3E-G3S%20Release%20Notes-x02.pdf"
-            >release notes</a
-          >
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3S-G3E_Release%20Notes-x03.pdf">release notes</a>
         </li>
         <hr class="p-rule--muted" />
       </ul>
@@ -98,10 +92,7 @@
         <div class="p-notification__content">
           <p class="p-notification__message">
             The Ubuntu images are tested on the
-            <a
-              href="https://www.renesas.com/en/design-resources/boards-kits/rz-g3e-evkit?part-status=Active"
-              >RZ/G3E-EVKIT</a
-            >
+            <a href="https://www.renesas.com/en/design-resources/boards-kits/rz-g3e-evkit?part-status=Active">RZ/G3E-EVKIT</a>
           </p>
         </div>
       </div>

--- a/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
+++ b/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
@@ -50,7 +50,6 @@
           </div>
         </div>
       </div>
-
       <hr class="p-rule--muted" />
       <div class="row">
         <div class="col-3">
@@ -69,7 +68,6 @@
           </div>
         </div>
       </div>
-
     </div>
   </div>
   <hr class="p-rule--muted" />

--- a/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
+++ b/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
@@ -1,10 +1,8 @@
-<div
-  tabindex="3"
-  role="tabpanel"
-  id="renesas-rz-g3s-tab"
-  aria-labelledby="renesas-rz-g3s"
-  aria-hidden="true"
->
+<div tabindex="3"
+     role="tabpanel"
+     id="renesas-rz-g3s-tab"
+     aria-labelledby="renesas-rz-g3s"
+     aria-hidden="true">
   <div class="p-section--shallow">
     <div class="row">
       <div class="col-6">
@@ -21,22 +19,30 @@
             coming soon.
           </p>
           <div>
-            <a
-              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-server-2604-release-20260507.img.xz"
-              class="p-button--positive"
-              >Download Ubuntu 26.04</a
-            >
-            <a
-              href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3s.tar.gz"
-              class="p-button"
-              >Download boot assets</a
-            >
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/iot-renesas-rz-classic-server-2604-release-20260507.img.xz"
+               class="p-button--positive">Download Ubuntu 26.04</a>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-26.04/x02/bootassets-rzg3s.tar.gz"
+               class="p-button">Download boot assets</a>
           </div>
           <div class="p-cta-block">
-            Ubuntu 26.04 for RZ/G3S&nbsp;<a
-              href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf"
-              >image installation instructions</a
-            >
+            Ubuntu 26.04 for RZ/G3S&nbsp;<a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G3E%20and%20RZ_G3S%20family%20EVKITs%20with%20classic%20Ubuntu%20images.pdf">image installation instructions</a>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Ubuntu Core 26</h3>
+        </div>
+        <div class="col-6">
+          <p>This is the Ubuntu Core 26 Certified release on Renesas IoT Platforms for the Renesas RZ family.</p>
+          <div>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuCoreQuickStartGuide_uc26_rzg_x03.pdf"
+               class="p-button--positive">Build your Core 26</a>
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/uc26/x03/bootassets-rzg3s.tar.gz"
+               class="p-button">Download boot assets</a>
+          </div>
+          <div class="p-cta-block">
+            Try Core 26&nbsp;<a href="https://people.canonical.com/~platform/images/renesas-iot/uc26/x03/iot-renesas-rz-core26-x03-release.img.xz">pre-built image</a>&nbsp;and follow&nbsp;<a href="https://documentation.ubuntu.com/core/how-to-guides/deploy-an-image/install-on-renesas/index.html">installation instructions</a>
           </div>
         </div>
       </div>
@@ -50,17 +56,11 @@
     <div class="col-6">
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu 26.04 for&nbsp;<a
-            href="https://www.renesas.com/en/products/rz-g3s"
-            >RZ/G3S</a
-          >
+          Get started with Ubuntu 26.04 for&nbsp;<a href="https://www.renesas.com/en/products/rz-g3s">RZ/G3S</a>
         </li>
         <li class="p-list__item">
           Ubuntu for RZ/G3S
-          <a
-            href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3E-G3S%20Release%20Notes-x02.pdf"
-            >release notes</a
-          >
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G3S-G3E_Release%20Notes-x03.pdf">release notes</a>
         </li>
         <hr class="p-rule--muted" />
       </ul>
@@ -68,10 +68,7 @@
         <div class="p-notification__content">
           <p class="p-notification__message">
             The Ubuntu images are tested on the
-            <a
-              href="https://www.renesas.com/en/design-resources/boards-kits/rz-g3s-evkit?part-status=Active"
-              >RZ/G3S-EVKIT</a
-            >
+            <a href="https://www.renesas.com/en/design-resources/boards-kits/rz-g3s-evkit?part-status=Active">RZ/G3S-EVKIT</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

Updated the downloads page for renesas-iot platforms

1) Updated Tab 5 (RZ/G3E Tab) with new copy doc information. This includes a new Ubuntu Core 26 section and a new release note for the get started section.

2) Updated Tab 6 (RZ/G3S tab) with new copy doc information. This included creating a new ubuntu core 26 section and updating the release notes in the get started section.


## QA

- Open the [DEMO](__DEMO_URL__)
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/renesas-iot#renesas-rz-g3e  and   http://0.0.0.0:8001/download/renesas-iot#renesas-rz-g3s 
    - Be sure to test on mobile, tablet and desktop screen sizes




- Copy Doc: https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?tab=t.0#heading=h.qo28ljy8t9qd\

- JIRA Ticket: https://warthogs.atlassian.net/browse/WD-38188?actionerId=557058%3Af58131cb-b67d-43c7-b30d-6b58d40bd077&sourceType=assign 
