### PR TITLE
Wd 38188 Copy Update Task - Fix (Added missing line separator)

### DIFF
--- a/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
+++ b/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
@@ -29,6 +29,7 @@
           </div>
         </div>
       </div>
+      <hr class="p-rule--muted" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Ubuntu Core 26</h3>


### PR DESCRIPTION
## Done

This is a fix for my approved copy update: https://github.com/canonical/ubuntu.com/pull/16671

I noticed a line separator was missing in Tab 6 (RZ/G3S tab)  between the Ubuntu Server 26.04 and Ubuntu Core 26 sections. So I made a fix to add that line separator.

## QA

- Open the [DEMO](__DEMO_URL__)
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/renesas-iot#renesas-rz-g3s and compare to the live site: https://ubuntu.com/download/renesas-iot#renesas-rz-g3s notice the line separator is now added.




## Old information from the copy update

- Copy Doc: https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?tab=t.0#heading=h.qo28ljy8t9qd\

- JIRA Ticket: https://warthogs.atlassian.net/browse/WD-38188?actionerId=557058%3Af58131cb-b67d-43c7-b30d-6b58d40bd077&sourceType=assign 
