### PR TITLE
Auto-Apply Filters on Certified Search

### DIFF
--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -269,8 +269,8 @@ function handleFilterClick(e) {
       urlParams.delete(name);
       // Only category pages
       if (pathCategory === id) {
-        const newURL = `/certified?${urlParams.toString()}`;
-        window.history.pushState({ path: newURL }, "", newURL);
+        window.location.replace(`/certified?${urlParams.toString()}`);
+        return;
       }
       // Append back deleted params
       // If multiple selected
@@ -319,11 +319,7 @@ function handleFilterClick(e) {
   }
 
   const newURL = `${window.location.pathname}?${urlParams.toString()}`;
-  window.history.pushState({ path: newURL }, "", newURL);
-}
-
-function submitFilters() {
-  window.location.replace(window.location.href);
+  window.location.replace(newURL);
 }
 
 /**
@@ -393,7 +389,7 @@ function clearFilters() {
   } else {
     objUrl.search = "";
   }
-  window.history.pushState({ url: objUrl }, "", objUrl);
+  window.location.replace(objUrl.toString());
 }
 
 // function to ensure only the option which has been changed is appended to the URL
@@ -445,11 +441,6 @@ function wireStaticFilterHandlers() {
       }
     },
   );
-
-  const submitFiltersButton = document.querySelector(".js-submit-filters");
-  if (submitFiltersButton) {
-    submitFiltersButton.addEventListener("click", submitFilters);
-  }
 
   const clearFiltersButton = document.querySelector(".js-clear-filters");
   if (clearFiltersButton) {

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -356,13 +356,24 @@ function toggleExpandFilters(e, element) {
   const { name, value } = element;
   const { category, vendor, release } = retrieveSelectedFilters();
 
+  setFilterLinkLoading(element, true);
+  let request;
+
   if (name === "vendor") {
     if (value === "true") {
       // Show all
-      renderFilters(category, vendor, release, -1, filterLimit, true, false);
+      request = renderFilters(
+        category,
+        vendor,
+        release,
+        -1,
+        filterLimit,
+        true,
+        false,
+      );
     } else {
       // Show default filterLimit
-      renderFilters(
+      request = renderFilters(
         category,
         vendor,
         release,
@@ -375,10 +386,18 @@ function toggleExpandFilters(e, element) {
   } else if (name === "release") {
     if (value === "true") {
       // Show all
-      renderFilters(category, vendor, release, filterLimit, -1, false, true);
+      request = renderFilters(
+        category,
+        vendor,
+        release,
+        filterLimit,
+        -1,
+        false,
+        true,
+      );
     } else {
       // Show default filterLimit
-      renderFilters(
+      request = renderFilters(
         category,
         vendor,
         release,
@@ -388,6 +407,22 @@ function toggleExpandFilters(e, element) {
         true,
       );
     }
+  }
+
+  request.finally(() => setFilterLinkLoading(element, false));
+}
+
+// /certified/filters.json can take a couple of seconds; without this the
+// "Show all" link looks unresponsive until the list suddenly appears.
+function setFilterLinkLoading(button, isLoading) {
+  if (isLoading) {
+    button.dataset.originalText = button.textContent;
+    button.disabled = true;
+    button.innerHTML =
+      '<i class="p-icon--spinner u-animation--spin"></i> ' + button.textContent;
+  } else {
+    button.disabled = false;
+    button.textContent = button.dataset.originalText;
   }
 }
 

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -36,6 +36,15 @@ tabBtn3.addEventListener("click", (e) => {
 // Set global filter limit for vendors and releases
 let filterLimit = 5;
 
+let filterNavigateTimer = null;
+
+function scheduleFilterNavigation() {
+  clearTimeout(filterNavigateTimer);
+  filterNavigateTimer = setTimeout(() => {
+    window.location.assign(window.location.href);
+  }, 300);
+}
+
 function loadFilters() {
   const { category, vendor, release } = retrieveSelectedFilters();
   renderFilters(category, vendor, release);
@@ -269,7 +278,9 @@ function handleFilterClick(e) {
       urlParams.delete(name);
       // Only category pages
       if (pathCategory === id) {
-        window.location.replace(`/certified?${urlParams.toString()}`);
+        const newURL = `/certified?${urlParams.toString()}`;
+        window.history.pushState({ path: newURL }, "", newURL);
+        scheduleFilterNavigation();
         return;
       }
       // Append back deleted params
@@ -319,7 +330,8 @@ function handleFilterClick(e) {
   }
 
   const newURL = `${window.location.pathname}?${urlParams.toString()}`;
-  window.location.replace(newURL);
+  window.history.pushState({ path: newURL }, "", newURL);
+  scheduleFilterNavigation();
 }
 
 /**
@@ -389,7 +401,7 @@ function clearFilters() {
   } else {
     objUrl.search = "";
   }
-  window.location.replace(objUrl.toString());
+  window.location.assign(objUrl.toString());
 }
 
 // function to ensure only the option which has been changed is appended to the URL

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -38,6 +38,15 @@ let filterLimit = 5;
 
 let filterNavigateTimer = null;
 
+const SCROLL_POSITION_KEY = "certifiedFiltersScrollY";
+
+// Filter changes reload the page, which otherwise resets the scroll position
+// to the top. Stash it before navigating away; an early inline script in
+// base.html restores it as soon as the new page starts loading.
+function saveScrollPosition() {
+  sessionStorage.setItem(SCROLL_POSITION_KEY, window.scrollY);
+}
+
 // certified_home() falls back to the certified homepage when a request has
 // neither `q` nor `category`. Keep an empty `q` so filter changes never
 // bounce the user off the search results view.
@@ -52,6 +61,7 @@ function searchResultsUrl(href) {
 function scheduleFilterNavigation() {
   clearTimeout(filterNavigateTimer);
   filterNavigateTimer = setTimeout(() => {
+    saveScrollPosition();
     window.location.assign(searchResultsUrl(window.location.href));
   }, 300);
 }
@@ -447,6 +457,7 @@ function clearFilters() {
   } else {
     objUrl.search = "";
   }
+  saveScrollPosition();
   window.location.assign(objUrl.toString());
 }
 

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -38,10 +38,21 @@ let filterLimit = 5;
 
 let filterNavigateTimer = null;
 
+// certified_home() falls back to the certified homepage when a request has
+// neither `q` nor `category`. Keep an empty `q` so filter changes never
+// bounce the user off the search results view.
+function searchResultsUrl(href) {
+  const url = new URL(href);
+  if (!url.searchParams.has("q") && !url.searchParams.has("category")) {
+    url.searchParams.set("q", "");
+  }
+  return url.toString();
+}
+
 function scheduleFilterNavigation() {
   clearTimeout(filterNavigateTimer);
   filterNavigateTimer = setTimeout(() => {
-    window.location.assign(window.location.href);
+    window.location.assign(searchResultsUrl(window.location.href));
   }, 300);
 }
 
@@ -440,7 +451,7 @@ function hideDrawerPageReload() {
 function wireStaticFilterHandlers() {
   if (filters1Elm) {
     filters1Elm.querySelectorAll("input").forEach((input) => {
-      input.addEventListener("click", handleCategoryClick);
+      input.addEventListener("click", handleFilterClick);
     });
   }
 
@@ -460,7 +471,17 @@ function wireStaticFilterHandlers() {
   }
 }
 
-loadFilters();
+// Vendor/release options are now server-rendered; only fetch them if
+// they're missing, and bind clicks to the ones already on the page.
+if (filters2Elm.querySelector("input") || filters3Elm.querySelector("input")) {
+  [filters2Elm, filters3Elm].forEach((section) => {
+    section.querySelectorAll("input").forEach((input) => {
+      input.addEventListener("click", handleFilterClick);
+    });
+  });
+} else {
+  loadFilters();
+}
 updateResultsPerPage();
 hideDrawerPageReload();
 wireStaticFilterHandlers();

--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -62,6 +62,10 @@
       padding-left: 2.2rem;
     }
 
+    .p-button--link:disabled {
+      cursor: not-allowed;
+    }
+
     .p-accordion__tab {
       @extend .p-accordion__tab;
 

--- a/templates/certified/search/_search-results-side-filters.html
+++ b/templates/certified/search/_search-results-side-filters.html
@@ -1,14 +1,14 @@
 <h2 class="p-muted-heading">Filters</h2>
 <a href="#drawer"
-    class="p-side-navigation__toggle js-drawer-toggle"
-    aria-controls="drawer">Toggle filters</a>
+   class="p-side-navigation__toggle js-drawer-toggle"
+   aria-controls="drawer">Toggle filters</a>
 <div class="p-side-navigation__overlay" aria-controls="drawer"></div>
 <nav class="p-side-navigation__drawer" aria-label="Filter list">
   <div class="p-side-navigation__drawer-header">
     <a href="#"
-        class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
-        aria-controls="drawer"
-        id="toggle-filters">Toggle filters</a>
+       class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
+       aria-controls="drawer"
+       id="toggle-filters">Toggle filters</a>
   </div>
   <div>
     <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
@@ -36,9 +36,9 @@
             </button>
           </div>
           <section class="p-accordion__panel is-dense"
-                    id="tab2-section"
-                    aria-hidden="false"
-                    aria-labelledby="tab2">
+                   id="tab2-section"
+                   aria-hidden="false"
+                   aria-labelledby="tab2">
           </section>
           <div class="js-show-expanded-vendor-filter-options">
             <button class="p-button--link js-vendor-count p-reveal-vendors is-dense js-show-all-vendors"
@@ -60,9 +60,9 @@
             </button>
           </div>
           <section class="p-accordion__panel is-dense"
-                    id="tab3-section"
-                    aria-hidden="false"
-                    aria-labelledby="tab3">
+                   id="tab3-section"
+                   aria-hidden="false"
+                   aria-labelledby="tab3">
           </section>
           <div class="js-show-expanded-release-filter-options">
             <button class="p-button--link p-reveal-versions is-dense js-show-all-releases"
@@ -77,12 +77,12 @@
     </aside>
     <div class="certified-filters-footer">
       <div class="certified-filters-footer-buttons p-cta-block">
-        <button class="p-button--positive js-submit-filters">Apply filters</button>
         <button class="p-button js-clear-filters">Clear all filters</button>
       </div>
     </div>
   </div>
 </nav>
 
-<script nonce="{{ csp_nonce }}" type="module"
+<script nonce="{{ csp_nonce }}"
+        type="module"
         src="/static/js/src/side-navigation.js"></script>

--- a/templates/certified/search/_search-results-side-filters.html
+++ b/templates/certified/search/_search-results-side-filters.html
@@ -1,3 +1,5 @@
+{# filter_limit mirrors filterLimit in certified-search-results.js #}
+{% set filter_limit = 5 %}
 <h2 class="p-muted-heading">Filters</h2>
 <a href="#drawer"
    class="p-side-navigation__toggle js-drawer-toggle"
@@ -39,9 +41,21 @@
                    id="tab2-section"
                    aria-hidden="false"
                    aria-labelledby="tab2">
+            {% if vendor_filters and vendor_filters.data %}
+              {% for make in vendor_filters.data %}
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         name="vendor"
+                         class="p-checkbox__input"
+                         value="{{ make }}"
+                         {% if make in request.args.getlist("vendor") %}checked{% endif %} />
+                  <span class="p-checkbox__label" id="{{ make|replace(' ', '-') }}">{{ make }}</span>
+                </label>
+              {% endfor %}
+            {% endif %}
           </section>
           <div class="js-show-expanded-vendor-filter-options">
-            <button class="p-button--link js-vendor-count p-reveal-vendors is-dense js-show-all-vendors"
+            <button class="p-button--link js-vendor-count p-reveal-vendors is-dense js-show-all-vendors{% if vendor_filters and vendor_filters.total <= filter_limit %} u-hide{% endif %}"
                     name="vendor"
                     value="true">Show all vendors</button>
             <button class="p-button--link p-reveal-vendors is-dense js-show-less-vendors u-hide"
@@ -63,9 +77,21 @@
                    id="tab3-section"
                    aria-hidden="false"
                    aria-labelledby="tab3">
+            {% if release_filters and release_filters.data %}
+              {% for version in release_filters.data %}
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         name="release"
+                         class="p-checkbox__input"
+                         value="{{ version }}"
+                         {% if version in request.args.getlist("release") %}checked{% endif %} />
+                  <span class="p-checkbox__label" id="{{ version|replace(' ', '-') }}">{{ version }}</span>
+                </label>
+              {% endfor %}
+            {% endif %}
           </section>
           <div class="js-show-expanded-release-filter-options">
-            <button class="p-button--link p-reveal-versions is-dense js-show-all-releases"
+            <button class="p-button--link p-reveal-versions is-dense js-show-all-releases{% if release_filters and release_filters.total <= filter_limit %} u-hide{% endif %}"
                     name="release"
                     value="true">Show all versions</button>
             <button class="p-button--link p-reveal-versions is-dense js-show-less-releases u-hide"

--- a/templates/certified/vendors/vendor.html
+++ b/templates/certified/vendors/vendor.html
@@ -44,6 +44,7 @@
       offset=offset,
       limit=limit,
       results=results,
+      release_filters=release_filters,
       vendor_page="true"
       %}
       {% include "certified/search/_search-results-main-block.html" %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -8,6 +8,21 @@
     <meta charset="UTF-8" />
     <meta name="keywords" content="index, follow" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    {# Restore the scroll position certified-search-results.js saves before a
+       filter reload, as early as possible so the page never visibly renders
+       at the top first. Reserve the height up front so the restore isn't
+       clamped to whatever has been parsed so far. #}
+    <script nonce="{{ csp_nonce }}">
+      (function () {
+        var y = sessionStorage.getItem("certifiedFiltersScrollY");
+        if (y !== null) {
+          sessionStorage.removeItem("certifiedFiltersScrollY");
+          document.documentElement.style.minHeight = Number(y) + innerHeight + "px";
+          scrollTo(0, Number(y));
+        }
+      })();
+    </script>
     <title>
       {% block title %}{% endblock %}
     | Ubuntu</title>

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -257,92 +257,128 @@ def get_vendors_releases_filters():
     ) = get_filters(request.args)
     new_certified_params = _parse_query_params(vendors, releases)
     if not new_certified_params:
-        vendor_filters = []
-        release_filters = []
-
-        if len(categories) == 0:
-            categories = [
-                "smart_core",
-                "soc",
-                "laptops",
-                "desktops",
-                "servers",
-            ]
-
-        for cat in categories:
-            cat = cat.lower()
-            # pathname replacements
-            if cat == "iot":
-                cat = "smart_core"
-            elif cat == "ubuntu core":
-                cat = "smart_core"
-            elif cat == "socs":
-                cat = "soc"
-            elif cat == "laptop":
-                cat = "laptops"
-            elif cat == "desktop":
-                cat = "desktops"
-            elif cat == "server":
-                cat = "servers"
-            elif cat == "server soc":
-                cat = "soc"
-
-            for vendor in certified_makes:
-                if vendor["make"] == "nVidia":
-                    vendor["make"] = "NVIDIA"
-                make = vendor["make"]
-
-                if (
-                    int(vendor[cat]) > 0
-                    and make not in vendor_filters
-                    and make not in selected_vendors
-                ):
-                    vendor_filters.append(make)
-
-            for release in certified_releases:
-                version = release["release"]
-
-                if (
-                    int(release[cat]) > 0
-                    and version not in release_filters
-                    and version != "18.04"
-                    and version not in selected_releases
-                ):
-                    release_filters.append(version)
-
-        # Reorder and put selected filters on top
-        vendor_filters.sort()
-        selected_vendors.extend(vendor_filters)
-        vendor_filters = selected_vendors
-        release_filters.sort(reverse=True)
-        selected_releases.extend(release_filters)
-        release_filters = selected_releases
-
-        total_vendors = len(vendor_filters)
-        total_releases = len(release_filters)
-
-        if vendors_limit != -1:
-            vendor_filters = vendor_filters[:vendors_limit]
-
-        if releases_limit != -1:
-            release_filters = release_filters[:releases_limit]
-
-        filters = {
-            "vendor_filters": {"data": vendor_filters, "total": total_vendors},
-            "release_filters": {
-                "data": release_filters,
-                "total": total_releases,
-            },
-        }
+        filters = build_filter_options(
+            certified_makes,
+            certified_releases,
+            categories,
+            selected_vendors,
+            selected_releases,
+            vendors_limit=vendors_limit,
+            releases_limit=releases_limit,
+        )
 
         return jsonify(filters)
     else:
         return redirect(url_for(request.endpoint, **new_certified_params))
 
 
-def get_filters(request_args=None, json: bool = False):
-    certified_releases = api.certified_releases(limit="0")["results"]
-    certified_makes = api.certified_vendors(limit="0")["results"]
+def build_filter_options(
+    certified_makes,
+    certified_releases,
+    categories,
+    selected_vendors,
+    selected_releases,
+    vendors_limit=5,
+    releases_limit=5,
+):
+    """Build vendor/release filter options for the given categories.
+
+    Returns the same shape as ``/certified/filters.json`` so the options can be
+    rendered server-side or fetched by the client. A limit of ``-1`` returns
+    every option.
+    """
+    # Copy so the caller's request.args lists are not mutated
+    selected_vendors = list(selected_vendors)
+    selected_releases = list(selected_releases)
+    vendor_filters = []
+    release_filters = []
+
+    if len(categories) == 0:
+        categories = [
+            "smart_core",
+            "soc",
+            "laptops",
+            "desktops",
+            "servers",
+        ]
+
+    for cat in categories:
+        cat = cat.lower()
+        # pathname replacements
+        if cat == "iot":
+            cat = "smart_core"
+        elif cat == "ubuntu core":
+            cat = "smart_core"
+        elif cat == "socs":
+            cat = "soc"
+        elif cat == "laptop":
+            cat = "laptops"
+        elif cat == "desktop":
+            cat = "desktops"
+        elif cat == "server":
+            cat = "servers"
+        elif cat == "server soc":
+            cat = "soc"
+
+        for vendor in certified_makes:
+            if vendor["make"] == "nVidia":
+                vendor["make"] = "NVIDIA"
+            make = vendor["make"]
+
+            if (
+                int(vendor.get(cat, 0) or 0) > 0
+                and make not in vendor_filters
+                and make not in selected_vendors
+            ):
+                vendor_filters.append(make)
+
+        for release in certified_releases:
+            version = release["release"]
+
+            if (
+                int(release.get(cat, 0) or 0) > 0
+                and version not in release_filters
+                and version != "18.04"
+                and version not in selected_releases
+            ):
+                release_filters.append(version)
+
+    # Reorder and put selected filters on top
+    vendor_filters.sort()
+    selected_vendors.extend(vendor_filters)
+    vendor_filters = selected_vendors
+    release_filters.sort(reverse=True)
+    selected_releases.extend(release_filters)
+    release_filters = selected_releases
+
+    total_vendors = len(vendor_filters)
+    total_releases = len(release_filters)
+
+    if vendors_limit != -1:
+        vendor_filters = vendor_filters[:vendors_limit]
+
+    if releases_limit != -1:
+        release_filters = release_filters[:releases_limit]
+
+    return {
+        "vendor_filters": {"data": vendor_filters, "total": total_vendors},
+        "release_filters": {
+            "data": release_filters,
+            "total": total_releases,
+        },
+    }
+
+
+def get_filters(
+    request_args=None,
+    json: bool = False,
+    certified_releases=None,
+    certified_makes=None,
+):
+    if certified_releases is None:
+        certified_releases = api.certified_releases(limit="0")["results"]
+    if certified_makes is None:
+        certified_makes = api.certified_vendors(limit="0")["results"]
 
     # Laptop filters
     laptop_releases = []
@@ -662,6 +698,8 @@ def certified_model_details(canonical_id):
 
 
 def certified_home():
+    certified_releases = api.certified_releases(limit="0")["results"]
+    certified_makes = api.certified_vendors(limit="0")["results"]
     (
         laptop_releases,
         laptop_vendors,
@@ -677,7 +715,11 @@ def certified_home():
         all_vendors,
         vendor_filters,
         release_filters,
-    ) = get_filters(request.args)
+    ) = get_filters(
+        request.args,
+        certified_releases=certified_releases,
+        certified_makes=certified_makes,
+    )
 
     # Parse url
     new_certified_params = _parse_query_params(release_filters, vendor_filters)
@@ -761,6 +803,14 @@ def certified_home():
         # Pagination
         total_results = models_response["count"]
 
+        filter_options = build_filter_options(
+            certified_makes,
+            certified_releases,
+            selected_categories,
+            request.args.getlist("vendor"),
+            request.args.getlist("release"),
+        )
+
         return render_template(
             "certified/search-results.html",
             results=results,
@@ -768,6 +818,8 @@ def certified_home():
             category=categories,
             releases=releases,
             vendors=vendors,
+            vendor_filters=filter_options["vendor_filters"],
+            release_filters=filter_options["release_filters"],
             total_results=total_results,
             total_pages=math.ceil(total_results / limit),
             offset=offset,
@@ -799,7 +851,9 @@ def create_category_views(category, template_path):
     Server, Ubuntu Core, Server SoC)
     template_path -- full template path (e.g. certified/search-results.html)
     """
-    if len(request.args.getlist("category")) > 1:
+    # This page always implies its own `category` via the path, not a query
+    # param, so any additional `category` selected means 2+ are now active.
+    if len(request.args.getlist("category")) > 0:
         url = f"/certified?{request.query_string.decode()}&category={category}"
         # UX requirement
         return redirect(url)
@@ -914,13 +968,21 @@ def create_category_views(category, template_path):
     # Pagination
     total_results = models_response["count"]
 
+    filter_options = build_filter_options(
+        certified_makes,
+        certified_releases,
+        [category],
+        request.args.getlist("vendor"),
+        request.args.getlist("release"),
+    )
+
     return render_template(
         template_path,
         results=results,
         query=query,
         releases=releases,
-        release_filters=release_filters,
-        vendor_filters=vendor_filters,
+        release_filters=filter_options["release_filters"],
+        vendor_filters=filter_options["vendor_filters"],
         vendors=vendors,
         total_results=total_results,
         total_pages=math.ceil(total_results / limit),
@@ -977,12 +1039,7 @@ def certified_vendors(vendor):
     limit = request.args.get("limit", default=20, type=int)
     offset = request.args.get("offset", default=0, type=int)
 
-    release_filters = []
     certified_releases = api.certified_releases(limit="0")["results"]
-
-    for release in certified_releases:
-        version = release["release"]
-        release_filters.append(version)
     releases = (
         ",".join(request.args.getlist("release"))
         if request.args.getlist("release")
@@ -1000,6 +1057,16 @@ def certified_vendors(vendor):
         selected_categories.append("Ubuntu Core")
 
     categories = ",".join(selected_categories) if selected_categories else None
+
+    # Vendor is fixed by the page, so only release options are relevant here.
+    # Same {data, total} shape as every other certified page's filters.
+    release_filters = build_filter_options(
+        [],
+        certified_releases,
+        selected_categories,
+        [],
+        request.args.getlist("release"),
+    )["release_filters"]
 
     query = request.args.get("q", default=None, type=str)
 


### PR DESCRIPTION
## Done

- Removed the "Apply filters" button on Certified search and made filters auto-apply instantly when changed
- Added js to restore page scroll when filters are applied for usability
- Added loading indicator to "show more" link when expanding filter options

## QA

- Open the [DEMO](https://ubuntu-com-16690.demos.haus/certified/laptops)
- Add and remove filters to check that they apply immediately without the need of a secondary action
- Check that the page restores the scroll position after applying a filter

## Issue / Card

Fixes [WD-37896](https://warthogs.atlassian.net/browse/WD-37896)


[WD-37896]: https://warthogs.atlassian.net/browse/WD-37896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
