### PR TITLE
Fix pixelated blog thumbnail images on new blog revamp (WD-38727)

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -6,10 +6,15 @@
   columns="4",
   link="/blog/" ~ article.slug,
   heading=article.title.rendered | safe,
-  image={
-    "src": article.image.source_url,
-    "alt": article.title.rendered | striptags
-  },
+  image=image(
+    url=article.image.source_url,
+    alt=article.title.rendered | striptags,
+    width="384",
+    height="216",
+    hi_def=True,
+    loading="auto",
+    output_mode="attrs"
+  ),
   footer={
     "content_type": article.group.name if article.group else "Company"
   },

--- a/templates/blog/featured-article.html
+++ b/templates/blog/featured-article.html
@@ -8,10 +8,15 @@
   columns="8",
   link="/blog/" ~ article.slug,
   heading=article.title.rendered | safe,
-  image={
-    "src": article.image.source_url,
-    "alt": article.title.rendered | striptags
-  },
+  image=image(
+    url=article.image.source_url,
+    alt=article.title.rendered | striptags,
+    width="768",
+    height="432",
+    hi_def=True,
+    loading="auto",
+    output_mode="attrs"
+  ),
   footer={
     "content_type": article.group.name if article.group else "Company"
   },


### PR DESCRIPTION
## Problem
Blog card and featured article thumbnails on the revamped blog use vf_card's `image` param, but were being fed a raw dict with `article.image.source_url` directly \u2014 bypassing Cloudinary's `image_template` helper entirely. That meant no responsive `srcset`, no auto format/quality optimisation, and images rendered at native/incorrect resolution, causing visible pixelation on smaller card sizes and high-DPI screens.

## Fix
- [Demo](https://ubuntu-com-16738.demos.haus/blog)
Build the `image` dict via `image_template` (registered as `image` in Jinja context) with `output_mode="attrs"` in:
- `templates/blog/blog-card.html`
- `templates/blog/featured-article.html`

This generates optimised Cloudinary URLs with responsive `srcset`/`sizes` and `hi_def` support for retina displays.

## Ticket
WD-38727
