### PR TITLE
chore: Update Certification checkbox sitemap version

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -145,7 +145,7 @@
     <loc>https://ubuntu.com/docs/steam/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://ubuntu.com/docs/checkbox/main/doc-sitemap.xml</loc>
+    <loc>https://ubuntu.com/docs/checkbox/stable/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://ubuntu.com/docs/hardware-api/latest/doc-sitemap.xml</loc>


### PR DESCRIPTION
## Done

- change sitemap index version to `stable`

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

N/A

## Issue / Card

N/A

## Screenshots

N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
