### PR TITLE
fix: inject nonce into gtm container script

### DIFF
--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -35,6 +35,9 @@
       const script = document.createElement('script');
       script.type = 'text/javascript';
       script.async = true;
+      // nonce lets gtm.js propagate it to tags the container injects
+      script.setAttribute('nonce', '{{ csp_nonce }}');
+      script.nonce = '{{ csp_nonce }}';
       // ensure PageViews is always tracked (on script load)
       script.onload = () => {
         dataLayer.push({


### PR DESCRIPTION
## Done
- added nonce for gtm containers to abide by CSP.
- **Note**:  take a look at the comment from Gianluigi on the [parent ticket](https://warthogs.atlassian.net/browse/WD-38498)

## QA
- Navigate to the landing page
- Open browser console and ensure that there are no GTM errors relating to CSP.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-38668
