### PR TITLE
chore: set direct links to remove redirects

### DIFF
--- a/templates/containers/rockcraft.html
+++ b/templates/containers/rockcraft.html
@@ -297,7 +297,7 @@
                   "link": {
                     "content_html": "Read more about Rockcraft commands&nbsp;&rsaquo;",
                     "attrs": {
-                      "href": "/containers/rockcraft/docs/latest/reference/commands/"
+                      "href": "/containers/rockcraft/docs/latest/reference/"
                     }
                   }
                 }

--- a/templates/containers/rockcraft.html
+++ b/templates/containers/rockcraft.html
@@ -50,7 +50,7 @@
           "primary": {
             "content_html": "Read the docs",
             "attrs": {
-              "href": "https://documentation.ubuntu.com/rockcraft/stable/"
+              "href": "/containers/rockcraft/docs/latest/"
             }
           }
         }
@@ -81,7 +81,7 @@
         stable, and OCI-compliant container images, based on Ubuntu.
       </p>
       <div class="p-cta-block">
-        <a href="https://documentation.ubuntu.com/rockcraft/stable/explanation/rocks/">Learn more about rocks&nbsp;&rsaquo;</a>
+        <a href="/containers/rockcraft/docs/latest/explanation/rocks/">Learn more about rocks&nbsp;&rsaquo;</a>
       </div>
     {%- endif -%}
 
@@ -124,8 +124,8 @@
 
     {%- if slot == 'list_item_description_4' -%}
       <p>
-        Rockcraft is built on top of existing concepts within the same family as <a href="https://documentation.ubuntu.com/snapcraft/9.0/#">Snapcraft</a>
-        and <a href="https://documentation.ubuntu.com/charmcraft/4.2/">Charmcraft</a>, making adoption seamless for developers that are already building snaps and charms.
+        Rockcraft is built on top of existing concepts within the same family as <a href="/docs/snapcraft/9/">Snapcraft</a>
+        and <a href="https://canonical.com/juju/docs/charmcraft/4/">Charmcraft</a>, making adoption seamless for developers that are already building snaps and charms.
       </p>
     {%- endif -%}
 
@@ -183,7 +183,7 @@
                   "link": {
                     "content_html": "Follow our quickstart guide&nbsp;&rsaquo;",
                     "attrs": {
-                      "href": "https://documentation.ubuntu.com/rockcraft/stable/how-to/get-started/"
+                      "href": "/containers/rockcraft/docs/latest/how-to/get-started/"
                     }
                   }
                 }
@@ -215,7 +215,7 @@
                   "link": {
                     "content_html": "Build a rock for a Spring Boot application&nbsp;&rsaquo;",
                     "attrs": {
-                      "href": "https://documentation.ubuntu.com/rockcraft/stable/tutorial/springboot/#tutorial-build-a-rock-for-a-spring-boot-app"
+                      "href": "/containers/rockcraft/docs/latest/tutorial/springboot/"
                     }
                   }
                 }
@@ -267,7 +267,7 @@
                   "link": {
                     "content_html": "Learn more about rockcraft.yaml files&nbsp;&rsaquo;",
                     "attrs": {
-                      "href": "https://documentation.ubuntu.com/rockcraft/stable/reference/rockcraft-yaml/"
+                      "href": "/containers/rockcraft/docs/latest/reference/rockcraft-yaml/"
                     }
                   }
                 }
@@ -297,7 +297,7 @@
                   "link": {
                     "content_html": "Read more about Rockcraft commands&nbsp;&rsaquo;",
                     "attrs": {
-                      "href": "https://documentation.ubuntu.com/rockcraft/stable/reference/"
+                      "href": "/containers/rockcraft/docs/latest/reference/commands/"
                     }
                   }
                 }
@@ -331,7 +331,7 @@
                   "link": {
                     "content_html": "Learn more about publishing rocks&nbsp;&rsaquo;",
                     "attrs": {
-                      "href": "https://documentation.ubuntu.com/rockcraft/stable/how-to/crafting/publish-a-rock/"
+                      "href": "/containers/rockcraft/docs/latest/how-to/crafting/publish-a-rock/"
                     }
                   }
                 }
@@ -442,7 +442,7 @@
      width="568"
      height="853" />',
         "description_html": "<p>Rockcraft divides your app into modular blocks called <em>parts</em>. When a part is processed, it performs steps from the parts lifecycle: <em>pull</em>, <em>overlay</em>, <em>build</em>, <em>stage</em>, and <em>prime</em>.</p>",
-        "cta_html": "<a href='https://documentation.ubuntu.com/rockcraft/stable/common/craft-parts/explanation/parts/'>Learn more about parts&nbsp;&rsaquo;</a>"
+        "cta_html": "<a href='/containers/rockcraft/docs/latest/common/craft-parts/explanation/parts/'>Learn more about parts&nbsp;&rsaquo;</a>"
       },
       {
         "title_text": "Declarative chiseling",
@@ -451,7 +451,7 @@
      width="568"
      height="853" />',
         "description_html": "<p>Rockcraft natively integrates with <a href='/chisel/docs/latest/'>Chisel</a> directly inside the YAML. Rather than starting with a full OS layer, developers can select the <code>bare</code> base and define precise slices.</p>",
-        "cta_html": "<a href='https://documentation.ubuntu.com/rockcraft/stable/reference/rockcraft-yaml/'>Learn about rockcraft.yaml&nbsp;&rsaquo;</a>"
+        "cta_html": "<a href='/containers/rockcraft/docs/latest/reference/rockcraft-yaml/'>Learn about rockcraft.yaml&nbsp;&rsaquo;</a>"
       },
       {
         "title_text": "Built-in plugins",
@@ -460,7 +460,7 @@
      width="568"
      height="853" />',
         "description_html": "<p>You do not need to write custom build scripts or manually configure virtual environments. Rockcraft handles ecosystem-specific build logic natively through its plugin ecosystem.</p>",
-        "cta_html": "<a href='https://documentation.ubuntu.com/rockcraft/stable/reference/plugins/'>Explore Rockcraft plugins&nbsp;&rsaquo;</a>"
+        "cta_html": "<a href='/containers/rockcraft/docs/latest/reference/plugins/'>Explore Rockcraft plugins&nbsp;&rsaquo;</a>"
       },
       {
         "title_text": "12-factor app ready",
@@ -469,7 +469,7 @@
      width="568"
      height="853" />',
         "description_html": "<p>Rockcraft provides built-in extensions for modern cloud-native web apps (Django, Flask, FastAPI, Node.js, Go), which silently inject a pre-configured underlying part.</p>",
-        "cta_html": "<a href='https://documentation.ubuntu.com/rockcraft/latest/how-to/web-app-rocks/set-up-web-app-rock/'>Set up a 12-factor app rock&nbsp;&rsaquo;</a>"
+        "cta_html": "<a href='/containers/rockcraft/docs/latest/how-to/web-app-rocks/set-up-web-app-rock/'>Set up a 12-factor app rock&nbsp;&rsaquo;</a>"
       }
     ]
   ) %}
@@ -499,14 +499,14 @@
           "primary": {
             "content_html": "Try the tutorials",
             "attrs": {
-              "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/"
+              "href": "/containers/rockcraft/docs/latest/tutorial/"
             }
           },
           "secondaries": [
             {
               "content_html": "Read the how-to guides",
               "attrs": {
-                "href": "https://documentation.ubuntu.com/rockcraft/latest/how-to/"
+                "href": "/containers/rockcraft/docs/latest/how-to/"
               }
             }
           ],


### PR DESCRIPTION
## Done

- Updated the links to point directly to source

## QA

- Open the [DEMO](https://ubuntu-com-16688.demos.haus/containers/rockcraft)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/containers/rockcraft
    - Be sure to test on mobile, tablet and desktop screen sizes
- **Note: ** RTD is only set up for prod ubuntu.com, therefore the links on demos will give 404. The reviewer only needs to make sure the links point to the requested urls in the copydoc. Or you can copy the changed link and append to https://ubuntu.com/xyz to make sure it works.

## Issue / Card

Fixes [WD-38379](https://warthogs.atlassian.net/browse/WD-38379)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-38379]: https://warthogs.atlassian.net/browse/WD-38379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
