### PR TITLE
Gate form submit button until required fields are filled

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -7,6 +7,10 @@
  */
 import "infer-preferred-language.js";
 import { prepareInputFields } from "./prepare-form-inputs.js";
+import {
+  initRequiredFieldGate,
+  destroyRequiredFieldGate,
+} from "./utils/required-field-gate.js";
 
 (function () {
   document.addEventListener("DOMContentLoaded", function () {
@@ -108,7 +112,6 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
       if (modalTrigger && modalTrigger !== document.body)
         modalTrigger.setAttribute("aria-expanded", "true");
       updateHash(triggeringHash);
-      checkRequiredCheckboxes();
       dataLayer.push({
         event: "interactive-forms",
         action: "open",
@@ -234,6 +237,8 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
         contactModal.querySelectorAll(".pagination a");
       const paginationContent = contactModal.querySelectorAll(".js-pagination");
       const submitButton = contactModal.querySelector('button[type="submit"]');
+      const gatedForm = contactModal.querySelector("form[data-required-gate]");
+      if (gatedForm) initRequiredFieldGate(gatedForm);
       const comment = contactModal.querySelector("#Comments_from_lead__c");
       const otherContainers = document.querySelectorAll(".js-other-container");
       const phoneNumberInput = document.querySelector("#phone");
@@ -330,6 +335,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
         // clean up event listeners when the modal is closed
         if (contactModal) {
+          if (gatedForm) destroyRequiredFieldGate(gatedForm);
           contactModal.removeEventListener("submit", submitForm);
           contactModal.removeEventListener("mousedown", handleModalMouseDown);
           contactModal.removeEventListener("mouseup", handleModalMouseUp);
@@ -582,31 +588,12 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
       fireLoadedEvent();
 
-      // Disable submit button if there are required checkboxes
-      const requiredFieldsets = document.querySelectorAll(
-        "fieldset.js-required-checkbox",
-      );
-      if (requiredFieldsets.length) {
-        submitButton.disabled = true;
-      }
-
       // Add event listeners to toggle checkbox visibility
       const ubuntuVersionCheckboxes = document.querySelector(
         "fieldset.js-toggle-checkbox-visibility",
       );
       ubuntuVersionCheckboxes?.addEventListener("change", function (event) {
         toggleCheckboxVisibility(ubuntuVersionCheckboxes, event.target);
-      });
-
-      // Add event listeners if there are required fieldsets present
-      if (requiredFieldsets.length > 0) {
-        const submitButton = document.querySelector(".js-submit-button");
-        submitButton.disabled = true;
-      }
-      requiredFieldsets?.forEach((fieldset) => {
-        fieldset.addEventListener("change", function (event) {
-          checkRequiredCheckboxes();
-        });
       });
 
       // Prefill user names and email address if they are logged in
@@ -759,33 +746,6 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
           });
         }
       }
-    }
-
-    /**
-     * Check all required fieldsets and enable/disable submit button accordingly
-     * Submit button is only enabled when ALL required fieldsets have at least one checkbox checked
-     */
-    function checkRequiredCheckboxes() {
-      const submitButton = document.querySelector(".js-submit-button");
-      const allRequiredFieldsets = document.querySelectorAll(
-        "fieldset.js-required-checkbox",
-      );
-      let allFieldsetsValid = true;
-
-      allRequiredFieldsets?.forEach((fieldset) => {
-        const checkboxes = fieldset.querySelectorAll("input[type='checkbox']");
-        let hasCheckedCheckbox = false;
-
-        checkboxes?.forEach((checkbox) => {
-          if (checkbox.checked) {
-            hasCheckedCheckbox = true;
-          }
-        });
-        if (!hasCheckedCheckbox) {
-          allFieldsetsValid = false;
-        }
-      });
-      submitButton.disabled = !allFieldsetsValid;
     }
   });
 })();

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -238,7 +238,7 @@ import {
       const paginationContent = contactModal.querySelectorAll(".js-pagination");
       const submitButton = contactModal.querySelector('button[type="submit"]');
       const gatedForm = contactModal.querySelector("form[data-required-gate]");
-      if (gatedForm) initRequiredFieldGate(gatedForm);
+      const gateHandle = gatedForm ? initRequiredFieldGate(gatedForm) : null;
       const comment = contactModal.querySelector("#Comments_from_lead__c");
       const otherContainers = document.querySelectorAll(".js-other-container");
       const phoneNumberInput = document.querySelector("#phone");
@@ -616,6 +616,10 @@ import {
         lastNameFields.forEach((field) => {
           field.value = lastName;
         });
+
+        // Programmatic value assignment fires no input/change event, so the
+        // gate never sees these prefilled values without an explicit nudge.
+        gateHandle?.refresh();
       }
 
       function submitForm(e) {

--- a/static/js/src/static-forms.js
+++ b/static/js/src/static-forms.js
@@ -1,3 +1,5 @@
+import { initRequiredFieldGate } from "./utils/required-field-gate.js";
+
 function setUpStaticForms(form, formId) {
   /**
    *
@@ -214,14 +216,6 @@ function setUpStaticForms(form, formId) {
     form.addEventListener("submit", () => attachLoadingSpinner(submitButton));
   }
 
-  // Disable submit button if there are required checkboxes
-  const requiredCheckboxes = document.querySelectorAll(
-    "fieldset.js-required-checkbox",
-  );
-  if (requiredCheckboxes.length) {
-    submitButton.disabled = true;
-  }
-
   form.addEventListener("submit", function (e) {
     setDataLayerConsentInfo();
   });
@@ -243,6 +237,13 @@ function extractMarketoID(str) {
 const forms = document.querySelectorAll(
   "form[action='/marketo/submit']:not(.js-modal-form)",
 );
+
+// Gating is opt-in and must bind before setUpStaticForms attaches the spinner
+// and consent submit listeners, so its stopImmediatePropagation() reaches them.
+document
+  .querySelectorAll("form[data-required-gate]:not(.js-modal-form)")
+  .forEach((form) => initRequiredFieldGate(form));
+
 if (forms.length) {
   forms.forEach((form) => setUpStaticForms(form, extractMarketoID(form.id)));
 }
@@ -303,43 +304,6 @@ const ubuntuVersionCheckboxes = document.querySelector(
 ubuntuVersionCheckboxes?.addEventListener("change", function (event) {
   toggleCheckboxVisibility(ubuntuVersionCheckboxes, event.target);
 });
-
-// Add event listeners to required fieldsets
-const requiredFieldsets = document.querySelectorAll(
-  "fieldset.js-required-checkbox",
-);
-requiredFieldsets?.forEach((fieldset) => {
-  fieldset.addEventListener("change", function (event) {
-    checkRequiredCheckboxes();
-  });
-});
-
-/**
- * Check all required fieldsets and enable/disable submit button accordingly
- * Submit button is only enabled when ALL required fieldsets have at least one checkbox checked
- */
-function checkRequiredCheckboxes() {
-  const submitButton = document.querySelector(".js-submit-button");
-  const allRequiredFieldsets = document.querySelectorAll(
-    "fieldset.js-required-checkbox",
-  );
-  let allFieldsetsValid = true;
-
-  allRequiredFieldsets.forEach((fieldset) => {
-    const checkboxes = fieldset.querySelectorAll("input[type='checkbox']");
-    let hasCheckedCheckbox = false;
-
-    checkboxes.forEach((checkbox) => {
-      if (checkbox.checked) {
-        hasCheckedCheckbox = true;
-      }
-    });
-    if (!hasCheckedCheckbox) {
-      allFieldsetsValid = false;
-    }
-  });
-  submitButton.disabled = !allFieldsetsValid;
-}
 
 /**
  * Sets the consent info from the data layer into the consent_info cookie

--- a/static/js/src/utils/required-field-gate.js
+++ b/static/js/src/utils/required-field-gate.js
@@ -90,12 +90,26 @@ export function findUnanswered(form) {
     }
   });
 
+  const reportedRadioGroups = new Set();
   form.querySelectorAll("input, select, textarea").forEach((control) => {
     if (!isEligible(control)) return;
     if (isValid(control)) return;
     // Controls inside a required question are reported as that question.
     if (control.closest(QUESTION_SELECTOR)) return;
-    missing.push({ target: control, label: controlLabel(control) });
+    let label = controlLabel(control);
+    // An unmarked required radio group is still one question: report it once,
+    // preferring its fieldset's legend over an arbitrary option's own label.
+    // Scoped to radios — other control types already have a correct label
+    // from controlLabel() and may share a fieldset with unrelated questions
+    // (e.g. the "about-you" fieldset wrapping several individually-labeled
+    // fields under one legend).
+    if (control.type === "radio") {
+      if (reportedRadioGroups.has(control.name)) return;
+      reportedRadioGroups.add(control.name);
+      const legend = control.closest("fieldset")?.querySelector("legend");
+      if (legend) label = legend.textContent.trim().replace(/:$/, "");
+    }
+    missing.push({ target: control, label });
   });
 
   return missing;
@@ -118,7 +132,9 @@ function clearSummary(summary) {
 function focusTarget(target) {
   const control =
     target.tagName === "FIELDSET"
-      ? target.querySelector("input:not(:disabled), select, textarea")
+      ? target.querySelector(
+          "input:not(:disabled), select:not(:disabled), textarea:not(:disabled)",
+        )
       : target;
   if (!control) return;
   control.focus();
@@ -170,13 +186,11 @@ function renderSummary(summary, missing) {
 export function initRequiredFieldGate(form) {
   destroyRequiredFieldGate(form);
 
-  const button = form.querySelector('button[type="submit"]');
+  // Spec §5's opt-in checklist promises either marker resolves the button.
+  const button = form.querySelector('.js-submit-button, button[type="submit"]');
   const summary = form.querySelector("[data-required-summary]");
   if (!button || !summary) return null;
 
-  // Applied here, never in the template: with JS off the visitor keeps a
-  // normal button and full native validation.
-  form.setAttribute("novalidate", "");
   if (summary.id) button.setAttribute("aria-describedby", summary.id);
 
   const refresh = () => {
@@ -210,6 +224,13 @@ export function initRequiredFieldGate(form) {
   window.addEventListener("pageshow", onInteraction);
 
   refresh();
+  // Applied only after a successful first refresh, and never in the
+  // template: if findUnanswered() ever threw here, novalidate must not
+  // already be set, or the submit listener's own refresh() call would throw
+  // before reaching preventDefault() while nothing else validates the form.
+  // Fail closed — native `required` validation stays the floor until the
+  // gate proves it can compute validity at least once.
+  form.setAttribute("novalidate", "");
 
   const handle = {
     refresh,

--- a/static/js/src/utils/required-field-gate.js
+++ b/static/js/src/utils/required-field-gate.js
@@ -104,3 +104,128 @@ export function findUnanswered(form) {
 export function isComplete(form) {
   return findUnanswered(form).length === 0;
 }
+
+const GATE_KEY = "__requiredFieldGate";
+const GATED_CLASS = "is-disabled";
+const SUMMARY_CLASS = "p-notification--caution";
+
+function clearSummary(summary) {
+  summary.textContent = "";
+  summary.classList.remove(SUMMARY_CLASS);
+}
+
+/** Focus the control a summary entry points at, or a question's first box. */
+function focusTarget(target) {
+  const control =
+    target.tagName === "FIELDSET"
+      ? target.querySelector("input:not(:disabled), select, textarea")
+      : target;
+  if (!control) return;
+  control.focus();
+  control.scrollIntoView({ block: "center" });
+}
+
+function renderSummary(summary, missing) {
+  clearSummary(summary);
+  summary.classList.add(SUMMARY_CLASS);
+
+  const heading = document.createElement("h3");
+  heading.className = "p-heading--5";
+  heading.setAttribute("tabindex", "-1");
+  heading.textContent = `${missing.length} answer${
+    missing.length === 1 ? "" : "s"
+  } still needed`;
+
+  const list = document.createElement("ul");
+  list.className = "p-list";
+  missing.forEach(({ target, label }) => {
+    const item = document.createElement("li");
+    item.className = "p-list__item";
+    const link = document.createElement("a");
+    link.href = "#";
+    link.textContent = label;
+    link.addEventListener("click", (event) => {
+      event.preventDefault();
+      focusTarget(target);
+    });
+    item.appendChild(link);
+    list.appendChild(item);
+  });
+
+  summary.appendChild(heading);
+  summary.appendChild(list);
+  return heading;
+}
+
+/**
+ * Gate a form's submit button until every required question has an answer.
+ * Idempotent — re-initialising tears down the previous handle first, which the
+ * modal path needs because initialiseForm() runs on every open.
+ */
+export function initRequiredFieldGate(form) {
+  destroyRequiredFieldGate(form);
+
+  const button = form.querySelector('button[type="submit"]');
+  const summary = form.querySelector("[data-required-summary]");
+  if (!button || !summary) return null;
+
+  // Applied here, never in the template: with JS off the visitor keeps a
+  // normal button and full native validation.
+  form.setAttribute("novalidate", "");
+  if (summary.id) button.setAttribute("aria-describedby", summary.id);
+
+  const refresh = () => {
+    const missing = findUnanswered(form);
+    if (missing.length) {
+      button.setAttribute("aria-disabled", "true");
+      button.classList.add(GATED_CLASS);
+    } else {
+      button.removeAttribute("aria-disabled");
+      button.classList.remove(GATED_CLASS);
+      clearSummary(summary);
+    }
+    return missing;
+  };
+
+  const onSubmit = (event) => {
+    const missing = refresh();
+    if (!missing.length) return;
+    event.preventDefault();
+    // Without this the spinner and consent listeners fire on a submission
+    // that never happens, and the button sticks on a spinner forever.
+    event.stopImmediatePropagation();
+    renderSummary(summary, missing).focus();
+  };
+
+  const onInteraction = () => refresh();
+
+  form.addEventListener("submit", onSubmit);
+  form.addEventListener("input", onInteraction);
+  form.addEventListener("change", onInteraction);
+  window.addEventListener("pageshow", onInteraction);
+
+  refresh();
+
+  const handle = {
+    refresh,
+    destroy() {
+      form.removeEventListener("submit", onSubmit);
+      form.removeEventListener("input", onInteraction);
+      form.removeEventListener("change", onInteraction);
+      window.removeEventListener("pageshow", onInteraction);
+      form.removeAttribute("novalidate");
+      button.removeAttribute("aria-disabled");
+      button.removeAttribute("aria-describedby");
+      button.classList.remove(GATED_CLASS);
+      clearSummary(summary);
+      delete form[GATE_KEY];
+    },
+  };
+
+  form[GATE_KEY] = handle;
+  return handle;
+}
+
+export function destroyRequiredFieldGate(form) {
+  if (form && form[GATE_KEY]) form[GATE_KEY].destroy();
+}

--- a/static/js/src/utils/required-field-gate.js
+++ b/static/js/src/utils/required-field-gate.js
@@ -1,0 +1,87 @@
+/**
+ * Required-field submit gating for generated Marketo forms.
+ *
+ * The button is gated with aria-disabled, never the disabled attribute, so it
+ * stays focusable, stays in the tab order, and can explain what is missing
+ * when pressed. See .scratch/form-required-field-gating/spec.md.
+ */
+
+const QUESTION_SELECTOR = "fieldset[data-required-question]";
+
+/**
+ * The visible question text for a required fieldset.
+ * _form-fields.html renders a screen-reader-only legend first and the visible
+ * one second, so prefer the visible one by class and fall back to any legend.
+ */
+function questionLabel(fieldset) {
+  const legend =
+    fieldset.querySelector("legend.js-formfield-title") ||
+    fieldset.querySelector("legend");
+  return legend ? legend.textContent.trim().replace(/:$/, "") : "This question";
+}
+
+/**
+ * The human-readable name of an individual control, taken from the label the
+ * form already renders. Nothing here is authored per form.
+ */
+function controlLabel(control) {
+  if (control.id) {
+    const label = control
+      .closest("form")
+      ?.querySelector(`label[for="${CSS.escape(control.id)}"]`);
+    if (label) return label.textContent.trim().replace(/:$/, "");
+  }
+  const wrapping = control.closest("label");
+  if (wrapping) return wrapping.textContent.trim().replace(/:$/, "");
+  return control.getAttribute("aria-label") || control.name || "This field";
+}
+
+function isEligible(control) {
+  return !control.disabled && control.type !== "hidden";
+}
+
+/**
+ * A required question is answered when at least one enabled box is ticked.
+ * HTML cannot express "at least one of this group", which is why this clause
+ * exists at all — form.checkValidity() is blind to it.
+ *
+ * Questions whose answer slot is a radio group, textarea or select carry
+ * native `required`, so they fall through to constraint validation.
+ */
+function isQuestionAnswered(fieldset) {
+  const checkboxes = fieldset.querySelectorAll('input[type="checkbox"]');
+  if (checkboxes.length) {
+    return Array.from(checkboxes).some((box) => box.checked && !box.disabled);
+  }
+  return Array.from(fieldset.querySelectorAll("input, select, textarea"))
+    .filter(isEligible)
+    .every((control) => !control.willValidate || control.checkValidity());
+}
+
+/**
+ * Every unanswered required question and unsatisfied required control.
+ * Questions come first, then individual controls, each in document order.
+ */
+export function findUnanswered(form) {
+  const missing = [];
+
+  form.querySelectorAll(QUESTION_SELECTOR).forEach((fieldset) => {
+    if (!isQuestionAnswered(fieldset)) {
+      missing.push({ target: fieldset, label: questionLabel(fieldset) });
+    }
+  });
+
+  form.querySelectorAll("input, select, textarea").forEach((control) => {
+    if (!isEligible(control)) return;
+    if (!control.willValidate || control.checkValidity()) return;
+    // Controls inside a required question are reported as that question.
+    if (control.closest(QUESTION_SELECTOR)) return;
+    missing.push({ target: control, label: controlLabel(control) });
+  });
+
+  return missing;
+}
+
+export function isComplete(form) {
+  return findUnanswered(form).length === 0;
+}

--- a/static/js/src/utils/required-field-gate.js
+++ b/static/js/src/utils/required-field-gate.js
@@ -41,21 +41,40 @@ function isEligible(control) {
 }
 
 /**
- * A required question is answered when at least one enabled box is ticked.
- * HTML cannot express "at least one of this group", which is why this clause
- * exists at all — form.checkValidity() is blind to it.
- *
- * Questions whose answer slot is a radio group, textarea or select carry
- * native `required`, so they fall through to constraint validation.
+ * Whether a single control's own answer satisfies constraint validation.
+ * Controls that never validate (e.g. checkboxes, which have no per-box
+ * `required`) are vacuously valid here — checkbox groups are judged as a
+ * group by isQuestionAnswered instead.
+ */
+function isValid(control) {
+  return !control.willValidate || control.checkValidity();
+}
+
+/**
+ * A required question is answered when every part of it is answered:
+ * at least one enabled checkbox is ticked (HTML cannot express "at least
+ * one of this group", which is why this clause exists at all —
+ * form.checkValidity() is blind to it) AND every other eligible control in
+ * the fieldset (radio group, textarea, select — anything that carries
+ * native `required`) passes constraint validation. A fieldset with no
+ * checkboxes is judged purely on the latter; a fieldset with no other
+ * controls is judged purely on the former — the `every`/vacuous-true clause
+ * keeps both cases correct without a branch.
  */
 function isQuestionAnswered(fieldset) {
   const checkboxes = fieldset.querySelectorAll('input[type="checkbox"]');
-  if (checkboxes.length) {
-    return Array.from(checkboxes).some((box) => box.checked && !box.disabled);
-  }
-  return Array.from(fieldset.querySelectorAll("input, select, textarea"))
+  const checkboxAnswered =
+    !checkboxes.length ||
+    Array.from(checkboxes).some((box) => box.checked && !box.disabled);
+
+  const othersAnswered = Array.from(
+    fieldset.querySelectorAll("input, select, textarea"),
+  )
+    .filter((control) => control.type !== "checkbox")
     .filter(isEligible)
-    .every((control) => !control.willValidate || control.checkValidity());
+    .every(isValid);
+
+  return checkboxAnswered && othersAnswered;
 }
 
 /**
@@ -73,7 +92,7 @@ export function findUnanswered(form) {
 
   form.querySelectorAll("input, select, textarea").forEach((control) => {
     if (!isEligible(control)) return;
-    if (!control.willValidate || control.checkValidity()) return;
+    if (isValid(control)) return;
     // Controls inside a required question are reported as that question.
     if (control.closest(QUESTION_SELECTOR)) return;
     missing.push({ target: control, label: controlLabel(control) });

--- a/static/js/src/utils/required-field-gate.js
+++ b/static/js/src/utils/required-field-gate.js
@@ -129,7 +129,12 @@ function renderSummary(summary, missing) {
   clearSummary(summary);
   summary.classList.add(SUMMARY_CLASS);
 
-  const heading = document.createElement("h3");
+  // h2, not h3: axe's heading-order rule caught this summary being the
+  // first heading-level element after the page's own h1 (fieldset legends
+  // and .js-formfield-title labels are not headings), which skipped a
+  // level. h2 keeps the hierarchy valid without a visual change — the
+  // class, not the tag, carries the size.
+  const heading = document.createElement("h2");
   heading.className = "p-heading--5";
   heading.setAttribute("tabindex", "-1");
   heading.textContent = `${missing.length} answer${

--- a/static/js/src/utils/required-field-gate.test.js
+++ b/static/js/src/utils/required-field-gate.test.js
@@ -31,6 +31,13 @@ const RADIO_QUESTION = `
     <label class="p-radio"><input required class="p-radio__input" type="radio" id="many" name="_radio_how-many-devices" value="11+" /><span>11+</span></label>
   </fieldset>`;
 
+const MIXED_QUESTION = `
+  <fieldset data-required-question id="mixed-field">
+    <legend class="p-heading--4 js-formfield-title is-required">Tell us about your setup</legend>
+    <label class="p-checkbox"><input class="p-checkbox__input" type="checkbox" id="mixed-desktop" value="Desktop" /><span>Desktop</span></label>
+    <textarea required aria-label="Tell us about your setup" id="mixed-details" rows="5"></textarea>
+  </fieldset>`;
+
 describe("findUnanswered", () => {
   it("reports an empty required text field by its label", () => {
     const form = buildForm(REQUIRED_TEXT);
@@ -111,6 +118,19 @@ describe("findUnanswered", () => {
     const form = buildForm(`
       <input type="hidden" name="formid" value="9998" required />
       <input type="text" id="off" name="off" required disabled />`);
+    expect(findUnanswered(form)).toHaveLength(0);
+  });
+
+  it("does not count a checkbox tick as answering a required textarea beside it", () => {
+    const form = buildForm(MIXED_QUESTION);
+    form.querySelector("#mixed-desktop").checked = true;
+    expect(findUnanswered(form)).toHaveLength(1);
+  });
+
+  it("accepts a mixed question only when both parts are answered", () => {
+    const form = buildForm(MIXED_QUESTION);
+    form.querySelector("#mixed-desktop").checked = true;
+    form.querySelector("#mixed-details").value = "Two laptops and a server.";
     expect(findUnanswered(form)).toHaveLength(0);
   });
 });

--- a/static/js/src/utils/required-field-gate.test.js
+++ b/static/js/src/utils/required-field-gate.test.js
@@ -36,6 +36,18 @@ const RADIO_QUESTION = `
     <label class="p-radio"><input required class="p-radio__input" type="radio" id="many" name="_radio_how-many-devices" value="11+" /><span>11+</span></label>
   </fieldset>`;
 
+// A hand-written form that forgot data-required-question on a required radio
+// fieldset — the exact defect found in _default-contact-us-form.html. No
+// question marker, so the fieldset never reaches isQuestionAnswered(); the
+// module's second loop, which walks individual controls, must still collapse
+// the group to one entry rather than reporting once per radio.
+const UNMARKED_RADIO_QUESTION = `
+  <fieldset id="how-many-machines">
+    <legend class="p-heading--2 js-formfield-title is-required">How many machines?</legend>
+    <label class="p-radio"><input required class="p-radio__input" type="radio" id="few-machines" name="_radio_how-many-machines" value="less than 5" /><span>&lt; 5 machines</span></label>
+    <label class="p-radio"><input class="p-radio__input" type="radio" id="many-machines" name="_radio_how-many-machines" value="5-15 machines" /><span>5-15 machines</span></label>
+  </fieldset>`;
+
 const MIXED_QUESTION = `
   <fieldset data-required-question id="mixed-field">
     <legend class="p-heading--4 js-formfield-title is-required">Tell us about your setup</legend>
@@ -108,6 +120,17 @@ describe("findUnanswered", () => {
     const form = buildForm(RADIO_QUESTION);
     form.querySelector("#many").checked = true;
     expect(findUnanswered(form)).toHaveLength(0);
+  });
+
+  it("reports an unmarked required radio group once, by its fieldset legend", () => {
+    // Regression test: before the fix this reported one entry per radio
+    // (five, in the real-world form), each labelled from its own option
+    // text instead of the question, because the fieldset carries no
+    // data-required-question marker for isQuestionAnswered() to key off.
+    const form = buildForm(UNMARKED_RADIO_QUESTION);
+    const missing = findUnanswered(form);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].label).toBe("How many machines?");
   });
 
   it("lists every miss across a mixed form", () => {

--- a/static/js/src/utils/required-field-gate.test.js
+++ b/static/js/src/utils/required-field-gate.test.js
@@ -241,7 +241,7 @@ describe("initRequiredFieldGate", () => {
     const form = buildForm(REQUIRED_TEXT);
     initRequiredFieldGate(form);
     submit(form);
-    const heading = form.querySelector("[data-required-summary] h3");
+    const heading = form.querySelector("[data-required-summary] h2");
     expect(heading.getAttribute("tabindex")).toBe("-1");
     expect(document.activeElement).toBe(heading);
   });
@@ -282,7 +282,7 @@ describe("initRequiredFieldGate", () => {
     submit(form);
     expect(spinner).not.toHaveBeenCalled();
     // One summary, not two.
-    expect(form.querySelectorAll("[data-required-summary] h3")).toHaveLength(1);
+    expect(form.querySelectorAll("[data-required-summary] h2")).toHaveLength(1);
   });
 
   it("destroy removes every trace of the gate", () => {

--- a/static/js/src/utils/required-field-gate.test.js
+++ b/static/js/src/utils/required-field-gate.test.js
@@ -1,0 +1,116 @@
+import { findUnanswered, isComplete } from "./required-field-gate.js";
+
+function buildForm(innerHTML) {
+  document.body.innerHTML = `<form data-required-gate>${innerHTML}
+    <div id="required-field-summary-1" data-required-summary role="alert"></div>
+    <button type="submit" class="js-submit-button">Submit</button>
+  </form>`;
+  return document.querySelector("form");
+}
+
+const REQUIRED_TEXT = `
+  <label class="is-required" for="company">Company:</label>
+  <input required id="company" name="company" type="text" />`;
+
+const REQUIRED_EMAIL = `
+  <label class="is-required" for="email">Email:</label>
+  <input required id="email" name="email" type="email"
+         pattern="^[^ ]+@[^ ]+\\.[a-z]{2,26}$" />`;
+
+const CHECKBOX_QUESTION = `
+  <fieldset data-required-question id="kind-of-device-field">
+    <legend class="p-heading--4 js-formfield-title is-required">What kind of device are you using?</legend>
+    <label class="p-checkbox"><input class="p-checkbox__input" type="checkbox" id="desktop" value="Desktop" /><span>Desktop</span></label>
+    <label class="p-checkbox"><input class="p-checkbox__input" type="checkbox" id="server" value="Server" /><span>Server</span></label>
+  </fieldset>`;
+
+const RADIO_QUESTION = `
+  <fieldset data-required-question id="how-many-devices-field">
+    <legend class="p-heading--4 js-formfield-title is-required">How many devices?</legend>
+    <label class="p-radio"><input required class="p-radio__input" type="radio" id="few" name="_radio_how-many-devices" value="1-10" /><span>1-10</span></label>
+    <label class="p-radio"><input required class="p-radio__input" type="radio" id="many" name="_radio_how-many-devices" value="11+" /><span>11+</span></label>
+  </fieldset>`;
+
+describe("findUnanswered", () => {
+  it("reports an empty required text field by its label", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    const missing = findUnanswered(form);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].label).toBe("Company");
+    expect(missing[0].target.id).toBe("company");
+  });
+
+  it("stops reporting a required text field once it has a value", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    form.querySelector("#company").value = "Canonical";
+    expect(findUnanswered(form)).toHaveLength(0);
+    expect(isComplete(form)).toBe(true);
+  });
+
+  it("treats a filled-but-malformed email as unanswered", () => {
+    const form = buildForm(REQUIRED_EMAIL);
+    form.querySelector("#email").value = "benjo@";
+    // The spec chose full validity over emptiness: a typo keeps the gate shut.
+    expect(findUnanswered(form)).toHaveLength(1);
+    expect(findUnanswered(form)[0].label).toBe("Email");
+  });
+
+  it("accepts a well-formed email", () => {
+    const form = buildForm(REQUIRED_EMAIL);
+    form.querySelector("#email").value = "benjo@canonical.com";
+    expect(findUnanswered(form)).toHaveLength(0);
+  });
+
+  it("reports an unanswered checkbox question once, by its legend", () => {
+    const form = buildForm(CHECKBOX_QUESTION);
+    const missing = findUnanswered(form);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].label).toBe("What kind of device are you using?");
+    expect(missing[0].target.id).toBe("kind-of-device-field");
+  });
+
+  it("accepts a checkbox question with any one box ticked", () => {
+    const form = buildForm(CHECKBOX_QUESTION);
+    form.querySelector("#server").checked = true;
+    expect(findUnanswered(form)).toHaveLength(0);
+  });
+
+  it("ignores checked boxes that have been disabled", () => {
+    // toggleCheckboxVisibility disables boxes in response to other boxes, and
+    // disabled controls are exempt from constraint validation.
+    const form = buildForm(CHECKBOX_QUESTION);
+    const server = form.querySelector("#server");
+    server.checked = true;
+    server.disabled = true;
+    expect(findUnanswered(form)).toHaveLength(1);
+  });
+
+  it("reports a radio group once, by its legend, not once per radio", () => {
+    const form = buildForm(RADIO_QUESTION);
+    const missing = findUnanswered(form);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].label).toBe("How many devices?");
+  });
+
+  it("accepts a radio group with a selection", () => {
+    const form = buildForm(RADIO_QUESTION);
+    form.querySelector("#many").checked = true;
+    expect(findUnanswered(form)).toHaveLength(0);
+  });
+
+  it("lists every miss across a mixed form", () => {
+    const form = buildForm(REQUIRED_TEXT + CHECKBOX_QUESTION + RADIO_QUESTION);
+    expect(findUnanswered(form).map((m) => m.label)).toEqual([
+      "What kind of device are you using?",
+      "How many devices?",
+      "Company",
+    ]);
+  });
+
+  it("ignores hidden and disabled controls", () => {
+    const form = buildForm(`
+      <input type="hidden" name="formid" value="9998" required />
+      <input type="text" id="off" name="off" required disabled />`);
+    expect(findUnanswered(form)).toHaveLength(0);
+  });
+});

--- a/static/js/src/utils/required-field-gate.test.js
+++ b/static/js/src/utils/required-field-gate.test.js
@@ -1,4 +1,9 @@
-import { findUnanswered, isComplete } from "./required-field-gate.js";
+import {
+  findUnanswered,
+  isComplete,
+  initRequiredFieldGate,
+  destroyRequiredFieldGate,
+} from "./required-field-gate.js";
 
 function buildForm(innerHTML) {
   document.body.innerHTML = `<form data-required-gate>${innerHTML}
@@ -132,5 +137,192 @@ describe("findUnanswered", () => {
     form.querySelector("#mixed-desktop").checked = true;
     form.querySelector("#mixed-details").value = "Two laptops and a server.";
     expect(findUnanswered(form)).toHaveLength(0);
+  });
+});
+
+function submit(form) {
+  return form.dispatchEvent(
+    new Event("submit", { bubbles: true, cancelable: true }),
+  );
+}
+
+describe("initRequiredFieldGate", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("gates an untouched form on initialisation", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    const button = form.querySelector("button[type=submit]");
+    expect(button.getAttribute("aria-disabled")).toBe("true");
+    expect(button.classList.contains("is-disabled")).toBe(true);
+    // Never the disabled attribute — the button must stay focusable.
+    expect(button.disabled).toBe(false);
+  });
+
+  it("applies novalidate so the gate owns all validation feedback", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    expect(form.hasAttribute("novalidate")).toBe(true);
+  });
+
+  it("points the button at the summary with aria-describedby", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    expect(
+      form
+        .querySelector("button[type=submit]")
+        .getAttribute("aria-describedby"),
+    ).toBe("required-field-summary-1");
+  });
+
+  it("un-gates when the last required answer arrives", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    const input = form.querySelector("#company");
+    input.value = "Canonical";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const button = form.querySelector("button[type=submit]");
+    expect(button.hasAttribute("aria-disabled")).toBe(false);
+    expect(button.classList.contains("is-disabled")).toBe(false);
+  });
+
+  it("re-gates when a required answer is cleared", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    const input = form.querySelector("#company");
+    input.value = "Canonical";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.value = "";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(
+      form.querySelector("button[type=submit]").getAttribute("aria-disabled"),
+    ).toBe("true");
+  });
+
+  it("un-gates on a checkbox question via the change event", () => {
+    const form = buildForm(CHECKBOX_QUESTION);
+    initRequiredFieldGate(form);
+    const box = form.querySelector("#server");
+    box.checked = true;
+    box.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(
+      form.querySelector("button[type=submit]").hasAttribute("aria-disabled"),
+    ).toBe(false);
+  });
+
+  it("blocks a gated submit and renders the summary", () => {
+    const form = buildForm(REQUIRED_TEXT + CHECKBOX_QUESTION);
+    initRequiredFieldGate(form);
+
+    const notCancelled = submit(form);
+    expect(notCancelled).toBe(false);
+
+    const summary = form.querySelector("[data-required-summary]");
+    expect(summary.textContent).toContain("2 answers still needed");
+    expect(summary.textContent).toContain("What kind of device are you using?");
+    expect(summary.textContent).toContain("Company");
+    expect(summary.classList.contains("p-notification--caution")).toBe(true);
+  });
+
+  it("singularises the summary heading for a single miss", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    submit(form);
+    expect(form.querySelector("[data-required-summary]").textContent).toContain(
+      "1 answer still needed",
+    );
+  });
+
+  it("moves focus to the summary heading on a blocked submit", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    submit(form);
+    const heading = form.querySelector("[data-required-summary] h3");
+    expect(heading.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(heading);
+  });
+
+  it("stops other submit listeners from running on a blocked submit", () => {
+    // Without stopImmediatePropagation the spinner listener fires and the
+    // button sticks showing a spinner for a submission that never happened.
+    const form = buildForm(REQUIRED_TEXT);
+    const spinner = jest.fn();
+    initRequiredFieldGate(form);
+    form.addEventListener("submit", spinner);
+    submit(form);
+    expect(spinner).not.toHaveBeenCalled();
+  });
+
+  it("lets a complete form submit and clears the summary", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    submit(form); // populate the summary first
+    expect(
+      form.querySelector("[data-required-summary]"),
+    ).not.toBeEmptyDOMElement();
+
+    const input = form.querySelector("#company");
+    input.value = "Canonical";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(form.querySelector("[data-required-summary]")).toBeEmptyDOMElement();
+    expect(submit(form)).toBe(true);
+  });
+
+  it("is idempotent — re-initialising does not double-bind", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    initRequiredFieldGate(form);
+    const spinner = jest.fn();
+    form.addEventListener("submit", spinner);
+    submit(form);
+    expect(spinner).not.toHaveBeenCalled();
+    // One summary, not two.
+    expect(form.querySelectorAll("[data-required-summary] h3")).toHaveLength(1);
+  });
+
+  it("destroy removes every trace of the gate", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    const gate = initRequiredFieldGate(form);
+    gate.destroy();
+
+    const button = form.querySelector("button[type=submit]");
+    expect(button.hasAttribute("aria-disabled")).toBe(false);
+    expect(button.classList.contains("is-disabled")).toBe(false);
+    expect(form.hasAttribute("novalidate")).toBe(false);
+    expect(form.querySelector("[data-required-summary]")).toBeEmptyDOMElement();
+    // And the submit listener is gone.
+    expect(submit(form)).toBe(true);
+  });
+
+  it("recomputes on pageshow so bfcache restores land gated correctly", () => {
+    // static-forms.js resets the spinner on a persisted pageshow; the gate
+    // recomputes independently rather than trusting a captured button state.
+    const form = buildForm(REQUIRED_TEXT);
+    initRequiredFieldGate(form);
+    const button = form.querySelector("button[type=submit]");
+
+    form.querySelector("#company").value = "Canonical";
+    window.dispatchEvent(new Event("pageshow"));
+    expect(button.hasAttribute("aria-disabled")).toBe(false);
+
+    form.querySelector("#company").value = "";
+    window.dispatchEvent(new Event("pageshow"));
+    expect(button.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("destroyRequiredFieldGate is safe on an ungated form", () => {
+    const form = buildForm(REQUIRED_TEXT);
+    expect(() => destroyRequiredFieldGate(form)).not.toThrow();
+  });
+
+  it("returns null when the form has no summary container", () => {
+    document.body.innerHTML = `<form data-required-gate>${REQUIRED_TEXT}
+      <button type="submit">Submit</button></form>`;
+    expect(initRequiredFieldGate(document.querySelector("form"))).toBeNull();
   });
 });

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -10,7 +10,7 @@
 </section>
 
 <section class="p-section">
-  <form action="/marketo/submit" method="post" id="mktoForm_{{ formid }}">
+  <form action="/marketo/submit" method="post" data-required-gate id="mktoForm_{{ formid }}">
     <div class="p-section">
       <hr class="p-rule is-fixed-width" />
       <div class="row--50-50 js-formfield">
@@ -121,7 +121,8 @@
     </div>
     <div class="p-section">
       <hr class="p-rule is-fixed-width" />
-      <fieldset class="p-fieldset-section js-formfield js-required-checkbox"
+      <fieldset class="p-fieldset-section js-formfield"
+                data-required-question
                 aria-required="true"
                 aria-labelledby="kind-of-device-legend">
         <div class="row--50-50">
@@ -488,6 +489,11 @@
                        tabindex="-1" />
               </li>
               {# End of honey pots #}
+              <li class="p-list__item">
+                <div id="required-field-summary-{{ formid }}"
+                     data-required-summary
+                     role="alert"></div>
+              </li>
               <li class="p-list__item">
                 <button type="submit" class="p-button--positive js-submit-button">Submit</button>
               </li>

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -173,6 +173,7 @@
     <div class="p-section">
       <hr class="p-rule is-fixed-width" />
       <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
+                data-required-question
                 aria-labelledby="how-many-machines-legend"
                 aria-required="true"
                 id="how-many-machines">

--- a/templates/shared/forms/_form-fields.html
+++ b/templates/shared/forms/_form-fields.html
@@ -33,42 +33,52 @@
             <div class="col">
               <ul class="p-list">
                 {% if fieldset_id == "about-you" %}
-                  <label class="is-required" for="firstName">First name:</label>
-                  <input required
-                         id="firstName"
-                         name="firstName"
-                         maxlength="255"
-                         autocomplete="given-name"
-                         type="text" />
-                  <label class="is-required" for="lastName">Last name:</label>
-                  <input required
-                         id="lastName"
-                         name="lastName"
-                         maxlength="255"
-                         autocomplete="family-name"
-                         type="text" />
-                  <label class="is-required" for="email">Email:</label>
-                  <input required
-                         id="email"
-                         name="email"
-                         maxlength="255"
-                         autocomplete="email"
-                         type="email"
-                         pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-                  <label class="is-required" for="company">Company:</label>
-                  <input required
-                         id="company"
-                         name="company"
-                         maxlength="255"
-                         autocomplete="organization"
-                         type="text" />
-                  <label class="is-required" for="title">Job Title:</label>
-                  <input required
-                         id="title"
-                         name="title"
-                         maxlength="255"
-                         autocomplete="organization-title"
-                         type="text" />
+                  <li class="p-list__item">
+                    <label class="is-required" for="firstName">First name:</label>
+                    <input required
+                           id="firstName"
+                           name="firstName"
+                           maxlength="255"
+                           autocomplete="given-name"
+                           type="text" />
+                  </li>
+                  <li class="p-list__item">
+                    <label class="is-required" for="lastName">Last name:</label>
+                    <input required
+                           id="lastName"
+                           name="lastName"
+                           maxlength="255"
+                           autocomplete="family-name"
+                           type="text" />
+                  </li>
+                  <li class="p-list__item">
+                    <label class="is-required" for="email">Email:</label>
+                    <input required
+                           id="email"
+                           name="email"
+                           maxlength="255"
+                           autocomplete="email"
+                           type="email"
+                           pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+                  </li>
+                  <li class="p-list__item">
+                    <label class="is-required" for="company">Company:</label>
+                    <input required
+                           id="company"
+                           name="company"
+                           maxlength="255"
+                           autocomplete="organization"
+                           type="text" />
+                  </li>
+                  <li class="p-list__item">
+                    <label class="is-required" for="title">Job Title:</label>
+                    <input required
+                           id="title"
+                           name="title"
+                           maxlength="255"
+                           autocomplete="organization-title"
+                           type="text" />
+                  </li>
 
                   {% with required = true %}
                     {% include "shared/forms/_country.html" %}
@@ -222,7 +232,12 @@
         </ul>
         <div class="u-off-screen">
           <label for="Comments_from_lead__c">
-            <h3 class="p-heading--4">Your comments</h3>
+            <!-- h2, not h3: this is the first heading after the page's h1
+                 (fieldset legends and .js-formfield-title labels above are
+                 not headings), so h3 here skipped a level. Axe's
+                 heading-order rule caught it; off-screen only, so the
+                 level change has no visual effect. -->
+            <h2 class="p-heading--4">Your comments</h2>
             <textarea id="Comments_from_lead__c"
                       name="Comments_from_lead__c"
                       rows="5"

--- a/templates/shared/forms/_form-fields.html
+++ b/templates/shared/forms/_form-fields.html
@@ -2,6 +2,7 @@
   <form {% if isModal %}class="js-modal-form"{% endif %}
         action="/marketo/submit"
         method="post"
+        data-required-gate
         id="mktoForm_{{ form_id }}">
     {% for fieldset in fieldsets %}
 
@@ -19,7 +20,8 @@
 
       <div class="{% if loop.index != fieldsets|length %}p-section{% endif %}">
         <hr class="p-rule is-fixed-width" />
-        <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox' or fieldset.inputType == 'checkbox-visibility' %} js-remove-checkbox-names{% if fieldset.isRequired %} js-required-checkbox{% endif %}{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% endif %}{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
+        <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox' or fieldset.inputType == 'checkbox-visibility' %} js-remove-checkbox-names{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% endif %}{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
+                  {% if fieldset.isRequired %}data-required-question{% endif %}
                   {% if fieldset.id %}id="{{ fieldset.id }}-field" aria-labelledby="{{ fieldset.id }}-legend"{% endif %}>
           <!-- This legend is for screen readers only, to fix a11y warning -->
           <legend class="u-hide">{{ fieldset.title }}</legend>
@@ -152,7 +154,7 @@
                         {% endfor %}
                       </div>
                     {% elif field.type == "select" %}
-                      <label {% if fieldset.isRequired %}class="is-required"{% endif %}
+                      <label {% if field.isRequired %}class="is-required"{% endif %}
                              for="{{ field_id }}">{{ field.label }}:</label>
                       <select id="{{ field_id }}" {% if field.isRequired %}required{% endif %}>
                         {% for option in field.options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}
@@ -209,6 +211,11 @@
                    tabindex="-1" />
           </li>
           {# End of honey pots #}
+          <li class="p-list__item">
+            <div id="required-field-summary-{{ form_id }}"
+                 data-required-summary
+                 role="alert"></div>
+          </li>
           <li class="p-list__item">
             <button type="submit" class="p-button--positive js-submit-button">Submit</button>
           </li>

--- a/templates/tests/_inline-form-generator.html
+++ b/templates/tests/_inline-form-generator.html
@@ -1,0 +1,21 @@
+{% extends "base_index.html" %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+{% block title %}Inline form generator test{% endblock %}
+
+{% block content %}
+  <section class="p-strip">
+    <div class="p-section--shallow">
+      <div class="row">
+        <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
+          <h1>Form generator - inline test</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {{ load_form("/tests/_inline-form-generator") | safe }}
+
+{% endblock content %}

--- a/templates/tests/_two-form-generator.html
+++ b/templates/tests/_two-form-generator.html
@@ -1,0 +1,27 @@
+{% extends "base_index.html" %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+{% block title %}Two form generator test{% endblock %}
+
+{% block content %}
+  <section class="p-strip">
+    <div class="p-section--shallow">
+      <div class="row">
+        <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
+          <h1>Form generator - two forms on one page</h1>
+          <p>
+            <a href="/contact-us"
+               aria-controls="contact-modal"
+               class="js-invoke-modal p-button">Contact us button</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {{ load_form("/tests/_inline-form-generator") | safe }}
+  {{ load_form("/tests/_form-generator") | safe }}
+
+{% endblock content %}

--- a/templates/tests/form-data.json
+++ b/templates/tests/form-data.json
@@ -47,6 +47,25 @@
               ]
             },
             {
+              "type": "select",
+              "id": "required-details-referral",
+              "label": "How did you hear about us",
+              "options": [
+                {
+                  "value": "",
+                  "label": "Please select"
+                },
+                {
+                  "value": "search",
+                  "label": "Search"
+                },
+                {
+                  "value": "event",
+                  "label": "Event"
+                }
+              ]
+            },
+            {
               "type": "long-text",
               "id": "required-details-summary",
               "label": "Summary",
@@ -293,6 +312,25 @@
                 {
                   "value": "11-50",
                   "label": "11-50"
+                }
+              ]
+            },
+            {
+              "type": "select",
+              "id": "required-details-referral",
+              "label": "How did you hear about us",
+              "options": [
+                {
+                  "value": "",
+                  "label": "Please select"
+                },
+                {
+                  "value": "search",
+                  "label": "Search"
+                },
+                {
+                  "value": "event",
+                  "label": "Event"
                 }
               ]
             },

--- a/templates/tests/form-data.json
+++ b/templates/tests/form-data.json
@@ -16,6 +16,295 @@
       },
       "fieldsets": [
         {
+          "title": "Tell us about the work",
+          "id": "required-details",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "text",
+              "id": "required-details-project-name",
+              "label": "Project name",
+              "isRequired": true
+            },
+            {
+              "type": "select",
+              "id": "required-details-team-size",
+              "label": "Team size",
+              "isRequired": true,
+              "options": [
+                {
+                  "value": "",
+                  "label": "Please select"
+                },
+                {
+                  "value": "1-10",
+                  "label": "1-10"
+                },
+                {
+                  "value": "11-50",
+                  "label": "11-50"
+                }
+              ]
+            },
+            {
+              "type": "long-text",
+              "id": "required-details-summary",
+              "label": "Summary",
+              "placeholder": "What are you building?"
+            }
+          ]
+        },
+        {
+          "title": "Tell us about your project",
+          "id": "about-your-project",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-your-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "If you use Ubuntu, which version(s) are you using?",
+          "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
+          "fields": [
+            {
+              "fieldTitle": "LTS within standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "24-04",
+                  "value": "24.04 LTS",
+                  "label": "24.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "22-04",
+                  "value": "22.04 LTS",
+                  "label": "22.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "LTS out of standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "18-04",
+                  "value": "18.04 LTS",
+                  "label": "18.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "16-04",
+                  "value": "16.04 LTS",
+                  "label": "16.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "14-04",
+                  "value": "14.04 LTS",
+                  "label": "14.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Outdated or non-LTS releases",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "22-10",
+                  "value": "22.10",
+                  "label": "non-LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "12-04",
+                  "value": "12.04 LTS",
+                  "label": "12.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Other",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "dont-use-ubuntu-today",
+                  "value": "I don't use Ubuntu today",
+                  "label": "I don't use Ubuntu today"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "i-dont-know",
+                  "value": "I don't know",
+                  "label": "I don't know"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "What kind of device are you using?",
+          "id": "kind-of-device",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "desktop-workstation",
+              "value": "Desktop/workstation",
+              "label": "Desktop/workstation"
+            },
+            {
+              "type": "checkbox",
+              "id": "physical-server",
+              "value": "Physical server",
+              "label": "Physical server"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-cloud",
+              "value": "Public cloud",
+              "label": "Public cloud"
+            },
+            {
+              "type": "checkbox",
+              "id": "virtual-machine",
+              "value": "Virtual machine",
+              "label": "Virtual machine"
+            },
+            {
+              "type": "checkbox",
+              "id": "iot-edge-device",
+              "value": "IoT/Edge device",
+              "label": "IoT/Edge device"
+            }
+          ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-devices",
+          "inputName": "how-many-devices-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "other",
+              "value": "Other",
+              "label": "Other",
+              "hasTextarea": true
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        }
+      ]
+    },
+    "/tests/_inline-form-generator": {
+      "templatePath": "/tests/_inline-form-generator.html",
+      "childrenPaths": [],
+      "isModal": false,
+      "formData": {
+        "title": "Contact Canonical",
+        "introText": "Inline harness for required-field submit gating.",
+        "formId": 9998,
+        "returnUrl": "/tests/_thank-you",
+        "lpUrl": "https://pages.ubuntu.com/things-contact-us.html",
+        "product": "",
+        "lpId": 9998
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us about the work",
+          "id": "required-details",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "text",
+              "id": "required-details-project-name",
+              "label": "Project name",
+              "isRequired": true
+            },
+            {
+              "type": "select",
+              "id": "required-details-team-size",
+              "label": "Team size",
+              "isRequired": true,
+              "options": [
+                {
+                  "value": "",
+                  "label": "Please select"
+                },
+                {
+                  "value": "1-10",
+                  "label": "1-10"
+                },
+                {
+                  "value": "11-50",
+                  "label": "11-50"
+                }
+              ]
+            },
+            {
+              "type": "long-text",
+              "id": "required-details-summary",
+              "label": "Summary",
+              "placeholder": "What are you building?"
+            }
+          ]
+        },
+        {
           "title": "Tell us about your project",
           "id": "about-your-project",
           "noCommentsFromLead": true,

--- a/tests/playwright/helpers/commands.ts
+++ b/tests/playwright/helpers/commands.ts
@@ -54,12 +54,14 @@ export const clickRecaptcha = async (page: Page) => {
  * @param testTextFields List of text fields to fill
  * @param testCheckboxFields List of checkbox fields to fill
  * @param testRadioFields List of radio fields to fill
+ * @param testSelectFields List of select fields to fill
  */
 export const fillExistingFields = async (
   page: Page | Locator,
   testTextFields: { field: string; value: string }[],
   testCheckboxFields: { field: string }[],
-  testRadioFields: { field: string }[]
+  testRadioFields: { field: string }[],
+  testSelectFields: { field: string; value: string }[] = []
 ) => {
   for (const { field, value } of testTextFields) {
     if (await isExistingField(page, field)) {
@@ -74,6 +76,11 @@ export const fillExistingFields = async (
   for (const { field } of testRadioFields) {
     if (await isExistingField(page, field)) {
       await page.locator(field).click({ force: true });
+    }
+  }
+  for (const { field, value } of testSelectFields) {
+    if (await isExistingField(page, field)) {
+      await page.locator(field).selectOption(value);
     }
   }
 };

--- a/tests/playwright/helpers/form-fields.ts
+++ b/tests/playwright/helpers/form-fields.ts
@@ -10,6 +10,19 @@ export const formTextFields = [
     value: "Test project description",
   },
   { field: 'textarea[id="advice"]', value: "Test advice" },
+  {
+    field: 'input[id="required-details-project-name"]',
+    value: "Test Project",
+  },
+  {
+    field: 'textarea[id="required-details-summary"]',
+    value: "Test summary",
+  },
+];
+
+// Fields for <select> elements, filled via selectOption rather than fill
+export const formSelectFields = [
+  { field: 'select[id="required-details-team-size"]', value: "1-10" },
 ];
 
 export const formCheckboxFields = [

--- a/tests/playwright/tests/forms/form-generator.spec.ts
+++ b/tests/playwright/tests/forms/form-generator.spec.ts
@@ -71,21 +71,11 @@ test.describe("Modal validation tests", () => {
     await expect(mktoForm).toBeVisible();
   });  
 
-  test("should disable submit button when required checkbox is not checked", async ({ page }) => {
-    // Check that submit button is disabled
-    const modal = page.locator("#contact-modal");
-    const submitButton = modal.getByRole("button", { name: /Submit/ });
-    await expect(submitButton).toBeDisabled();
-  });
-
-  test("should enable submit button when required checkbox is checked", async ({ page }) => {
-    // Check the required checkbox (scoped to modal)
-    const modal = page.locator("#contact-modal");
-    await modal.locator('input[aria-label="physical-server"]').check({ force: true });
-
-    const submitButton = modal.getByRole("button", { name: /Submit/ });
-    await expect(submitButton).toBeEnabled();
-  });
+  // Required-field submit gating coverage (disable-until-answered, then
+  // enable-once-answered) moved to required-field-gate.spec.ts under Task 6,
+  // which asserts against the new aria-disabled-based mechanism. The old
+  // js-required-checkbox/disabled-attribute mechanism these two tests
+  // targeted no longer exists as of Task 2.
 
   test("should fill and redirect to marketo submission endpoint", async ({ page }) => {
     const modal = page.locator("#contact-modal");

--- a/tests/playwright/tests/forms/form-generator.spec.ts
+++ b/tests/playwright/tests/forms/form-generator.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { fillExistingFields, acceptCookiePolicy } from "../../helpers/commands";
-import { formTextFields, modalFormCheckboxFields, modalFormRadioFields } from "../../helpers/form-fields";
+import { formTextFields, modalFormCheckboxFields, modalFormRadioFields, formSelectFields } from "../../helpers/form-fields";
 
 const openModal = async (page: Page) => {
   await page.goto("/tests/_form-generator");
@@ -89,7 +89,7 @@ test.describe("Modal validation tests", () => {
 
   test("should fill and redirect to marketo submission endpoint", async ({ page }) => {
     const modal = page.locator("#contact-modal");
-    await fillExistingFields(modal, formTextFields, modalFormCheckboxFields, modalFormRadioFields);
+    await fillExistingFields(modal, formTextFields, modalFormCheckboxFields, modalFormRadioFields, formSelectFields);
 
     await modal.getByRole("button", { name: /Submit/ }).click();
     await page.waitForURL(/\/marketo\/submit/, { timeout: 10000 });
@@ -101,7 +101,7 @@ test.describe("Modal validation tests", () => {
       response.url().includes('/marketo/submit') && response.status() === 400
     );
     const modal = page.locator("#contact-modal");
-    await fillExistingFields(modal, formTextFields, modalFormCheckboxFields, modalFormRadioFields);
+    await fillExistingFields(modal, formTextFields, modalFormCheckboxFields, modalFormRadioFields, formSelectFields);
 
     // Honeypot fields
     await modal.locator('input[name="website"]').fill('test');

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 
 export const INLINE_FORM = "/tests/_inline-form-generator";
 export const MODAL_FORM = "/tests/_form-generator";
@@ -170,7 +171,7 @@ test.describe("Inline form gating", () => {
     await page
       .locator("form[data-required-gate] button[type=submit]")
       .click({ force: true });
-    const heading = page.locator("[data-required-summary] h3");
+    const heading = page.locator("[data-required-summary] h2");
     await expect(heading).toBeFocused();
   });
 
@@ -383,9 +384,9 @@ test.describe("Opt-in scoping", () => {
     await page.goto("/tests/_static-default-form");
     const button = page.locator("form[data-required-gate] button[type=submit]");
     await expect(button).toHaveAttribute("aria-disabled", "true");
-    expect(
-      await button.evaluate((el: HTMLButtonElement) => el.disabled),
-    ).toBe(false);
+    expect(await button.evaluate((el: HTMLButtonElement) => el.disabled)).toBe(
+      false,
+    );
     await button.focus();
     await expect(button).toBeFocused();
 
@@ -393,6 +394,49 @@ test.describe("Opt-in scoping", () => {
     await expect(page.locator("[data-required-summary]")).toContainText(
       "What kind of device are you using?",
     );
+  });
+
+  test("the default contact-us form un-gates once every required answer is supplied", async ({
+    page,
+  }) => {
+    // The inline/modal "un-gates" tests exercise the generated fixture
+    // forms, not this template. _default-contact-us-form.html has a
+    // different field mix — no required-details project/team/summary
+    // fields, an unmarked (no id) required checkbox fieldset, and a native
+    // `required` radio (input[name="_radio_how-many-machines-do-you-have"])
+    // instead of a data-required-question fieldset — so it needs its own
+    // coverage that this template genuinely opens once answered.
+    await page.context().addCookies([
+      {
+        name: "_cookies_accepted",
+        value: "all",
+        domain: "0.0.0.0",
+        path: "/",
+      },
+    ]);
+    await page.goto("/tests/_static-default-form");
+    const form = page.locator("form[data-required-gate]");
+    const button = form.locator("button[type=submit]");
+    await expect(button).toHaveAttribute("aria-disabled", "true");
+
+    await form.locator("#firstName").fill("Benjamin");
+    await form.locator("#lastName").fill("Oni");
+    await form.locator("#company").fill("Canonical");
+    await form.locator("#title").fill("Engineer");
+    await form.locator("#email").fill("benjo@canonical.com");
+    // force: true — custom-styled checkbox/radio, same precedent as the
+    // rest of this suite.
+    await form
+      .locator("fieldset[data-required-question] input[type=checkbox]")
+      .first()
+      .check({ force: true });
+    await form
+      .locator('input[name="_radio_how-many-machines-do-you-have"]')
+      .first()
+      .check({ force: true });
+
+    await expect(button).not.toHaveAttribute("aria-disabled", "true");
+    await expect(button).not.toHaveClass(/is-disabled/);
   });
 
   test("a hand-written form without the marker is not gated", async ({
@@ -406,5 +450,225 @@ test.describe("Opt-in scoping", () => {
       "aria-disabled",
       "true",
     );
+  });
+});
+
+test.describe("Accessibility of the gated state", () => {
+  test("gated form has no axe violations", async ({ page }) => {
+    await page.goto(INLINE_FORM);
+    const results = await new AxeBuilder({ page })
+      .include("form[data-required-gate]")
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("summary after a failed press has no axe violations", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    // force: true — aria-disabled, not natively disabled; see the "Inline
+    // form gating" block above.
+    await page
+      .locator("form[data-required-gate] button[type=submit]")
+      .click({ force: true });
+    const results = await new AxeBuilder({ page })
+      .include("form[data-required-gate]")
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("the gated button is keyboard reachable and announces its state", async ({
+    page,
+  }) => {
+    // Axe will happily pass a button that is focusable and says nothing useful,
+    // so assert the mechanism directly.
+    await page.goto(INLINE_FORM);
+    const button = page.locator("form[data-required-gate] button[type=submit]");
+
+    await button.focus();
+    await expect(button).toBeFocused();
+    await expect(button).toHaveAttribute("aria-disabled", "true");
+
+    const describedBy = await button.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    await expect(page.locator(`#${describedBy}`)).toHaveAttribute(
+      "role",
+      "alert",
+    );
+  });
+
+  test("a summary link moves focus to the question it names", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    await page
+      .locator("form[data-required-gate] button[type=submit]")
+      .click({ force: true });
+    await page
+      .locator("[data-required-summary] a", {
+        hasText: "What kind of device are you using?",
+      })
+      .click();
+    // This exercises focusTarget's FIELDSET branch: the summary entry's
+    // target is the "kind of device" fieldset (a required checkbox
+    // question, not a single control), so the assertion must land on an
+    // actual focusable control inside it — the first checkbox — not merely
+    // confirm the link exists.
+    await expect(
+      page.locator("#kind-of-device-field input[type=checkbox]").first(),
+    ).toBeFocused();
+  });
+});
+
+test.describe("The no-JS floor", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("the button is neither muted nor disabled with JS off", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    const button = page.locator("form[data-required-gate] button[type=submit]");
+    await expect(button).not.toHaveAttribute("aria-disabled", /.*/);
+    await expect(button).not.toHaveClass(/is-disabled/);
+    // Not the R10 substitution: with JS off there is no aria-disabled at
+    // all, so Playwright's aria-disabled-aware toBeDisabled() is exactly
+    // the right check here — this block asserts the absence of gating.
+    await expect(button).not.toBeDisabled();
+    await expect(page.locator("form[data-required-gate]")).not.toHaveAttribute(
+      "novalidate",
+      /.*/,
+    );
+  });
+
+  test("native validation blocks an empty required text field", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    const url = page.url();
+    await page.locator("form[data-required-gate] button[type=submit]").click();
+    expect(page.url()).toBe(url); // browser refused to submit
+  });
+
+  test("native validation blocks a required radio group", async ({ page }) => {
+    await page.goto(INLINE_FORM);
+    const valid = await page
+      .locator("#how-many-devices-field input[type=radio]")
+      .first()
+      .evaluate((el: HTMLInputElement) => el.checkValidity());
+    expect(valid).toBe(false);
+  });
+
+  test("native validation blocks a required textarea and select", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    for (const id of [
+      "#required-details-summary",
+      "#required-details-team-size",
+      "#required-details-project-name",
+    ]) {
+      const valid = await page
+        .locator(id)
+        .evaluate((el: HTMLInputElement) => el.checkValidity());
+      expect(valid, `${id} should be invalid while empty`).toBe(false);
+    }
+  });
+
+  test("KNOWN GAP: required checkbox groups are NOT blocked with JS off", async ({
+    page,
+  }) => {
+    // Not a bug in this feature — HTML cannot express "at least one of this
+    // group", so a required checkbox group has no native floor and none is
+    // faked. Documented in spec §4. The real fix is server-side validation,
+    // tracked as the marketo-forms-no-js-data-loss effort.
+    //
+    // This test asserts the gap so it shows up in test output rather than
+    // living only in prose. If it ever fails, someone added a floor and this
+    // test plus spec §4 should be updated together.
+    await page.goto(INLINE_FORM);
+    const boxes = page.locator("#kind-of-device-field input[type=checkbox]");
+    const count = await boxes.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(boxes.nth(i)).not.toHaveAttribute("required", /.*/);
+    }
+  });
+});
+
+test.describe("Button scoping", () => {
+  test("each form's gating drives only its own button", async ({ page }) => {
+    // TWO_FORM renders two independent generated forms in one document: an
+    // inline form (#mktoForm_9998) and a modal form (#mktoForm_9999, inside
+    // #contact-modal). Both render the hardcoded about-you fields under the
+    // SAME ids (firstName, email, company, title — _form-fields.html), so
+    // every field locator below is scoped to one form's element, never a
+    // bare id selector.
+    //
+    // Before this work, both entry points resolved the submit button with
+    // document.querySelector(".js-submit-button") — first match in document
+    // order, i.e. always the inline form's button. Filling in the MODAL
+    // form's required fields would therefore have incorrectly un-gated the
+    // untouched INLINE form's button, while the modal's own button was never
+    // correctly wired at all. This test fills the modal and asserts the
+    // opposite: the modal's own button un-gates, and the inline form's
+    // button — never touched — stays gated throughout.
+    await page.context().addCookies([
+      {
+        name: "_cookies_accepted",
+        value: "all",
+        domain: "0.0.0.0",
+        path: "/",
+      },
+    ]);
+    await page.goto(TWO_FORM);
+
+    const inlineForm = page.locator("#mktoForm_9998");
+    const inlineButton = inlineForm.locator("button[type=submit]");
+    await expect(inlineButton).toHaveAttribute("aria-disabled", "true");
+
+    await page.locator(".js-invoke-modal").first().click();
+    const modalForm = page.locator("#contact-modal form");
+    await expect(modalForm).toBeVisible();
+    const modalButton = modalForm.locator("button[type=submit]");
+    await expect(modalButton).toHaveAttribute("aria-disabled", "true");
+
+    // Fully answer the MODAL form's required questions only.
+    await modalForm.locator("#firstName").fill("Benjamin");
+    await modalForm.locator("#lastName").fill("Oni");
+    await modalForm.locator("#email").fill("benjo@canonical.com");
+    await modalForm.locator("#company").fill("Canonical");
+    await modalForm.locator("#title").fill("Engineer");
+    // Explicit, not relying on prepare-form-inputs.js's geoip pre-fill: that
+    // module resolves its target with document.querySelector("select#country")
+    // (the same first-match-in-document class of bug this test is about, just
+    // in an unrelated module) so on a two-country-select page it only ever
+    // reaches the inline form's #country, leaving the modal's unfilled. Out
+    // of scope for the required-field-gate feature this task audits — select
+    // it directly here, exactly as a real visitor on this page would have to.
+    await modalForm.locator("#country").selectOption("US");
+    await modalForm.locator("#required-details-project-name").fill("Gating");
+    await modalForm.locator("#required-details-team-size").selectOption("1-10");
+    await modalForm
+      .locator("#required-details-summary")
+      .fill("Testing the gate.");
+    // force: true — custom-styled checkbox/radio, same precedent as the
+    // rest of this suite.
+    await modalForm
+      .locator("#kind-of-device-field input[type=checkbox]")
+      .first()
+      .check({ force: true });
+    await modalForm
+      .locator("#how-many-devices-field input[type=radio]")
+      .first()
+      .check({ force: true });
+
+    // The modal's own button un-gates...
+    await expect(modalButton).not.toHaveAttribute("aria-disabled", "true");
+    await expect(modalButton).not.toHaveClass(/is-disabled/);
+
+    // ...while the untouched inline form's button, on the same page, stays
+    // gated. Under the old document-order bug this would have flipped too.
+    await expect(inlineButton).toHaveAttribute("aria-disabled", "true");
+    await expect(inlineButton).toHaveClass(/is-disabled/);
   });
 });

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+
+export const INLINE_FORM = "/tests/_inline-form-generator";
+export const MODAL_FORM = "/tests/_form-generator";
+export const TWO_FORM = "/tests/_two-form-generator";
+
+test.describe("Gating harness pages", () => {
+  test("inline harness renders a generated form with the full field mix", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+
+    const form = page.locator('form[id^="mktoForm_"]');
+    await expect(form).toBeVisible();
+
+    // The fixture must cover every field type the gate has to reason about.
+    await expect(form.locator("#required-details-summary")).toHaveAttribute(
+      "required",
+      "",
+    );
+    await expect(form.locator("#required-details-team-size")).toHaveAttribute(
+      "required",
+      "",
+    );
+    await expect(form.locator("#required-details-project-name")).toHaveAttribute(
+      "required",
+      "",
+    );
+    await expect(form.locator("#kind-of-device-field")).toBeAttached();
+    await expect(form.locator("#how-many-devices-field")).toBeAttached();
+    await expect(form.locator("#email")).toHaveAttribute("type", "email");
+  });
+
+  test("modal harness still renders its form", async ({ page }) => {
+    await page.goto(MODAL_FORM);
+    await page.locator(".js-invoke-modal").first().click();
+    await expect(page.locator("#contact-modal form")).toBeVisible();
+  });
+
+  test("two-form harness renders an inline form and a modal form", async ({
+    page,
+  }) => {
+    await page.goto(TWO_FORM);
+
+    const inlineForm = page.locator("#mktoForm_9998");
+    await expect(inlineForm).toBeVisible();
+
+    await page.locator(".js-invoke-modal").first().click();
+    await expect(page.locator("#contact-modal form")).toBeVisible();
+
+    await expect(page.locator(".js-submit-button")).toHaveCount(2);
+  });
+});

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -166,6 +166,24 @@ test.describe("Inline form gating", () => {
     await expect(button.locator(".p-icon--spinner")).toHaveCount(0);
   });
 
+  test("Enter in a text field triggers implicit submission and is gated the same way", async ({
+    page,
+  }) => {
+    // Spec §2 names this — Enter in a text field submits with no click at
+    // all — as one of three reasons the gate intercepts the form's submit
+    // event rather than the button's click. The unit suite dispatches a
+    // synthetic submit Event, which jsdom never generates from a real
+    // implicit-submission keystroke, so only Playwright proves this path.
+    await page.goto(INLINE_FORM);
+    const url = page.url();
+    await page.fill("#firstName", "Benjamin");
+    await page.locator("#firstName").press("Enter");
+
+    const summary = page.locator("[data-required-summary]");
+    await expect(summary).toContainText("still needed");
+    expect(page.url()).toBe(url); // no navigation
+  });
+
   test("focus lands on the summary heading", async ({ page }) => {
     await page.goto(INLINE_FORM);
     await page
@@ -393,6 +411,12 @@ test.describe("Opt-in scoping", () => {
     await button.click({ force: true });
     await expect(page.locator("[data-required-summary]")).toContainText(
       "What kind of device are you using?",
+    );
+    // Regression guard: the "how many machines" radio group must be marked
+    // with data-required-question and reported once as its own question, not
+    // once per radio labelled from an arbitrary option's text.
+    await expect(page.locator("[data-required-summary]")).not.toContainText(
+      "< 5 machines",
     );
   });
 

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -89,11 +89,15 @@ test.describe("Template markers", () => {
     page,
   }) => {
     await page.goto(INLINE_FORM);
-    // #required-details-team-size has field.isRequired: true, so its label
-    // must carry is-required. Before the fix the label read fieldset.isRequired.
+    // field.isRequired: true -> label marked required
     await expect(
       page.locator('label[for="required-details-team-size"]'),
     ).toHaveClass(/is-required/);
+    // field.isRequired absent, but its fieldset IS required. Before the fix the
+    // label read fieldset.isRequired and wrongly showed as required.
+    await expect(
+      page.locator('label[for="required-details-referral"]'),
+    ).not.toHaveClass(/is-required/);
   });
 
   test.describe("No gated styling is server-rendered", () => {

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -302,14 +302,51 @@ test.describe("Modal form gating", () => {
   test("listeners do not accumulate across open/close cycles", async ({
     page,
   }) => {
-    const form = await openModal(page);
-    for (let i = 0; i < 3; i++) {
-      await page.locator("#contact-modal .js-close").first().click();
+    // The original version of this test asserted a single rendered <h3> on
+    // a gated press, which cannot fail regardless of whether destroy() is
+    // ever wired: initRequiredFieldGate() self-destroys any prior handle on
+    // the same physical <form> node (the modal reuses that node across
+    // opens, which is also why field values persist), so leaked handlers
+    // never accumulate to begin with; and even N leaked submit listeners
+    // would still render exactly one <h3>, because the first one to run
+    // calls stopImmediatePropagation(), which — per the DOM spec — stops
+    // every other listener on that node, and renderSummary() clears the
+    // summary before appending. Neither path exercises destroy()-in-close().
+    //
+    // Instead, instrument window.addEventListener/removeEventListener to
+    // track the net count of "pageshow" listeners — the one listener the
+    // gate registers on `window` (not on the form), which destroy() is
+    // responsible for removing. Take a baseline reading before the first
+    // open (other code may register its own pageshow listeners, so don't
+    // assume zero), run several full open/close cycles, and assert the net
+    // count returns to that baseline rather than growing per cycle.
+    await page.addInitScript(() => {
+      (window as any).__pageshowNet = 0;
+      const add = window.addEventListener.bind(window);
+      const remove = window.removeEventListener.bind(window);
+      window.addEventListener = function (type: string, ...rest: any[]) {
+        if (type === "pageshow") (window as any).__pageshowNet++;
+        return (add as any)(type, ...rest);
+      };
+      window.removeEventListener = function (type: string, ...rest: any[]) {
+        if (type === "pageshow") (window as any).__pageshowNet--;
+        return (remove as any)(type, ...rest);
+      };
+    });
+
+    await page.goto(MODAL_FORM);
+    const baseline = await page.evaluate(() => (window as any).__pageshowNet);
+
+    for (let i = 0; i < 4; i++) {
       await page.locator(".js-invoke-modal").first().click();
+      await expect(page.locator("#contact-modal")).toBeVisible();
+      await page.locator("#contact-modal .js-close").first().click();
     }
-    await form.locator("button[type=submit]").click({ force: true });
-    // One summary heading, not four.
-    await expect(form.locator("[data-required-summary] h3")).toHaveCount(1);
+
+    const afterCycles = await page.evaluate(
+      () => (window as any).__pageshowNet,
+    );
+    expect(afterCycles).toBe(baseline);
   });
 
   test("un-gates once every required answer is supplied", async ({ page }) => {

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -226,3 +226,117 @@ test.describe("Inline form gating", () => {
     );
   });
 });
+
+test.describe("Modal form gating", () => {
+  // Pre-accept cookies for every test in this block: the site-wide consent
+  // banner is fixed to the bottom of the viewport and the modal's submit
+  // button sits near the bottom of a long modal, so the banner physically
+  // overlaps it. Playwright's force:true click bypasses actionability
+  // checks but still dispatches at real coordinates, so an unaccepted
+  // banner silently swallows the click — same root cause as the inline
+  // suite's "un-gates" test above, but it affects every click here because
+  // of the modal's layout, not just field-heavy tests.
+  test.beforeEach(async ({ page }) => {
+    await page.context().addCookies([
+      {
+        name: "_cookies_accepted",
+        value: "all",
+        domain: "0.0.0.0",
+        path: "/",
+      },
+    ]);
+  });
+
+  async function openModal(page) {
+    await page.goto(MODAL_FORM);
+    await page.locator(".js-invoke-modal").first().click();
+    await expect(page.locator("#contact-modal")).toBeVisible();
+    return page.locator("#contact-modal form");
+  }
+
+  test("button is gated when the modal opens", async ({ page }) => {
+    const form = await openModal(page);
+    const button = form.locator("button[type=submit]");
+    await expect(button).toHaveAttribute("aria-disabled", "true");
+    // Must stay focusable: Playwright's toBeDisabled()/not.toBeDisabled()
+    // treats aria-disabled as disabled (elementState() -> getAriaDisabled(),
+    // which fires for role=button), so it can never pass here. Assert the
+    // underlying contract directly instead, as the inline suite does above.
+    expect(await button.evaluate((el: HTMLButtonElement) => el.disabled)).toBe(
+      false,
+    );
+    await button.focus();
+    await expect(button).toBeFocused();
+  });
+
+  test("a gated press explains what is missing inside the modal", async ({
+    page,
+  }) => {
+    const form = await openModal(page);
+    // force: true — aria-disabled, not natively disabled; see above.
+    await form.locator("button[type=submit]").click({ force: true });
+    await expect(form.locator("[data-required-summary]")).toContainText(
+      "still needed",
+    );
+  });
+
+  test("re-opening recomputes rather than assuming a blank form", async ({
+    page,
+  }) => {
+    const form = await openModal(page);
+    await form
+      .locator("#kind-of-device-field input[type=checkbox]")
+      .first()
+      .check({ force: true });
+
+    await page.locator("#contact-modal .js-close").first().click();
+    await page.locator(".js-invoke-modal").first().click();
+
+    // The tick is retained, so that question must not be listed again.
+    await form.locator("button[type=submit]").click({ force: true });
+    await expect(form.locator("[data-required-summary]")).not.toContainText(
+      "What kind of device are you using?",
+    );
+  });
+
+  test("listeners do not accumulate across open/close cycles", async ({
+    page,
+  }) => {
+    const form = await openModal(page);
+    for (let i = 0; i < 3; i++) {
+      await page.locator("#contact-modal .js-close").first().click();
+      await page.locator(".js-invoke-modal").first().click();
+    }
+    await form.locator("button[type=submit]").click({ force: true });
+    // One summary heading, not four.
+    await expect(form.locator("[data-required-summary] h3")).toHaveCount(1);
+  });
+
+  test("un-gates once every required answer is supplied", async ({ page }) => {
+    const form = await openModal(page);
+    const button = form.locator("button[type=submit]");
+
+    await form.locator("#firstName").fill("Benjamin");
+    await form.locator("#lastName").fill("Oni");
+    await form.locator("#email").fill("benjo@canonical.com");
+    await form.locator("#company").fill("Canonical");
+    await form.locator("#title").fill("Engineer");
+    await form.locator("#required-details-project-name").fill("Gating");
+    await form.locator("#required-details-team-size").selectOption("1-10");
+    await form.locator("#required-details-summary").fill("Testing the gate.");
+    // force: true — these are custom-styled checkboxes/radios whose visible
+    // control overlaps the native input's hit target; same precedent as the
+    // inline suite above (and static-forms.spec.ts, form-generator.spec.ts).
+    await form
+      .locator("#kind-of-device-field input[type=checkbox]")
+      .first()
+      .check({ force: true });
+    await form
+      .locator("#how-many-devices-field input[type=radio]")
+      .first()
+      .check({ force: true });
+
+    await expect(button).not.toHaveAttribute("aria-disabled", "true");
+    await expect(button).not.toHaveClass(/is-disabled/);
+  });
+});

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -377,3 +377,34 @@ test.describe("Modal form gating", () => {
     await expect(button).not.toHaveClass(/is-disabled/);
   });
 });
+
+test.describe("Opt-in scoping", () => {
+  test("the default contact-us form is gated", async ({ page }) => {
+    await page.goto("/tests/_static-default-form");
+    const button = page.locator("form[data-required-gate] button[type=submit]");
+    await expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(
+      await button.evaluate((el: HTMLButtonElement) => el.disabled),
+    ).toBe(false);
+    await button.focus();
+    await expect(button).toBeFocused();
+
+    await button.click({ force: true });
+    await expect(page.locator("[data-required-summary]")).toContainText(
+      "What kind of device are you using?",
+    );
+  });
+
+  test("a hand-written form without the marker is not gated", async ({
+    page,
+  }) => {
+    // The guard against shipping a behaviour change to unexamined templates.
+    await page.goto("/tests/_static-client-form");
+    const form = page.locator("form[action='/marketo/submit']").first();
+    await expect(form).not.toHaveAttribute("data-required-gate", /.*/);
+    await expect(form.locator("button[type=submit]")).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+});

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -51,3 +51,66 @@ test.describe("Gating harness pages", () => {
     await expect(page.locator(".js-submit-button")).toHaveCount(2);
   });
 });
+
+test.describe("Template markers", () => {
+  test("generated form carries the opt-in marker and question markers", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    const form = page.locator("form[data-required-gate]");
+    await expect(form).toBeVisible();
+
+    // Required fieldsets are marked; optional ones are not.
+    await expect(
+      form.locator("#kind-of-device-field[data-required-question]"),
+    ).toBeAttached();
+    await expect(
+      form.locator("#how-many-devices-field[data-required-question]"),
+    ).toBeAttached();
+    await expect(
+      form.locator("#required-details-field[data-required-question]"),
+    ).toBeAttached();
+    await expect(
+      form.locator("#ubuntu-versions-field[data-required-question]"),
+    ).toHaveCount(0);
+  });
+
+  test("summary container is present, empty and adjacent to the submit button", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    const summary = page.locator("[data-required-summary]");
+    await expect(summary).toHaveAttribute("role", "alert");
+    await expect(summary).toBeEmpty();
+    await expect(summary).toHaveAttribute("id", /^required-field-summary-/);
+  });
+
+  test("select label and select input agree about required-ness", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    // #required-details-team-size has field.isRequired: true, so its label
+    // must carry is-required. Before the fix the label read fieldset.isRequired.
+    await expect(
+      page.locator('label[for="required-details-team-size"]'),
+    ).toHaveClass(/is-required/);
+  });
+
+  test.describe("No gated styling is server-rendered", () => {
+    test.use({ javaScriptEnabled: false });
+
+    test("form and button carry no gating attributes without JS", async ({
+      page,
+    }) => {
+      await page.goto(INLINE_FORM);
+      const form = page.locator("form[data-required-gate]");
+      await expect(form).toBeVisible();
+      await expect(form).not.toHaveAttribute("novalidate", /.*/);
+
+      const button = form.locator("button[type=submit]");
+      await expect(button).not.toHaveAttribute("aria-disabled", /.*/);
+      await expect(button).not.toHaveClass(/is-disabled/);
+      await expect(button).not.toBeDisabled();
+    });
+  });
+});

--- a/tests/playwright/tests/forms/required-field-gate.spec.ts
+++ b/tests/playwright/tests/forms/required-field-gate.spec.ts
@@ -22,10 +22,9 @@ test.describe("Gating harness pages", () => {
       "required",
       "",
     );
-    await expect(form.locator("#required-details-project-name")).toHaveAttribute(
-      "required",
-      "",
-    );
+    await expect(
+      form.locator("#required-details-project-name"),
+    ).toHaveAttribute("required", "");
     await expect(form.locator("#kind-of-device-field")).toBeAttached();
     await expect(form.locator("#how-many-devices-field")).toBeAttached();
     await expect(form.locator("#email")).toHaveAttribute("type", "email");
@@ -116,5 +115,114 @@ test.describe("Template markers", () => {
       await expect(button).not.toHaveClass(/is-disabled/);
       await expect(button).not.toBeDisabled();
     });
+  });
+});
+
+test.describe("Inline form gating", () => {
+  // Scoped to the gated form throughout: the harness page extends the site
+  // shell, whose header carries its own button[type=submit] (site search),
+  // so an unscoped locator is ambiguous.
+  test("button is gated on an untouched form", async ({ page }) => {
+    await page.goto(INLINE_FORM);
+    const button = page.locator("form[data-required-gate] button[type=submit]");
+    await expect(button).toHaveAttribute("aria-disabled", "true");
+    await expect(button).toHaveClass(/is-disabled/);
+    // Must stay focusable: Playwright's toBeDisabled() treats aria-disabled
+    // as disabled, so assert the underlying contract directly instead — no
+    // native disabled property/attribute, and still focusable.
+    expect(await button.evaluate((el: HTMLButtonElement) => el.disabled)).toBe(
+      false,
+    );
+    await button.focus();
+    await expect(button).toBeFocused();
+  });
+
+  test("a gated press explains what is missing and does not submit", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    const url = page.url();
+    // force: true — a real browser dispatches the click on an aria-disabled
+    // (not natively disabled) button; Playwright's actionability checks
+    // refuse to, so bypass them to exercise the same path a user would.
+    await page
+      .locator("form[data-required-gate] button[type=submit]")
+      .click({ force: true });
+
+    const summary = page.locator("[data-required-summary]");
+    await expect(summary).toContainText("still needed");
+    await expect(summary).toContainText("What kind of device are you using?");
+    expect(page.url()).toBe(url); // no navigation
+  });
+
+  test("a gated press leaves no loading spinner", async ({ page }) => {
+    // Regression test for the stopImmediatePropagation contract.
+    await page.goto(INLINE_FORM);
+    const button = page.locator("form[data-required-gate] button[type=submit]");
+    await button.click({ force: true }); // aria-disabled, not natively disabled — see above
+    await expect(button).not.toHaveClass(/is-processing/);
+    await expect(button).toContainText("Submit");
+    await expect(button.locator(".p-icon--spinner")).toHaveCount(0);
+  });
+
+  test("focus lands on the summary heading", async ({ page }) => {
+    await page.goto(INLINE_FORM);
+    await page
+      .locator("form[data-required-gate] button[type=submit]")
+      .click({ force: true });
+    const heading = page.locator("[data-required-summary] h3");
+    await expect(heading).toBeFocused();
+  });
+
+  test("un-gates once every required answer is supplied", async ({ page }) => {
+    // Pre-accept cookies: the site-wide consent banner is fixed to the
+    // bottom of the viewport and, once this many fields are filled, sits
+    // on top of the below-the-fold radio group — nothing to do with gating.
+    await page.context().addCookies([
+      {
+        name: "_cookies_accepted",
+        value: "all",
+        domain: "0.0.0.0",
+        path: "/",
+      },
+    ]);
+    await page.goto(INLINE_FORM);
+    const button = page.locator("form[data-required-gate] button[type=submit]");
+
+    await page.fill("#firstName", "Benjamin");
+    await page.fill("#lastName", "Oni");
+    await page.fill("#email", "benjo@canonical.com");
+    await page.fill("#company", "Canonical");
+    await page.fill("#title", "Engineer");
+    await page.fill("#required-details-project-name", "Gating");
+    await page.selectOption("#required-details-team-size", "1-10");
+    await page.fill("#required-details-summary", "Testing the gate.");
+    // force: true — these are custom-styled checkboxes/radios whose visible
+    // control overlaps the native input's hit target; the rest of this suite
+    // (static-forms.spec.ts, form-generator.spec.ts) does the same.
+    await page
+      .locator("#kind-of-device-field input[type=checkbox]")
+      .first()
+      .check({ force: true });
+    await page
+      .locator("#how-many-devices-field input[type=radio]")
+      .first()
+      .check({ force: true });
+
+    await expect(button).not.toHaveAttribute("aria-disabled", "true");
+    await expect(button).not.toHaveClass(/is-disabled/);
+  });
+
+  test("a filled-but-malformed email keeps the button gated", async ({
+    page,
+  }) => {
+    await page.goto(INLINE_FORM);
+    await page.fill("#email", "benjo@");
+    await page
+      .locator("form[data-required-gate] button[type=submit]")
+      .click({ force: true });
+    await expect(page.locator("[data-required-summary]")).toContainText(
+      "Email",
+    );
   });
 });

--- a/tests/playwright/tests/forms/static-forms.spec.ts
+++ b/tests/playwright/tests/forms/static-forms.spec.ts
@@ -132,21 +132,15 @@ test.describe("Radio field handling", () => {
 
 test.describe("Required checkbox validation", () => {
   // Task 5 removed the legacy fieldset.js-required-checkbox /
-  // checkRequiredCheckboxes gating from static-forms.js, but
-  // _default-contact-us-form.html (which _static-default-form renders)
-  // hasn't been migrated onto the new required-field gate yet — that's
-  // Task 7. Until then this template is temporarily ungated by design.
-  test.fixme(
-    "should disable submit button when required checkbox is not checked",
-    async ({ page }) => {
-      await page.goto("/tests/_static-default-form");
-      await acceptCookiePolicy(page);
-
-      // Check that submit button is disabled
-      const submitButton = page.getByRole("button", { name: /Submit/ });
-      await expect(submitButton).toBeDisabled();
-    },
-  );
+  // checkRequiredCheckboxes gating from static-forms.js. The
+  // "disable-until-checked" coverage this used to provide for
+  // _default-contact-us-form.html moves to Task 7's "the default
+  // contact-us form is gated" test in required-field-gate.spec.ts, which
+  // asserts against the real mechanism (aria-disabled, is-disabled, the
+  // summary) once that template is migrated onto the new gate — not
+  // toBeDisabled() against a native disabled attribute the design
+  // deliberately never sets, which would start passing again for the
+  // wrong reason.
 
   test("should enable submit button when required checkbox is checked", async ({ page }) => {
     await page.goto("/tests/_static-default-form");

--- a/tests/playwright/tests/forms/static-forms.spec.ts
+++ b/tests/playwright/tests/forms/static-forms.spec.ts
@@ -130,27 +130,27 @@ test.describe("Radio field handling", () => {
   });
 });
 
-test.describe("Required checkbox validation", () => {
-  // Task 5 removed the legacy fieldset.js-required-checkbox /
-  // checkRequiredCheckboxes gating from static-forms.js. The
-  // "disable-until-checked" coverage this used to provide for
-  // _default-contact-us-form.html moves to Task 7's "the default
-  // contact-us form is gated" test in required-field-gate.spec.ts, which
-  // asserts against the real mechanism (aria-disabled, is-disabled, the
-  // summary) once that template is migrated onto the new gate — not
-  // toBeDisabled() against a native disabled attribute the design
-  // deliberately never sets, which would start passing again for the
-  // wrong reason.
-  //
-  // Task 7 also removed its sibling, "should enable submit button when
-  // required checkbox is checked". Once the template carries
-  // data-required-gate, ticking one checkbox still leaves the form's
-  // other required fields empty, so the button stays aria-disabled and
-  // Playwright reports it disabled — the test's whole premise, that one
-  // checkbox is the deciding factor, is no longer true. That coverage now
-  // lives in required-field-gate.spec.ts's "Opt-in scoping" block, in the
-  // test "the default contact-us form un-gates once every required answer
-  // is supplied" — not the identically-named tests in the Inline/Modal
-  // form gating blocks, which exercise the generated fixture forms, not
-  // this template.
-});
+// Required checkbox validation
+//
+// Task 5 removed the legacy fieldset.js-required-checkbox /
+// checkRequiredCheckboxes gating from static-forms.js. The
+// "disable-until-checked" coverage this used to provide for
+// _default-contact-us-form.html moves to Task 7's "the default
+// contact-us form is gated" test in required-field-gate.spec.ts, which
+// asserts against the real mechanism (aria-disabled, is-disabled, the
+// summary) once that template is migrated onto the new gate — not
+// toBeDisabled() against a native disabled attribute the design
+// deliberately never sets, which would start passing again for the
+// wrong reason.
+//
+// Task 7 also removed its sibling, "should enable submit button when
+// required checkbox is checked". Once the template carries
+// data-required-gate, ticking one checkbox still leaves the form's
+// other required fields empty, so the button stays aria-disabled and
+// Playwright reports it disabled — the test's whole premise, that one
+// checkbox is the deciding factor, is no longer true. That coverage now
+// lives in required-field-gate.spec.ts's "Opt-in scoping" block, in the
+// test "the default contact-us form un-gates once every required answer
+// is supplied" — not the identically-named tests in the Inline/Modal
+// form gating blocks, which exercise the generated fixture forms, not
+// this template.

--- a/tests/playwright/tests/forms/static-forms.spec.ts
+++ b/tests/playwright/tests/forms/static-forms.spec.ts
@@ -131,14 +131,22 @@ test.describe("Radio field handling", () => {
 });
 
 test.describe("Required checkbox validation", () => {
-  test("should disable submit button when required checkbox is not checked", async ({ page }) => {    
-    await page.goto("/tests/_static-default-form");
-    await acceptCookiePolicy(page);
+  // Task 5 removed the legacy fieldset.js-required-checkbox /
+  // checkRequiredCheckboxes gating from static-forms.js, but
+  // _default-contact-us-form.html (which _static-default-form renders)
+  // hasn't been migrated onto the new required-field gate yet — that's
+  // Task 7. Until then this template is temporarily ungated by design.
+  test.fixme(
+    "should disable submit button when required checkbox is not checked",
+    async ({ page }) => {
+      await page.goto("/tests/_static-default-form");
+      await acceptCookiePolicy(page);
 
-    // Check that submit button is disabled
-    const submitButton = page.getByRole("button", { name: /Submit/ });
-    await expect(submitButton).toBeDisabled();
-  });
+      // Check that submit button is disabled
+      const submitButton = page.getByRole("button", { name: /Submit/ });
+      await expect(submitButton).toBeDisabled();
+    },
+  );
 
   test("should enable submit button when required checkbox is checked", async ({ page }) => {
     await page.goto("/tests/_static-default-form");

--- a/tests/playwright/tests/forms/static-forms.spec.ts
+++ b/tests/playwright/tests/forms/static-forms.spec.ts
@@ -147,7 +147,10 @@ test.describe("Required checkbox validation", () => {
   // data-required-gate, ticking one checkbox still leaves the form's
   // other required fields empty, so the button stays aria-disabled and
   // Playwright reports it disabled — the test's whole premise, that one
-  // checkbox is the deciding factor, is no longer true. That coverage
-  // moved to required-field-gate.spec.ts's "un-gates once every required
-  // answer is supplied".
+  // checkbox is the deciding factor, is no longer true. That coverage now
+  // lives in required-field-gate.spec.ts's "Opt-in scoping" block, in the
+  // test "the default contact-us form un-gates once every required answer
+  // is supplied" — not the identically-named tests in the Inline/Modal
+  // form gating blocks, which exercise the generated fixture forms, not
+  // this template.
 });

--- a/tests/playwright/tests/forms/static-forms.spec.ts
+++ b/tests/playwright/tests/forms/static-forms.spec.ts
@@ -141,15 +141,13 @@ test.describe("Required checkbox validation", () => {
   // toBeDisabled() against a native disabled attribute the design
   // deliberately never sets, which would start passing again for the
   // wrong reason.
-
-  test("should enable submit button when required checkbox is checked", async ({ page }) => {
-    await page.goto("/tests/_static-default-form");
-    await acceptCookiePolicy(page);
-
-    // Check the required checkbox
-    await page.locator('input[aria-labelledby="physical-server"]').check({ force: true });
-
-    const submitButton = page.getByRole("button", { name: /Submit/ });
-    await expect(submitButton).toBeEnabled();
-  });
+  //
+  // Task 7 also removed its sibling, "should enable submit button when
+  // required checkbox is checked". Once the template carries
+  // data-required-gate, ticking one checkbox still leaves the form's
+  // other required fields empty, so the button stays aria-disabled and
+  // Playwright reports it disabled — the test's whole premise, that one
+  // checkbox is the deciding factor, is no longer true. That coverage
+  // moved to required-field-gate.spec.ts's "un-gates once every required
+  // answer is supplied".
 });


### PR DESCRIPTION
## Done

- Submit button on generated Marketo forms stays visibly un-pressable until every required field is answered, using `aria-disabled` rather than `disabled` so it keeps focus and can say what's missing when pressed.

⚠️ This ships to all 65 generated forms at once and gating changes submission rates by construction — worth a sign-off from whoever owns lead volume before merge.

## QA

- Open the [DEMO](https://ubuntu-com-16712.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- `/tests/_inline-form-generator` — button starts muted but focusable; press it for a summary of what's missing; fill everything and it goes green
- `/tests/_form-generator` — same inside the modal; close and reopen keeps your answers
- `/tests/_static-client-form` — unchanged, gating is opt-in
- With JavaScript off — button works normally and native validation blocks, except required checkbox groups (HTML can't express "at least one"; pre-existing, documented, covered by a deliberate test)

## Issue / Card

Fixes #

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

