### PR TITLE
chore: update releases.yml for the new point release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -7,18 +7,18 @@ latest:
   core_version: "24"
   release_date: "April 2026"
   eol: "April 2031"
-  release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/1"
-  blog_post_url: "https://ubuntu.com/blog/upgrade-your-desktop-ubuntu-26-04-lts"
+  release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"
+  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon"
   mascot_image_large:
     url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182
     height: 182
-  iso_download_size: "5.9GB"
+  iso_download_size: "6.0GB"
   arm_iso_download_size: "3.9GB"
-  server_iso_size: "3GB"
+  server_iso_size: "2.7GB"
   arm_server_iso_size: "2.9GB"
-  raspi_desktop_iso_size: "2.6GB"
-  raspi_server_iso_size: "1.1GB"
+  raspi_desktop_iso_size: "2.9GB"
+  raspi_server_iso_size: "1.4GB"
   rasp_pi_core_24_size: "314MB"
 lts:
   slug: ResoluteRaccoon
@@ -67,6 +67,7 @@ wsl:
 
 checksums:
   desktop:
+    "26.04.1": "601e30fbf5d97759367c632e2c33630665039b7e2158fd068403da3ccf1bda1f *ubuntu-26.04.1-desktop-amd64.iso"
     "26.04": "487f87faaf547ea30e0aba4d5b53346292571256b25333a978db1692bcee9dd2 *ubuntu-26.04-desktop-amd64.iso"
     "25.10": "32e30d72ae4798c633323a2684d94a11582bb03a6ab38d2b0d5ae5eabc5e577b *ubuntu-25.10-desktop-amd64.iso"
     "25.04": "b87366b62eddfbecb60e681ba83299c61884a0d97569abe797695c8861f5dea4 *ubuntu-25.04-desktop-amd64.iso"
@@ -76,9 +77,11 @@ checksums:
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   desktop-arm64:
+    "26.04.1": "c54d196489d3c867975fb3bbb72ca52ec2e137456e305481f81096304e4d2517 *ubuntu-26.04.1-desktop-arm64.iso"
     "26.04": "c2afd538d66fdd77377d03f1ed2ac76a34f1c116baecc9a8170d68f833121f57 *ubuntu-26.04-desktop-arm64.iso"
     "25.10": "9d383dd57220dec520fdec3be05da258d27d435c02fe6e296c5d0a505741a787 *ubuntu-25.10-desktop-arm64.iso"
   live-server:
+    "26.04.1": "cc8a95cde20f6ced61a322420de00f10cc3c90ced545daa46cb9c1a117f1d927 *ubuntu-26.04.1-live-server-amd64.iso"
     "26.04": "dec49008a71f6098d0bcfc822021f4d042d5f2db279e4d75bdd981304f1ca5d9 *ubuntu-26.04-live-server-amd64.iso"
     "25.10": "dc54870e5261c0abad19f74b8146659d10e625971792bd42d7ecde820b60a1d0 *ubuntu-25.10-live-server-amd64.iso"
     "25.04": "8b44046211118639c673335a80359f4b3f0d9e52c33fe61c59072b1b61bdecc5 *ubuntu-25.04-live-server-amd64.iso"
@@ -89,10 +92,12 @@ checksums:
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   live-server-arm64:
+    "26.04.1": "af78753c94b924c85c4964c670692a853f7c80299a4064e317edad95462e3168 *ubuntu-26.04.1-live-server-arm64.iso"
     "26.04": "c9aa567e6560b2eddae3af03fc686002e35b6fee96f97fd5df3271e846439fdd *ubuntu-26.04-live-server-arm64.iso"
     "25.10": "ecf579664c0be9e4a68ae7b617399ce943c2dee49eb1fcc6702a5671a4f88320 *ubuntu-25.10-live-server-arm64.iso"
     "24.04.4": "9a6ce6d7e66c8abed24d24944570a495caca80b3b0007df02818e13829f27f32 *ubuntu-24.04.4-live-server-arm64.iso"
   desktop-arm64+raspi:
+    "26.04.1": "8216f54cc1df2fcf7de37530a7edccdd200abd7dcfbc5d4f0407df7513544d6a *ubuntu-26.04.1-preinstalled-desktop-arm64+raspi.img.xz"
     "26.04": "c8b5d454baf26c6ed3f2a211cdd80183671aed8b67a92817cf5750e02da7f6a6 *ubuntu-26.04-preinstalled-desktop-arm64+raspi.img.xz"
     "25.10": "d35bc2aa6ed256293c4eab4d6066274364ddc790d327bb1ec1bfac117ec89dd3 *ubuntu-25.10-preinstalled-desktop-arm64+raspi.img.xz"
     "25.04": "278b1748c783a69edb526e7e29d51b4e55f505a1dcddcc8be3977df5b8d87088 *ubuntu-25.04-preinstalled-desktop-arm64+raspi.img.xz"
@@ -102,6 +107,7 @@ checksums:
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
+    "26.04.1": "d59ef9c6e85b906995501f166d00726ab80b59be7b65cdeac0fa31b996053e13 *ubuntu-26.04.1-preinstalled-server-arm64+raspi.img.xz"
     "26.04": "10604098a0c4eeb7359e58e12b01badbce8c74b0d53b414e633ba0b047b512cd *ubuntu-26.04-preinstalled-server-arm64+raspi.img.xz"
     "25.10": "b7d8c52fd25e2b6a86f07669769850076a97c2aa1dcbb29cb3038ad5c619cc68 *ubuntu-25.10-preinstalled-server-arm64+raspi.img.xz"
     "25.04": "a1439585661b69fd43a29610b443ae460893c5ea88c2036ae979ae6071827ec6 *ubuntu-25.04-preinstalled-server-arm64+raspi.img.xz"
@@ -116,6 +122,7 @@ checksums:
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64-preinstalled:
+    "26.04.1": "0fafe15634d3b66c3fcb4df17a5fde0b340d2d663af47e4fb5ffb59b9dddc94a *ubuntu-26.04.1-preinstalled-server-riscv64.img.xz"
     "26.04": "42210dc700bd7967e7fe294f60d8ee643b27e5870b8f49a4d710155485258aae *ubuntu-26.04-preinstalled-server-riscv64.img.xz"
     "25.10": "16ba9ab3d2c1e5138d35defb5f3abfb83bb9f9df69944b0e0bb8b4219e9045d1 *ubuntu-25.10-preinstalled-server-riscv64.img.xz"
     "24.04.4": "f032fcca77479a4e8518002dbb3b822ed504739381d0648ba6e593982508e606 *ubuntu-24.04.4-preinstalled-server-riscv64.img.xz"
@@ -123,6 +130,7 @@ checksums:
     "22.04.5": "4281edf7bff64d7ac4f8bae5b1ded7b66937ec51dd62ddfdbc7851e5c8c68ecb *ubuntu-22.04.5-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   server-riscv64-live:
+    "26.04.1": "c44c0e9343a477e08943a140d21ac903ec891ece5c0a69f7424e198562f9f272 *ubuntu-26.04.1-live-server-riscv64.iso"
     "26.04": "82afc6b53c1009d6359017bc9522858670942746e8522d0d6ec951af828b919e *ubuntu-26.04-live-server-riscv64.iso"
     "25.10": "839f0602ead71d8c5a85444164e8cd09af48c348a0ecd729f01531c95f39e00e *ubuntu-25.10-live-server-riscv64.iso"
     "25.04": "5c16519f6137a890044c5fb4110264586f5aaddcb9e493bd6ac6bd5fc9934107 *ubuntu-25.04-live-server-riscv64.img.gz"
@@ -132,8 +140,10 @@ checksums:
   core-22-armhf+raspi:
     "22": "4c4b3958626611aff85bfa5873c45ad22fdf7642be868b5722900fa88e6fca86 *ubuntu-core-22-armhf+raspi.img.xz"
   wsl:
+    "26.04.1": "48d56724b5c8e60f24893e83e73bbb58c60b3ca22fba3da977075420acd54104 *ubuntu-26.04.1-wsl-amd64.wsl"
     "26.04": "96c7f5fb28a7fe28245331f9bfbe4375f18dd29a4850116ad3c4f60f6700c55c *ubuntu-26.04-wsl-amd64.wsl"
     "24.04.4": "9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5 *ubuntu-24.04.4-wsl-amd64.wsl"
   wsl-arm64:
+    "26.04.1": "c7d893d7ccb291009e6096c5a946937337b6fd4c426f11b6541f6cd2bf894f7d *ubuntu-26.04.1-wsl-arm64.wsl"
     "26.04": "9fae7b65ac7be0ebb019987c922f1f1f1aaffb061834eb22e76a5e2a958dd3f6 *ubuntu-26.04-wsl-arm64.wsl"
     "24.04.4": "6b244d89f412a68f51e58f396fab65bed3b5896a25c045a99bef9c78a07df507 *ubuntu-24.04.4-wsl-arm64.wsl"

--- a/releases.yaml
+++ b/releases.yaml
@@ -2,13 +2,13 @@ latest:
   slug: ResoluteRaccoon
   name: "Resolute Raccoon"
   short_version: "26.04"
-  full_version: "26.04"
-  desktop_version: "26.04"
+  full_version: "26.04.1"
+  desktop_version: "26.04.1"
   core_version: "24"
   release_date: "April 2026"
   eol: "April 2031"
-  release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"
-  blog_post_url: "https://ubuntu.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon"
+  release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/1"
+  blog_post_url: "https://ubuntu.com/blog/upgrade-your-desktop-ubuntu-26-04-lts"
   mascot_image_large:
     url: "https://assets.ubuntu.com/v1/c2fb7c9e-resolute_raccoon_black.png"
     width: 182
@@ -24,7 +24,7 @@ lts:
   slug: ResoluteRaccoon
   name: "Resolute Raccoon"
   short_version: "26.04"
-  full_version: "26.04"
+  full_version: "26.04.1"
   release_date: "April 2026"
   eol: "April 2031"
   release_notes_url: "https://documentation.ubuntu.com/release-notes/26.04/"

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -41,9 +41,9 @@ You can
     }
   }
 
-  document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll(".js-verify-download").forEach(function (button) {
-      button.addEventListener("click", verifyDownloadContent);
-    });
+  // Bound immediately rather than on DOMContentLoaded: arm64 pages redirect to
+  // cdimage during load, which aborts the document and DOMContentLoaded never fires.
+  document.querySelectorAll(".js-verify-download").forEach(function (button) {
+    button.addEventListener("click", verifyDownloadContent);
   });
 </script>


### PR DESCRIPTION
## Done

- Update `releases.yml` for the new `26.04.1` point release

## QA

- Open the [DEMO](https://ubuntu-com-16711.demos.haus/download/desktop)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify it says 26.04.1
- Try to download the iso, verify it downloads correct iso

## Fixes

Fixes [WD-38553](https://warthogs.atlassian.net/browse/WD-38553)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-38553]: https://warthogs.atlassian.net/browse/WD-38553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ