### PR TITLE
docs: record the ignore_blocks macro trade-off

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -223,6 +223,28 @@ python -m pip install -U djlint
 A global install is still worth having, since some of our other repos do not pin
 djLint at all. It only needs to stay off the old versions.
 
+Note that `.djlintrc` is read from the project directory by whichever `djlint`
+runs, so config changes reach your editor even when the pin does not. Options
+that need a recent djLint, such as `ignore_blocks`, will be read by an old one
+and applied incorrectly.
+
+#### Macro formatting
+
+`.djlintrc` sets `ignore_blocks: macro` so djLint leaves the body of a
+`{% macro %}` at column 0, which is the style our macro files use. The trade-off
+is that reformatting a macro file also pulls its parameters back to column 0:
+
+``` jinja
+{% macro vf_highlighted_cta(     {% macro vf_highlighted_cta(
+  cta_text                  ->   cta_text
+) -%}                            ) -%}
+```
+
+Without the option djLint indents the closing `) -%}` and the whole macro body
+instead, which is worse. Both settings are stable, neither reproduces the hand
+formatting currently in the files, so expect a small diff either way when you
+reformat one.
+
 ### Configuring editors
 
 These are instructions for setting up various editors to use the above tools:


### PR DESCRIPTION
## Done

Documents a trade-off in the `ignore_blocks: macro` setting added in #16718 that I described wrongly at the time: it keeps macro bodies at column 0 as intended, but reformatting a macro file also pulls its parameters back to column 0. Also notes that `.djlintrc` is read from the project directory by whichever djlint runs, so config reaches your editor even when the pin does not.

Docs only, no behaviour change.

## QA

- Read the "Macro formatting" section added to `HACKING.md`.
- To see it: `.venv/bin/djlint templates/macros/_vf_highlighted-cta.jinja --check` wants to move `cta_text` to column 0. Removing `ignore_blocks` from `.djlintrc` and rerunning instead indents `) -%}` and the whole macro body, which is the worse of the two.

The setting is staying as it is. Both options are stable and neither reproduces the hand formatting currently in the macro files, so this is about setting expectations before someone reformats one.

## Issue / Card

WD-38520

## Screenshots

N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

