### PR TITLE
fix: added guard for webinar

### DIFF
--- a/templates/engage/shared/_webinar-embed.html
+++ b/templates/engage/shared/_webinar-embed.html
@@ -1,4 +1,4 @@
-{% if metadata["webinar_code"] is defined %}
+{% if metadata["webinar_code"] %}
   {% if "channel_id" in metadata %}
     {% set channel_id = metadata["channel_id"] %}
   {% else %}


### PR DESCRIPTION
## Done
- Added a guard to `webinar_code` so that page renders even if it doesn't exist.

## QA
- Visit /engage/cra-checklist on the demo
- Ensure that the page loads.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-38202

