### PR TITLE
feat(/download/qualcomm-iot): add 'Arduino VENTUNO Q' tab

### DIFF
--- a/templates/download/qualcomm-iot/index.html
+++ b/templates/download/qualcomm-iot/index.html
@@ -65,7 +65,7 @@
                     role="tab"
                     aria-selected="true"
                     aria-controls="rb3-gen2-tab">
-              Qualcomm Dragonwing™ RB3 Gen 2 Vision Development Kit (QCS6490)
+              Qualcomm Dragonwing&trade; RB3 Gen 2 Vision Development Kit (QCS6490)
             </button>
           </li>
           <li>
@@ -74,7 +74,7 @@
                     role="tab"
                     aria-selected="false"
                     aria-controls="rb3-gen2-lite-tab">
-              Qualcomm Dragonwing™ RB3 Gen 2 Lite Vision Development Kit (QCS5430)
+              Qualcomm Dragonwing&trade; RB3 Gen 2 Lite Vision Development Kit (QCS5430)
             </button>
           </li>
           <li>
@@ -83,7 +83,7 @@
                     role="tab"
                     aria-selected="false"
                     aria-controls="evaluation-kit-tab">
-              Qualcomm Dragonwing™ IQ-9075 Evaluation Kit (EVK)
+              Qualcomm Dragonwing&trade; IQ-9075 Evaluation Kit (EVK)
             </button>
           </li>
           <li>
@@ -92,7 +92,7 @@
                     role="tab"
                     aria-selected="false"
                     aria-controls="evaluation-kit2-tab">
-              Qualcomm Dragonwing™ IQ-8275 Evaluation Kit (EVK)
+              Qualcomm Dragonwing&trade; IQ-8275 Evaluation Kit (EVK)
             </button>
           </li>
           <li>
@@ -101,7 +101,16 @@
                     role="tab"
                     aria-selected="false"
                     aria-controls="evaluation-kit3-tab">
-              Qualcomm Dragonwing™ IQ-X7181 Evaluation Kit (EVK)
+              Qualcomm Dragonwing&trade; IQ-X7181 Evaluation Kit (EVK)
+            </button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="ventunoq"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="arduino-ventuno-q-tab">
+              Arduino VENTUNO&trade; Q
             </button>
           </li>
           <li>
@@ -121,6 +130,7 @@
         {% include "download/qualcomm-iot/tabs/evaluation-kit-tab.html" %}
         {% include "download/qualcomm-iot/tabs/evaluation-kit2-tab.html" %}
         {% include "download/qualcomm-iot/tabs/evaluation-kit3-tab.html" %}
+        {% include "download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html" %}
         {% include "download/qualcomm-iot/tabs/development-board-tab.html" %}
       </div>
     </div>

--- a/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
+++ b/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
@@ -74,7 +74,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the Arduino VENTUNO Q platform
+            The Ubuntu images are tested on the <a href="https://www.arduino.cc/product-ventuno-q">Arduino VENTUNO Q</a> platform
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
+++ b/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
@@ -37,7 +37,7 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x13/ubuntu-desktop-24.04/"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ventunoq/ubuntu-desktop-24.04/20260729-248/"
                title="Download Ubuntu Desktop 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -66,7 +66,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for VENTUNO Q <a
-            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x13/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
+            href="https://people.canonical.com/~platform/images/qualcomm-iot/ventunoq/ubuntu-desktop-24.04/20260729-248/Ubuntu_24.04_Arduino_Ventuno_Q_Release_Notes.pdf"
             title="Read full release notes of Ubuntu 24.04 for VENTUNO Q">release notes</a>
         </li>
       </ul>

--- a/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
+++ b/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
@@ -61,7 +61,7 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for VENTUNO Q <a
-            href="https://docs.arduino.cc/software/app-lab/configure/flash/#use-the-arduino-flasher-cli"
+            href="https://docs.arduino.cc/software/app-lab/configure/flash/"
             title="Read image installation instructions of Ubuntu 24.04 for VENTUNO Q">image installation instructions</a>
         </li>
         <li class="p-list__item">

--- a/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
+++ b/templates/download/qualcomm-iot/tabs/arduino-ventuno-q-tab.html
@@ -1,0 +1,85 @@
+<div tabindex="0" role="tabpanel" id="arduino-ventuno-q-tab" aria-labelledby="ventunoq" aria-hidden="true">
+  <div class="p-section--shallow">
+    <div class="row">
+      <div class="col-3">
+        <h2 class="u-hide--small">Arduino VENTUNO&trade; Q</h2>
+      </div>
+      <div class="col-6">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/ca6a9bb5-ventuno_q_perspective_01_4k_1.png",
+            alt="Arduino VENTUNO Q",
+            width="600",
+            height="338",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="p-rule--muted" />
+  <div class="row">
+    <div class="col-3">
+      <h3 class="p-heading--5">Ubuntu 24.04 LTS</h3>
+    </div>
+    <div class="col-6">
+      <p>
+        This is the optimized Ubuntu 24.04 release on Arduino VENTUNO Q platform. This image also contains packages maintained by Arduino on top of Ubuntu image.
+      </p>
+      <div class="p-section--shallow">
+        <div class="row">
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Desktop 24.04</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x13/ubuntu-desktop-24.04/"
+               title="Download Ubuntu Desktop 24.04">Download</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Boot firmware</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button"
+               href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCS8300/QLI.1.7-Ver.1.3/QLI.1.7-Ver.1.3-ubuntu-QCS8300-nhlos-bins.tar.gz"
+               title="Download boot firmware">Download</a>
+          </div>
+        </div>
+      </div>
+
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 24.04 for <a href="https://www.arduino.cc/product-ventuno-q"
+            title="Read more about Arduino VENTUNO Q">VENTUNO Q</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu 24.04 for VENTUNO Q <a
+            href="https://docs.arduino.cc/software/app-lab/configure/flash/#use-the-arduino-flasher-cli"
+            title="Read image installation instructions of Ubuntu 24.04 for VENTUNO Q">image installation instructions</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu 24.04 for VENTUNO Q <a
+            href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x13/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_IQ-9075_IQ-8275_Evaluation_Kits_Release_Notes.pdf"
+            title="Read full release notes of Ubuntu 24.04 for VENTUNO Q">release notes</a>
+        </li>
+      </ul>
+      <hr class="p-rule--muted" />
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the Arduino VENTUNO Q platform
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <hr class="p-rule--muted" />
+</div>


### PR DESCRIPTION
**Merge on August 25th with Ventuno release**

## Done

- add 'Arduino VENTUNO Q' tab based on [copydoc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0#heading=h.qeo03eobmu3)
 
## QA

- Open the [DEMO](https://ubuntu-com-16701.demos.haus//download/qualcomm-iot#ventunoq)
- Compare against the [copydoc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0#heading=h.qeo03eobmu3)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38403

