### PR TITLE
copy-update: links to rockcraft and chisel docs

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -356,9 +356,9 @@
         </p>
         <p>No more worries about library incompatibilities, just seamless development to deployment.</p>
         <div class="p-cta-block">
-          <a href="https://documentation.ubuntu.com/rockcraft/en/latest/"
+          <a href="https://ubuntu.com/containers/rockcraft/docs/latest/"
              class="p-button">Learn more about Rockcraft</a>
-          <a href="https://documentation.ubuntu.com/chisel/en/latest/"
+          <a href="https://ubuntu.com/chisel/docs/latest/"
              class="p-button">Learn more about Chisel</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updated links on the /containers page based on the [copy doc](https://docs.google.com/document/d/1OtyfNeA--EJgpgvDzqcbJ8jqa6d9H5H9xyxHNxcKXvc/edit?tab=t.0)

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /containers
- Verify that the links to rockcraft and chisel documentations redirect you to the correct link

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38378
