### PR TITLE
fix(calculator): correct public cloud cost calculation formula

### DIFF
--- a/static/js/src/ceph-pricing-calculator.js
+++ b/static/js/src/ceph-pricing-calculator.js
@@ -8,6 +8,17 @@ const switchCost = 11308.0;
 const cephDeploymentCost = 50000;
 const hardwareMaintenanceCost = 25000;
 
+// Public cloud cost, see the formula in the spreadsheet copydoc
+// https://docs.google.com/spreadsheets/d/1cn5daIlWGpKF5557ERFY4Ok4_0IlJKTDbZjRXcXyhjk/edit?
+function calculatePublicCloudCost(selectedStorage, selectedMonths) {
+  return (
+    (50 * 1024 * 0.023 +
+      450 * 1024 * 0.022 +
+      (selectedStorage * 1024 - 500) * 1024 * 0.021) *
+    selectedMonths
+  );
+}
+
 const capacityTable = [
   {
     capacity: 2.25,
@@ -223,12 +234,10 @@ document.addEventListener("DOMContentLoaded", function () {
       additionalStorageCost +
       hardwareCost;
 
-    // Public cloud cost, see the formula in the spreadsheet copydoc
-    const publicCloudCost =
-      (50 * 1024 * 0.023 +
-        450 * 1024 * 0.022 +
-        (((selectedStorage * 1024)-500) * 1024) * 0.021) *
-      selectedMonths;
+    const publicCloudCost = calculatePublicCloudCost(
+      selectedStorage,
+      selectedMonths,
+    );
 
     function formatCurrency(value) {
       return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -278,3 +287,11 @@ document.querySelectorAll(".js-show").forEach((ele) => {
   ele.classList.remove("u-hide");
 });
 initializeSliders();
+
+// This file is loaded as a plain (non-module) browser script, so it can't use
+// `export`. `module` is only defined under CommonJS (e.g. Jest/Node), so this
+// is a no-op in the browser and only exposes `calculatePublicCloudCost` for
+// unit testing.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { calculatePublicCloudCost };
+}

--- a/static/js/src/ceph-pricing-calculator.js
+++ b/static/js/src/ceph-pricing-calculator.js
@@ -227,7 +227,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const publicCloudCost =
       (50 * 1024 * 0.023 +
         450 * 1024 * 0.022 +
-        (selectedStorage * 1024 * 1024 - 500) * 0.021) *
+        (((selectedStorage * 1024)-500) * 1024) * 0.021) *
       selectedMonths;
 
     function formatCurrency(value) {

--- a/static/js/src/ceph-pricing-calculator.test.js
+++ b/static/js/src/ceph-pricing-calculator.test.js
@@ -1,0 +1,43 @@
+/**
+ * Regression tests for the public cloud cost formula in the Ceph pricing
+ * calculator (WD-38476).
+ *
+ * The formula previously subtracted a flat `500` from
+ * `selectedStorage * 1024 * 1024` before multiplying by the per-GB rate,
+ * instead of converting the 500 TB "included" allowance to the same unit
+ * first. This produced an inflated public cloud cost estimate. The fixed
+ * formula is:
+ *
+ *   (selectedStorage * 1024 - 500) * 1024 * 0.021
+ *
+ * `calculatePublicCloudCost` is exported via a CommonJS-guarded
+ * `module.exports` (this file is loaded as a plain, non-bundled browser
+ * script, so it can't use ES module `export`), which is a no-op in the
+ * browser and only used here so the formula can be unit tested directly.
+ *
+ * Note: requiring this module also runs its top-level side effects
+ * (`initializeSliders()`), which queries `#compare-costs-form`, so a
+ * minimal stub of that element must exist in the DOM before requiring it.
+ */
+
+document.body.innerHTML = `<form id="compare-costs-form"></form>`;
+const { calculatePublicCloudCost } = require("./ceph-pricing-calculator.js");
+
+describe("calculatePublicCloudCost", () => {
+  it("calculates the correct cost for 9 (TB) over 12 months", () => {
+    expect(calculatePublicCloudCost(9, 12)).toBeCloseTo(2384928.768, 2);
+  });
+
+  it("calculates the correct cost for 2.25 (TB) over 1 month", () => {
+    expect(calculatePublicCloudCost(2.25, 1)).toBeCloseTo(50108.416, 2);
+  });
+
+  it("calculates the correct cost for 18 (TB) over 36 months", () => {
+    expect(calculatePublicCloudCost(18, 36)).toBeCloseTo(14289297.408, 2);
+  });
+
+  it("scales linearly with the number of months", () => {
+    const oneMonth = calculatePublicCloudCost(9, 1);
+    expect(calculatePublicCloudCost(9, 12)).toBeCloseTo(oneMonth * 12, 6);
+  });
+});


### PR DESCRIPTION
## Done

The Ceph pricing calculator's public cloud cost formula had a unit mismatch. The first 50 TB and next 450 TB tiers were converted to GB using `* 1024`, but only `500` (GB) was subtracted when calculating for rest of >500TB .

Look this sheet for more reference: https://docs.google.com/spreadsheets/d/1cn5daIlWGpKF5557ERFY4Ok4_0IlJKTDbZjRXcXyhjk/edit?gid=2037140473#gid=2037140473


```diff
- (selectedStorage * 1024 * 1024 - 500) * 0.021
+ (((selectedStorage * 1024) - 500) * 1024) * 0.021
```

## QA
- Go to https://ubuntu-com-16710.demos.haus//ceph/pricing-calculator 
- See that the formula now matches the fix suggested in the linked issue algebraically: `(selectedStorage * 1024 - 500) * 1024 == selectedStorage * 1024 * 1024 - 500 * 1024`.

## Fixes
 [WD-38476](https://warthogs.atlassian.net/browse/WD-38476)16695

[WD-38476]: https://warthogs.atlassian.net/browse/WD-38476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ