### PR TITLE
feat: update releases checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -67,6 +67,7 @@ wsl:
 
 checksums:
   desktop:
+    "26.04.1": "601e30fbf5d97759367c632e2c33630665039b7e2158fd068403da3ccf1bda1f *ubuntu-26.04.1-desktop-amd64.iso"
     "26.04": "487f87faaf547ea30e0aba4d5b53346292571256b25333a978db1692bcee9dd2 *ubuntu-26.04-desktop-amd64.iso"
     "25.10": "32e30d72ae4798c633323a2684d94a11582bb03a6ab38d2b0d5ae5eabc5e577b *ubuntu-25.10-desktop-amd64.iso"
     "25.04": "b87366b62eddfbecb60e681ba83299c61884a0d97569abe797695c8861f5dea4 *ubuntu-25.04-desktop-amd64.iso"
@@ -79,6 +80,7 @@ checksums:
     "26.04": "c2afd538d66fdd77377d03f1ed2ac76a34f1c116baecc9a8170d68f833121f57 *ubuntu-26.04-desktop-arm64.iso"
     "25.10": "9d383dd57220dec520fdec3be05da258d27d435c02fe6e296c5d0a505741a787 *ubuntu-25.10-desktop-arm64.iso"
   live-server:
+    "26.04.1": "cc8a95cde20f6ced61a322420de00f10cc3c90ced545daa46cb9c1a117f1d927 *ubuntu-26.04.1-live-server-amd64.iso"
     "26.04": "dec49008a71f6098d0bcfc822021f4d042d5f2db279e4d75bdd981304f1ca5d9 *ubuntu-26.04-live-server-amd64.iso"
     "25.10": "dc54870e5261c0abad19f74b8146659d10e625971792bd42d7ecde820b60a1d0 *ubuntu-25.10-live-server-amd64.iso"
     "25.04": "8b44046211118639c673335a80359f4b3f0d9e52c33fe61c59072b1b61bdecc5 *ubuntu-25.04-live-server-amd64.iso"
@@ -132,6 +134,7 @@ checksums:
   core-22-armhf+raspi:
     "22": "4c4b3958626611aff85bfa5873c45ad22fdf7642be868b5722900fa88e6fca86 *ubuntu-core-22-armhf+raspi.img.xz"
   wsl:
+    "26.04.1": "48d56724b5c8e60f24893e83e73bbb58c60b3ca22fba3da977075420acd54104 *ubuntu-26.04.1-wsl-amd64.wsl"
     "26.04": "96c7f5fb28a7fe28245331f9bfbe4375f18dd29a4850116ad3c4f60f6700c55c *ubuntu-26.04-wsl-amd64.wsl"
     "24.04.4": "9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5 *ubuntu-24.04.4-wsl-amd64.wsl"
   wsl-arm64:


### PR DESCRIPTION
## Done

- Update releases checksums per https://releases.ubuntu.com/resolute/SHA256SUMS

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
