### PR TITLE
chore: bump up image-template and blog versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==7.3.1
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.image-template==1.9.0
+git+https://github.com/canonical/canonicalwebteam.image-template.git@skip-q-auto-for-webp#egg=canonicalwebteam.image-template
 canonicalwebteam.discourse==7.9.0
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==3.1.1
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==7.3.1
+git+https://github.com/canonical/canonicalwebteam.blog.git@update-image-template#egg=canonicalwebteam.blog
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 git+https://github.com/canonical/canonicalwebteam.image-template.git@skip-q-auto-for-webp#egg=canonicalwebteam.image-template

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.http==1.0.4
 git+https://github.com/canonical/canonicalwebteam.blog.git@update-image-template#egg=canonicalwebteam.blog
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
-git+https://github.com/canonical/canonicalwebteam.image-template.git@skip-q-auto-for-webp#egg=canonicalwebteam.image-template
+canonicalwebteam.image-template==1.10.0
 canonicalwebteam.discourse==7.9.0
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.10


### PR DESCRIPTION
## Done
See https://github.com/canonical/canonicalwebteam.image-template/pull/73

## QA
- Deploy to staging on [jenkins](https://jenkins.canonical.com/webteam/job/staging.ubuntu.com/)
- Visit /blog/draft-blogs/test-stonking-stingray-animation
- Ensure animations (esp. the 30fps and 24fps ones) run until completion.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-38731


