### PR TITLE
Fix create circle link

### DIFF
--- a/templates/community/circles.html
+++ b/templates/community/circles.html
@@ -30,7 +30,7 @@ meta_copydoc %}
           <p>
             Ubuntu Circles are local communities built around a shared love for Ubuntu and open source.
             <br/>
-            Together, they meet, create, and contribute to make Ubuntu even better. Find a Circle in your region or <a href="/community/docs/locos/create">start your own</a>.
+            Together, they meet, create, and contribute to make Ubuntu even better. Find a Circle in your region or <a href="/community/docs/circles/create">start your own</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Update 'create circle' link currently pointing to old LoCo doc source

## Done

- Current link points to old LoCo documentation source. Link should be updated to new /circles/ source. 

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
