### PR TITLE
feat(kubernetes): add warning note about rocks.c.c decommission

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/1.34/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.34/release-notes.md
@@ -18,6 +18,8 @@ toc: False
 
 ---
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 # 1.34+ck2
 
 ### Mar 10, 2026 - `charmed-kubernetes --channel 1.34/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.35/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.35/release-notes.md
@@ -18,6 +18,8 @@ toc: False
 
 ---
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 # 1.35
 
 ### Apr 16, 2026 - `charmed-kubernetes --channel 1.35/stable`

--- a/templates/kubernetes/charmed-k8s/docs/docker-registry.md
+++ b/templates/kubernetes/charmed-k8s/docs/docker-registry.md
@@ -18,6 +18,8 @@ for your cluster, taking care of the storage and distribution of
 container images. There are a few reasons why this may be a useful option
 for your cluster:
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 -  Providing the images required by Charmed Kubernetes without requiring
    access to a public registry (e.g. in environments where network access
    is controlled, expensive or otherwise problematic).
@@ -196,4 +198,3 @@ juju config kubernetes-control-plane image-registry=$REGISTRY
     <p>See the guide to <a href="/kubernetes/charmed-k8s/docs/how-to-contribute"> contributing </a> or discuss these docs in our <a href="https://kubernetes.slack.com/archives/CG1V2CAMB"> public Slack  channel</a>.</p>
   </div>
 </div>
-

--- a/templates/kubernetes/charmed-k8s/docs/how-to-install.md
+++ b/templates/kubernetes/charmed-k8s/docs/how-to-install.md
@@ -18,6 +18,8 @@ Charmed Kubernetes, additional guides are available to take you through the
 installation steps for a number of different substrates. The 'Cloud' install
 page covers many different scenarios with Juju-supported clouds.
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 - [Install on a cloud](/kubernetes/charmed-k8s/docs/install-manual)
 - [Install on existing machines](/kubernetes/charmed-k8s/docs/install-existing)
 - [Install locally with LXD](/kubernetes/charmed-k8s/docs/install-local)

--- a/templates/kubernetes/charmed-k8s/docs/install-existing.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-existing.md
@@ -22,6 +22,8 @@ In this guide, we will create a manual cloud with 3 existing machines. We will t
 deploy a minimal installation of **Charmed Kubernetes** to this cloud using the
 [Kubernetes Core][kubernetes-core] bundle.
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>

--- a/templates/kubernetes/charmed-k8s/docs/install-local.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-local.md
@@ -21,6 +21,8 @@ requirements which may exceed a standard laptop or desktop machine. It is only
 recommended on a machine running at least Ubuntu 20.04 with 32GB RAM and 128GB of
 SSD storage.
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>

--- a/templates/kubernetes/charmed-k8s/docs/install-manual.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-manual.md
@@ -24,6 +24,8 @@ customise the install:
   - Testing a pre-release version
   - ...and many more
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 ## What you will need
 
 The rest of this page assumes you already have Juju installed and have added

--- a/templates/kubernetes/charmed-k8s/docs/install-offline.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-offline.md
@@ -25,6 +25,8 @@ services in a restricted environment you may already have some 'air-gap'
 resources available, and may only need to configure Charmed Kubernetes to
 make use of them.
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Shrinkwrap</span>

--- a/templates/kubernetes/charmed-k8s/docs/ipv6.md
+++ b/templates/kubernetes/charmed-k8s/docs/ipv6.md
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
       - name: nginxdualstack
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---
@@ -177,4 +177,3 @@ No additional issues with IPv6 on MAAS are known at this time.
 [ip-families]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
 [asset-ipv4-ipv6-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/ipv4-ipv6-overlay.yaml
 [asset-nginx-dual-stack]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/specs/nginx-dual-stack.yaml
-

--- a/templates/kubernetes/charmed-k8s/docs/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/release-notes.md
@@ -13,6 +13,8 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+{% include "kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html" %}
+
 # 1.35
 
 ### Apr 16, 2026 - `charmed-kubernetes --channel 1.35/stable`

--- a/templates/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms.md
+++ b/templates/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms.md
@@ -1,0 +1,37 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/charmed-k8s/docs/shared/_side-navigation.md"
+context:
+  title: "Rocks registry affected charms"
+  description: Charms affected by the rocks.canonical.com registry decommission
+keywords: rocks.canonical.com, registry, charm
+tags: [reference]
+sidebar: k8smain-sidebar
+permalink: rocks-registry-affected-charms.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+Canonical is decommissioning the `rocks.canonical.com` container image registry. This affects Charmed Kubernetes releases 1.35 and earlier. Existing deployments must migrate to the new `ghcr.io/canonical/cdk` registry by updating the `image-registry` configuration for every deployed charm and component listed below.
+
+- [ceph-csi-operator](https://github.com/charmed-kubernetes/ceph-csi-operator)
+- [charm-aws-cloud-provider](https://github.com/charmed-kubernetes/charm-aws-cloud-provider)
+- [charm-calico](https://github.com/charmed-kubernetes/charm-calico)
+- [charm-cilium](https://github.com/charmed-kubernetes/charm-cilium)
+- [charm-containerd](https://github.com/charmed-kubernetes/charm-containerd)
+- [charm-coredns](https://github.com/charmed-kubernetes/charm-coredns)
+- [charm-flannel](https://github.com/charmed-kubernetes/charm-flannel)
+- [charm-kube-ovn](https://github.com/charmed-kubernetes/charm-kube-ovn)
+- [charm-kubernetes-control-plane](https://github.com/charmed-kubernetes/charm-kubernetes-control-plane)
+- [charm-multus](https://github.com/charmed-kubernetes/charm-multus)
+- [charm-sriov-cni](https://github.com/charmed-kubernetes/charm-sriov-cni)
+- [charm-sriov-network-device-plugin](https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin)
+- [cinder-csi-operator](https://github.com/canonical/cinder-csi-operator)
+- [k8s-operator](https://github.com/canonical/k8s-operator)
+- [keystone-k8s-auth-operator](https://github.com/canonical/keystone-k8s-auth-operator)
+- [kubernetes-metrics-server-operator](https://github.com/charmed-kubernetes/kubernetes-metrics-server-operator)
+- [layer-canal](https://github.com/charmed-kubernetes/layer-canal)
+- [metallb-operator](https://github.com/charmed-kubernetes/metallb-operator)
+- [openstack-cloud-controller-operator](https://github.com/charmed-kubernetes/openstack-cloud-controller-operator)
+- [vsphere-cloud-provider](https://github.com/charmed-kubernetes/vsphere-cloud-provider)

--- a/templates/kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html
+++ b/templates/kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html
@@ -1,0 +1,11 @@
+<div class="p-notification--caution is-inline">
+  <div class="p-notification__content">
+    <span class="p-notification__title">Warning:</span>
+    <p class="p-notification__message">Canonical is decommissioning the <code>rocks.canonical.com</code> container image registry as part of our infrastructure modernization. The registry will be unavailable after <strong>August 31, 2026</strong>. This affects Charmed Kubernetes releases 1.35 and earlier. New Charmed Kubernetes 1.36+ deployments use <code>ghcr.io/canonical/cdk</code> by default. Existing deployments, or deployments with an overridden <code>image-registry</code> value, must be migrated. Configure the <code>image-registry</code> value for each deployed component charm that uses Canonical images, including CNI and CSI charms. See the <a href="/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms">list of affected charms</a>.</p>
+    <pre><code class="lang-bash">juju config &lt;charm-name&gt; image-registry=ghcr.io/canonical/cdk
+</code></pre>
+    <p>For example:</p>
+    <pre><code class="lang-bash">juju config kubernetes-control-plane image-registry=ghcr.io/canonical/cdk
+</code></pre>
+  </div>
+</div>

--- a/templates/kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html
+++ b/templates/kubernetes/charmed-k8s/docs/shared/_rocks-registry-decommission-warning.html
@@ -2,7 +2,7 @@
   <div class="p-notification__content">
     <span class="p-notification__title">Warning:</span>
     <p class="p-notification__message">Canonical is decommissioning the <code>rocks.canonical.com</code> container image registry as part of our infrastructure modernization. The registry will be unavailable after <strong>August 31, 2026</strong>. This affects Charmed Kubernetes releases 1.35 and earlier. New Charmed Kubernetes 1.36+ deployments use <code>ghcr.io/canonical/cdk</code> by default. Existing deployments, or deployments with an overridden <code>image-registry</code> value, must be migrated. Configure the <code>image-registry</code> value for each deployed component charm that uses Canonical images, including CNI and CSI charms. See the <a href="/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms">list of affected charms</a>.</p>
-    <pre><code class="lang-bash">juju config &lt;charm-name&gt; image-registry=ghcr.io/canonical/cdk
+    <pre><code class="lang-bash">juju config &lt;charm&gt; image-registry=ghcr.io/canonical/cdk
 </code></pre>
     <p>For example:</p>
     <pre><code class="lang-bash">juju config kubernetes-control-plane image-registry=ghcr.io/canonical/cdk

--- a/templates/kubernetes/charmed-k8s/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/charmed-k8s/docs/shared/_side-navigation.md
@@ -25,6 +25,7 @@
 ## Reference
 - [Version info](/kubernetes/charmed-k8s/docs/supported-versions)
 - [Release notes](/kubernetes/charmed-k8s/docs/release-notes)
+- [Rocks registry affected charms](/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms)
 - [Snap refresh settings](/kubernetes/charmed-k8s/docs/snap-refresh)
 - [Kubernetes Packages](/kubernetes/charmed-k8s/docs/packages)
 - [Inclusive naming](/kubernetes/charmed-k8s/docs/inclusive-naming)


### PR DESCRIPTION
## Done

Add documentation regarding the decommission of `rocks.canonical.com` and the migration to `ghcr.io/canonical/cdk`. The PR also contains a list of the affected charms.

## QA

- Open the [DEMO](https://ubuntu-com-16675.demos.haus/kubernetes/charmed-k8s/docs/install-existing)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/charmed-k8s/docs/install-existing
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the warning notice

## Issue / Card

Fixes #

## Screenshots

<img width="3599" height="2269" alt="image" src="https://github.com/user-attachments/assets/28944826-cf1e-4c4e-b74b-9a1c9703ab7b" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
