### PR TITLE
Copy update: Renesas IoT tabs

### DIFF
--- a/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
+++ b/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
@@ -56,7 +56,7 @@
           <h3 class="p-heading--5">Ubuntu Core 26</h3>
         </div>
         <div class="col-6">
-          <p>This is the Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.</p>
+          <p>This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.</p>
           <div>
             <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuCoreQuickStartGuide_uc26_rzg_x03.pdf"
                class="p-button--positive">Build your Core 26</a>

--- a/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
+++ b/templates/download/renesas-iot/tab-5-renesas-rz-g3e.html
@@ -56,7 +56,7 @@
           <h3 class="p-heading--5">Ubuntu Core 26</h3>
         </div>
         <div class="col-6">
-          <p>This is the Ubuntu Core 26 Certified release on Renesas IoT Platforms for the Renesas RZ family.</p>
+          <p>This is the Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.</p>
           <div>
             <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuCoreQuickStartGuide_uc26_rzg_x03.pdf"
                class="p-button--positive">Build your Core 26</a>

--- a/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
+++ b/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
@@ -35,7 +35,7 @@
           <h3 class="p-heading--5">Ubuntu Core 26</h3>
         </div>
         <div class="col-6">
-          <p>This is the Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.</p>
+          <p>This is an Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.</p>
           <div>
             <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuCoreQuickStartGuide_uc26_rzg_x03.pdf"
                class="p-button--positive">Build your Core 26</a>

--- a/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
+++ b/templates/download/renesas-iot/tab-6-renesas-rz-g3s.html
@@ -35,7 +35,7 @@
           <h3 class="p-heading--5">Ubuntu Core 26</h3>
         </div>
         <div class="col-6">
-          <p>This is the Ubuntu Core 26 Certified release on Renesas IoT Platforms for the Renesas RZ family.</p>
+          <p>This is the Early Access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.</p>
           <div>
             <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuCoreQuickStartGuide_uc26_rzg_x03.pdf"
                class="p-button--positive">Build your Core 26</a>


### PR DESCRIPTION
## Done

- copy update for Renesas IoT tabs

## QA

- Open the [DEMO](https://ubuntu-com-16676.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check that all suggestions from the [copydoc](https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?pli=1&tab=t.0#heading=h.2zbp9yvkgpfe) are implemented 

## Issue / Card

Fixes [WD-38307](https://warthogs.atlassian.net/browse/WD-38307)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-38307]: https://warthogs.atlassian.net/browse/WD-38307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ