### PR TITLE
Update registration link & remove links to previous blog

### DIFF
--- a/templates/summit/call-for-collaboration.html
+++ b/templates/summit/call-for-collaboration.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 
 {% block title %}
-  Ubuntu Summit 26.04 | Call for collaboration
+  Ubuntu Summit | Call for collaboration
 {% endblock title %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1pjIpFWL7yu6Jc2gZGqCRvckd4clPVrLtGpRwTaw9-CY{% endblock %}
@@ -146,11 +146,6 @@
           <p>
             While the physical event takes place in London, watch parties and Summit extended events are hosted all over the world by local communities.
           </p>
-          <div class="p-cta-block">
-            <a href="/blog/ubuntu-summit-26-04-is-coming-save-the-date-and-share-your-story"
-               class="p-button"
-               aria-label="Learn more about ubuntu summit 25.10">Learn more</a>
-          </div>
         </div>
       </div>
     </div>

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -32,7 +32,7 @@
             Tune in to our London livestream from the comfort of your home, from an Ubuntu release watch party, or from anywhere else around the world.
           </p>
           <div class="p-cta-block">
-            <a href="https://discourse.ubuntu.com/t/register-for-ubuntu-summit/65270" class="p-button--positive">Register for the Summit</a>
+            <a href="https://discourse.ubuntu.com/c/ubuntu-summit/" class="p-button--positive">Register for the Summit</a>
             <a href="/summit/call-for-collaboration" class="p-button">Find out how you can contribute</a>
           </div>
         </div>
@@ -90,10 +90,6 @@
         <p>
           While the physical event takes place in London, watch parties and Summit extended events are hosted all over the world by local communities.
         </p>
-        <div class="p-cta-block">
-          <a href="/blog/ubuntu-summit-26-04-is-coming-save-the-date-and-share-your-story" aria-label="Learn more about The Ubuntu Summit">
-            Learn more&nbsp;&rsaquo;
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updating registration link to https://discourse.ubuntu.com/c/ubuntu-summit/
- Removing Summit number in page title
- Removing CTA sections containing blog links that aren't relevant

## QA

- Open the [DEMO](https://ubuntu-com-16698.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare to copydocs ([/summit](https://docs.google.com/document/d/1lj-xPVQjWqo2J_eZ-3ldKhJHj6RQ0Cwmk_Mr4QA4UTY/edit?tab=t.drdrmoltf7ot), [/summit/call-for-collaboration](https://docs.google.com/document/d/1pjIpFWL7yu6Jc2gZGqCRvckd4clPVrLtGpRwTaw9-CY/edit?tab=t.dxdptoffij7w))

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

