### PR TITLE
fix: remove `k8s-operator` from affected charms

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms.md
+++ b/templates/kubernetes/charmed-k8s/docs/rocks-registry-affected-charms.md
@@ -28,7 +28,6 @@ Canonical is decommissioning the `rocks.canonical.com` container image registry.
 - [charm-sriov-cni](https://github.com/charmed-kubernetes/charm-sriov-cni)
 - [charm-sriov-network-device-plugin](https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin)
 - [cinder-csi-operator](https://github.com/canonical/cinder-csi-operator)
-- [k8s-operator](https://github.com/canonical/k8s-operator)
 - [keystone-k8s-auth-operator](https://github.com/canonical/keystone-k8s-auth-operator)
 - [kubernetes-metrics-server-operator](https://github.com/charmed-kubernetes/kubernetes-metrics-server-operator)
 - [layer-canal](https://github.com/charmed-kubernetes/layer-canal)


### PR DESCRIPTION
## Done

Update the list of affected charms by the `rocks.canonical.com` decomission.

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
