### PR TITLE
Update certified secondary navigation with dropdown functionality

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -572,18 +572,23 @@ certification:
   children:
     - title: Overview
       path: /certified
+    - title: Search hardware
+      path: /certified/laptops
+    - title: Category
+      path: /certified/category
+      children:
+        - title: Laptops
+          path: /certified/laptops
+        - title: Desktops
+          path: /certified/desktops
+        - title: Servers
+          path: /certified/servers
+        - title: IoT
+          path: /certified/iot
+        - title: SoCs
+          path: /certified/socs
     - title: Why certify?
       path: /certified/why-certify
-    - title: Laptops
-      path: /certified/laptops
-    - title: Desktops
-      path: /certified/desktops
-    - title: Servers
-      path: /certified/servers
-    - title: IoT
-      path: /certified/iot
-    - title: SoCs
-      path: /certified/socs
 
 edge-computing:
   title: Micro cloud

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -27,10 +27,46 @@ nav.classList.remove("u-hide");
 document.addEventListener("DOMContentLoaded", () => {
   setUpGlobalNav();
   wireDropdownFetchTriggers();
+  setupSecondaryNavDropdowns();
 });
 window.addEventListener("load", () => {
   handleUrlHash();
 });
+
+// Opens or closes a single secondary-nav dropdown toggle.
+function toggleSecondaryNavDropdown(toggle, open) {
+  const dropdown = document.getElementById(
+    toggle.getAttribute("aria-controls"),
+  );
+  dropdown?.setAttribute("aria-hidden", !open);
+  toggleIsActiveState(toggle.parentNode, open);
+}
+
+// Wires inline dropdowns inside the secondary navigation bar.
+function setupSecondaryNavDropdowns() {
+  const toggles = [].slice.call(
+    secondaryNav?.querySelectorAll(
+      ".p-navigation__item--dropdown-toggle [aria-controls]",
+    ) ?? [],
+  );
+
+  // Close all secondary dropdowns when the user clicks outside the secondary nav.
+  document.addEventListener("click", (e) => {
+    if (!e.target.closest(".p-navigation.is-secondary")) {
+      toggles.forEach((toggle) => toggleSecondaryNavDropdown(toggle, false));
+    }
+  });
+
+  toggles.forEach((toggle) => {
+    toggle.addEventListener("click", (e) => {
+      e.preventDefault();
+      const shouldOpen = !toggle.parentNode.classList.contains("is-active");
+      // Close siblings before opening the clicked one.
+      toggles.forEach((t) => toggleSecondaryNavDropdown(t, false));
+      toggleSecondaryNavDropdown(toggle, shouldOpen);
+    });
+  });
+}
 
 //Helper functions
 

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -39,6 +39,7 @@ function toggleSecondaryNavDropdown(toggle, open) {
     toggle.getAttribute("aria-controls"),
   );
   dropdown?.setAttribute("aria-hidden", !open);
+  toggle.setAttribute("aria-expanded", open);
   toggleIsActiveState(toggle.parentNode, open);
 }
 

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -192,6 +192,20 @@
                         </span>
                       </span>
                     </li>
+                  {# Nav item with sub-children renders as an inline Vanilla dropdown. #}
+                  {% elif child.children %}
+                    <li class="p-navigation__item--dropdown-toggle {% if child.active %}is-selected{% endif %}" id="secondary-nav-dropdown-{{ loop.index }}">
+                      <a href="#secondary-nav-dropdown-{{ loop.index }}-menu"
+                         aria-controls="secondary-nav-dropdown-{{ loop.index }}-menu"
+                         class="p-navigation__link">{{ child.title }}</a>
+                      <ul class="p-navigation__dropdown" id="secondary-nav-dropdown-{{ loop.index }}-menu" aria-hidden="true">
+                        {% for item in child.children %}
+                          <li>
+                            <a href="{{ item.path }}" class="p-navigation__dropdown-item">{{ item.title }}</a>
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </li>
                   {% elif child.path != '/blog/archives' %}
                     {% set has_access = not child.login_required or child.login_required and user_info %}
                     {% if has_access %}

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -197,11 +197,14 @@
                     <li class="p-navigation__item--dropdown-toggle {% if child.active %}is-selected{% endif %}" id="secondary-nav-dropdown-{{ loop.index }}">
                       <a href="#secondary-nav-dropdown-{{ loop.index }}-menu"
                          aria-controls="secondary-nav-dropdown-{{ loop.index }}-menu"
+                         aria-expanded="false"
+                         aria-haspopup="true"
                          class="p-navigation__link">{{ child.title }}</a>
                       <ul class="p-navigation__dropdown" id="secondary-nav-dropdown-{{ loop.index }}-menu" aria-hidden="true">
                         {% for item in child.children %}
                           <li>
-                            <a href="{{ item.path }}" class="p-navigation__dropdown-item">{{ item.title }}</a>
+                            <a href="{{ item.path }}" class="p-navigation__dropdown-item"
+                               {% if item.active %}aria-current="page"{% endif %}>{{ item.title }}</a>
                           </li>
                         {% endfor %}
                       </ul>

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -110,6 +110,20 @@ def get_secondary_navigation(path):
                 # Include all siblings
                 breadcrumbs["children"] = nav_section.get("children", [])
 
+            # Mark the parent nav item active when the current path matches a dropdown sub-item.
+            for grandchild in child.get("children", []):
+                if (
+                    grandchild["path"] == path
+                    and path.startswith(nav_section["path"])
+                ) or (path.startswith(grandchild["path"])):
+                    if len(grandchild["path"]) > longest_match_path:
+                        longest_match_path = len(grandchild["path"])
+                        child_to_set_active = child
+
+                    nav_section["active"] = True
+                    breadcrumbs["section"] = nav_section
+                    breadcrumbs["children"] = nav_section.get("children", [])
+
         # set the child most closely matching the current path as active
         if child_to_set_active:
             child_to_set_active["active"] = True

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -110,7 +110,8 @@ def get_secondary_navigation(path):
                 # Include all siblings
                 breadcrumbs["children"] = nav_section.get("children", [])
 
-            # Mark the parent nav item active when the current path matches a dropdown sub-item.
+            # Mark the parent nav item active when the current path matches
+            # a dropdown sub-item.
             for grandchild in child.get("children", []):
                 if (
                     grandchild["path"] == path
@@ -119,6 +120,7 @@ def get_secondary_navigation(path):
                     if len(grandchild["path"]) > longest_match_path:
                         longest_match_path = len(grandchild["path"])
                         child_to_set_active = child
+                    grandchild["active"] = True
 
                     nav_section["active"] = True
                     breadcrumbs["section"] = nav_section


### PR DESCRIPTION
## Done

- Updated secondary navigation of certified bubble and added dropdown support to secondary nav

## QA

- Open the [DEMO](https://ubuntu-com-16686.demos.haus/certified)
- Check that the navigation in certified pages show "Search hardware", "Category" and "Why certify?"

## Issue / Card

Fixes [WD-37894](https://warthogs.atlassian.net/browse/WD-37894)

[WD-37894]: https://warthogs.atlassian.net/browse/WD-37894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
