### PR TITLE
Feat: add missing AI search crawlers and serve robots.txt at root

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -904,7 +904,6 @@ release-notes/precise-pangolin/?: "https://wiki.ubuntu.com/PrecisePangolin/Relea
 releases/?: "https://releases.ubuntu.com"
 releaseendoflife/?: "/about/release-cycle"
 risc-v/?: /download/risc-v/canonical-built
-robots.txt?: "/static/files/robots.txt"
 robotics/esm/?: "/robotics/ros-esm"
 rss\.xml/?: "/blog/feed"
 rss\.xmlsubscribe=feed/?: "/blog/feed"

--- a/robots.txt
+++ b/robots.txt
@@ -60,16 +60,20 @@ Crawl-delay: 1
 
 # ===========================================
 # AI OPTIMIZED RULES
-# Includes: OpenAI (Browsing & Crawling), Perplexity, and Anthropic
+# Includes: OpenAI (Browsing & Crawling), Perplexity, Anthropic, and Apple
 # ===========================================
 User-agent: GPTBot
 User-agent: ChatGPT-User
+User-agent: OAI-SearchBot
 User-agent: ClaudeBot
 User-agent: Claude-Web
 User-agent: anthropic-ai
+User-agent: Claude-SearchBot
 User-agent: Google-Extended
 User-agent: meta-externalagent
 User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Applebot-Extended
 User-agent: cohere-ai
 User-agent: Bytespider
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -43,6 +43,7 @@ parts:
       - flask/app/webapp
       - flask/app/templates
       - flask/app/static
+      - flask/app/robots.txt
       - flask/app/scripts
       - flask/app/redirects.yaml
       - flask/app/deleted.yaml

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2420,8 +2420,7 @@ def google_ads_verification():
     """
     Serve the Google Ads account-access verification token from the domain
     root. Google fetches /Google-Ads.txt directly and does not reliably
-    follow redirects, so this is served in place rather than through a
-    redirects.yaml entry like robots.txt uses.
+    follow redirects, so this is served in place via a dedicated route.
     """
     return flask.send_from_directory(
         flask.current_app.static_folder, "files/Google-Ads.txt"


### PR DESCRIPTION
## Done


- Add missing AI search crawlers as suggested in  the ticket https://warthogs.atlassian.net/browse/WD-38045
- Serve robots.txt at the root (no redirect)
Previously `/robots.txt` was a **302** redirect to `/static/files/robots.txt`, which tells crawlers to re-check the original location every crawl cycle (a wasted request per cycle). 

## QA
- Open the https://ubuntu-com-16709.demos.haus/robots.txt
- Ensure there is no redirect in networks tab
- Ensure the suggested crawlers are now part of robots.txt

## Fixes
[WD-38045](https://warthogs.atlassian.net/browse/WD-38045).


[WD-38045]: https://warthogs.atlassian.net/browse/WD-38045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ