### PR TITLE
Copy Update: Fixed urls on container's doc page

### DIFF
--- a/templates/containers/docs.html
+++ b/templates/containers/docs.html
@@ -30,7 +30,7 @@
     ) -%}
     {%- if slot == 'description' -%}
       <p>
-      Canonical containers, also known as “rocks”, are a new generation of secure, stable and OCI-compliant Ubuntu images, <a href="https://ubuntu.com/chisel/docs/latest/">hardened by design</a>, and offering a <a href="https://ubuntu.com/containers/rockcraft/docs/latest/explanation/pebble/">specialized and predictable UX</a>.
+      Canonical containers, also known as “rocks”, are a new generation of secure, stable and OCI-compliant Ubuntu images, <a href="/chisel/docs/latest/">hardened by design</a>, and offering a <a href="/containers/rockcraft/docs/latest/explanation/pebble/">specialized and predictable UX</a>.
       </p>
     {%- endif -%}
   {% endcall -%}
@@ -156,11 +156,11 @@
       ),
       "description_html": "
       <p>
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/get-started/'>
+        <a href='/containers/rockcraft/docs/latest/how-to/get-started/'>
           Get started - quick guide
         </a>
         <br />
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/hello-world/#setup-your-environment'>
+        <a href='/containers/rockcraft/docs/latest/tutorial/hello-world/#setup-your-environment'>
           Use Rockcraft with Multipass
         </a>
       </p>
@@ -179,7 +179,7 @@
        ),
        "description_html": "
       <p>
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/reference/rockcraft-yaml/'>
+        <a href='/containers/rockcraft/docs/latest/reference/rockcraft-yaml/'>
           Rocks project file
         </a>
         <br />
@@ -187,19 +187,19 @@
           Use parts to build your container application
         </a>
         <br />
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/crafting/convert-to-pebble-layer/'>
+        <a href='/containers/rockcraft/docs/latest/how-to/crafting/convert-to-pebble-layer/'>
           Define rocks services
         </a>
         <br />
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/chiseling/chisel-existing-rock/'>
+        <a href='/containers/rockcraft/docs/latest/how-to/chiseling/chisel-existing-rock/'>
           Harden a rock
         </a>
         <br />
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/chiseling/chisel-existing-rock/#chisel-the-python-rock'>
+        <a href='/containers/rockcraft/docs/latest/how-to/chiseling/chisel-existing-rock/#chisel-the-python-rock'>
           Install a custom package slice
         </a>
         <br />
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/crafting/add-internal-user-to-a-rock/'>
+        <a href='/containers/rockcraft/docs/latest/how-to/crafting/add-internal-user-to-a-rock/'>
           Define a non root user
         </a>
       </p>
@@ -217,7 +217,7 @@
       ),
       "description_html": "
       <p>
-        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/reference/commands/pack/'>
+        <a href='/containers/rockcraft/docs/latest/reference/commands/pack/'>
           Pack a rock
         </a>
       </p>
@@ -235,7 +235,7 @@
       "type": "description",
       "item": {
         "type": "html",
-        "content": "<p>Try building a <a href='https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/hello-world/'>'Hello world' rock</a>. You can also build rocks for a variety of applications.</p>"
+        "content": "<p>Try building a <a href='/containers/rockcraft/docs/latest/tutorial/hello-world/'>'Hello world' rock</a>. You can also build rocks for a variety of applications.</p>"
       }
     }
   ]
@@ -248,7 +248,7 @@
   padding="deep",
   links=[
     {
-      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/flask/",
+      "href": "/containers/rockcraft/docs/latest/tutorial/flask/",
       "text": "Flask",
       "label": "Flask",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/a2d5e5ca-flask.png",
@@ -261,7 +261,7 @@
             )
     },
     {
-      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/django/",
+      "href": "/containers/rockcraft/docs/latest/tutorial/django/",
       "text": "Django",
       "label": "Django",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/dc8d56ca-django.png",
@@ -274,7 +274,7 @@
             )
     },
     {
-      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/fastapi/",
+      "href": "/containers/rockcraft/docs/latest/tutorial/fastapi/",
       "text": "FastAPI",
       "label": "FastAPI",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/9d2ae13c-fastapi.png",
@@ -287,7 +287,7 @@
             )
     },
     {
-      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/go/",
+      "href": "/containers/rockcraft/docs/latest/tutorial/go/",
       "text": "Go",
       "label": "Go",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/3a282fac-go.png",
@@ -300,7 +300,7 @@
             )
     },
     {
-      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/express/",
+      "href": "/containers/rockcraft/docs/latest/tutorial/express/",
       "text": "Express",
       "label": "Express",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/28615cea-express.png",
@@ -313,7 +313,7 @@
             )
     },
     {
-      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/springboot/",
+      "href": "/containers/rockcraft/docs/latest/tutorial/springboot/",
       "text": "Spring Boot",
       "label": "Spring Boot",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/001aa9b3-spring_boot.png",

--- a/templates/containers/docs.html
+++ b/templates/containers/docs.html
@@ -30,7 +30,7 @@
     ) -%}
     {%- if slot == 'description' -%}
       <p>
-      Canonical containers, also known as “rocks”, are a new generation of secure, stable and OCI-compliant Ubuntu images, <a href="/chisel/docs/latest/">hardened by design</a>, and offering a <a href="https://documentation.ubuntu.com/rockcraft/latest/explanation/pebble/">specialized and predictable UX</a>.
+      Canonical containers, also known as “rocks”, are a new generation of secure, stable and OCI-compliant Ubuntu images, <a href="https://ubuntu.com/chisel/docs/latest/">hardened by design</a>, and offering a <a href="https://ubuntu.com/containers/rockcraft/docs/latest/explanation/pebble/">specialized and predictable UX</a>.
       </p>
     {%- endif -%}
   {% endcall -%}
@@ -156,11 +156,11 @@
       ),
       "description_html": "
       <p>
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/how-to/get-started'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/get-started/'>
           Get started - quick guide
         </a>
         <br />
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/tutorial/hello-world/#setup-your-environment'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/hello-world/#setup-your-environment'>
           Use Rockcraft with Multipass
         </a>
       </p>
@@ -179,7 +179,7 @@
        ),
        "description_html": "
       <p>
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/reference/rockcraft-yaml/'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/reference/rockcraft-yaml/'>
           Rocks project file
         </a>
         <br />
@@ -187,19 +187,19 @@
           Use parts to build your container application
         </a>
         <br />
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/how-to/crafting/convert-to-pebble-layer/'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/crafting/convert-to-pebble-layer/'>
           Define rocks services
         </a>
         <br />
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/how-to/chiseling/chisel-existing-rock/#chisel-the-python-rock'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/chiseling/chisel-existing-rock/'>
           Harden a rock
         </a>
         <br />
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/how-to/chiseling/install-slice/'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/chiseling/chisel-existing-rock/#chisel-the-python-rock'>
           Install a custom package slice
         </a>
         <br />
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/how-to/crafting/add-internal-user-to-a-rock/'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/how-to/crafting/add-internal-user-to-a-rock/'>
           Define a non root user
         </a>
       </p>
@@ -217,7 +217,7 @@
       ),
       "description_html": "
       <p>
-        <a href='https://documentation.ubuntu.com/rockcraft/latest/reference/commands/pack/'>
+        <a href='https://ubuntu.com/containers/rockcraft/docs/latest/reference/commands/pack/'>
           Pack a rock
         </a>
       </p>
@@ -235,7 +235,7 @@
       "type": "description",
       "item": {
         "type": "html",
-        "content": "<p>Try building a <a href='https://documentation.ubuntu.com/rockcraft/latest/tutorial/hello-world/#tutorial-create-a-hello-world-rock'>'Hello world' rock</a>. You can also build rocks for a variety of applications.</p>"
+        "content": "<p>Try building a <a href='https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/hello-world/'>'Hello world' rock</a>. You can also build rocks for a variety of applications.</p>"
       }
     }
   ]
@@ -248,7 +248,7 @@
   padding="deep",
   links=[
     {
-      "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/flask/",
+      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/flask/",
       "text": "Flask",
       "label": "Flask",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/a2d5e5ca-flask.png",
@@ -261,7 +261,7 @@
             )
     },
     {
-      "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/django/",
+      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/django/",
       "text": "Django",
       "label": "Django",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/dc8d56ca-django.png",
@@ -274,7 +274,7 @@
             )
     },
     {
-      "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/fastapi/",
+      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/fastapi/",
       "text": "FastAPI",
       "label": "FastAPI",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/9d2ae13c-fastapi.png",
@@ -287,7 +287,7 @@
             )
     },
     {
-      "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/go/",
+      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/go/",
       "text": "Go",
       "label": "Go",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/3a282fac-go.png",
@@ -300,7 +300,7 @@
             )
     },
     {
-      "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/express/",
+      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/express/",
       "text": "Express",
       "label": "Express",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/28615cea-express.png",
@@ -313,7 +313,7 @@
             )
     },
     {
-      "href": "https://documentation.ubuntu.com/rockcraft/latest/tutorial/springboot/",
+      "href": "https://ubuntu.com/containers/rockcraft/docs/latest/tutorial/springboot/",
       "text": "Spring Boot",
       "label": "Spring Boot",
       "image_attrs": image(url="https://assets.ubuntu.com/v1/001aa9b3-spring_boot.png",


### PR DESCRIPTION
## Done

- Updated the following links on https://ubuntu.com/containers/docs : 
   - `hardened by design`
   - `specialized and predictable UX`
   - `Pack a rock`
   - `Get started - quick guide`
   - `Use Rockcraft with Multipass`
   - `Rocks project file`
   - `Define rocks services`
   - `Harden a rock`
   - `Install a custom package slice`
   - `Define a non root user`
   - `'Hello World' rock`
   - `Flask`
   - `Django`
   - `FastAPI`
   - `Go`
   - `Express`
   - `Spring Boot`

Copy Doc: https://docs.google.com/document/d/1Vs57mJHBcn_Q48rkR8UrVq8eHvDG7R4581wRhcVQQr0/edit?tab=t.0

Jira Ticket: https://warthogs.atlassian.net/browse/WD-38381

## QA

- Open the [DEMO](https://ubuntu-com-16697.demos.haus/containers/docs)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Test the new links

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
