### PR TITLE
chore(WD-38742): copy update to SmartStart information

### DIFF
--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -59,32 +59,14 @@
           <li class="p-list__item is-ticked">Snapcraft 101 training</li>
           <li class="p-list__item is-ticked">Snap store services</li>
           <li class="p-list__item is-ticked">
-            Device fees and 24/7 support<a id="footnote-1-link" href="#footnote-1" aria-describedby="footnote-1"><sup>1</sup></a>
-          </li>
-          <li class="p-list__item is-ticked">
-            Ubuntu Pro subscription<a id="footnote-2-link" href="#footnote-2" aria-describedby="footnote-2"><sup>2</sup></a>
-          </li>
-          <li class="p-list__item is-ticked">
-            Deployment services<a id="footnote-3-link" href="#footnote-3" aria-describedby="footnote-3"><sup>3</sup></a>
+            Deployment services<a id="footnote-1-link" href="#footnote-1" aria-describedby="footnote-1"><sup>1</sup></a>
           </li>
         </ul>
         <ol class="p-list">
           <li id="footnote-1" class="p-list__item">
-            <sup>1</sup> Valid for one year for up to 1,000 devices, with annual renewal required for devices fee and store fee. Alternatively, valid for the full Core LTS + Legacy support period for 300 devices, with no annual renewal.
+            <sup>1</sup> Includes either packaging of up to three application snaps (subject to approval) or equivalent consulting hours. This also excludes Store proxy deployments.
             <a class="u-off-screen"
                href="#footnote-1-link"
-               aria-label="Back to content">↩</a>
-          </li>
-          <li id="footnote-2" class="p-list__item">
-            <sup>2</sup> The Pro subscription requires annual renewal when the 1,000-device option is selected (see point <a href="#footnote-1" aria-describedby="footnote-1"><sup>1</sup></a>).
-            <a class="u-off-screen"
-               href="#footnote-2-link"
-               aria-label="Back to content">↩</a>
-          </li>
-          <li id="footnote-3" class="p-list__item">
-            <sup>3</sup> Includes either packaging of up to three application snaps (subject to approval) or equivalent consulting hours. This also excludes Store proxy deployments.
-            <a class="u-off-screen"
-               href="#footnote-3-link"
                aria-label="Back to content">↩</a>
           </li>
         </ol>
@@ -97,7 +79,7 @@
       <div class="p-section--shallow">
         <hr class="p-rule--muted" />
         <h3 class="p-heading--2">
-          Engineering services<a id="footnote-4-link" href="#footnote-4" aria-describedby="footnote-4"><sup>4</sup></a>
+          Engineering services<a id="footnote-2-link" href="#footnote-2" aria-describedby="footnote-2"><sup>2</sup></a>
         </h3>
       </div>
     </div>
@@ -184,10 +166,10 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <p id="footnote-4">
-        <sup>4</sup> Engineering services can be purchased separately from the SmartStart package. Ubuntu Pro is not included.
+      <p id="footnote-2">
+        <sup>2</sup> Engineering services can be purchased separately from the SmartStart package. Ubuntu Pro is not included.
         <a class="u-off-screen"
-           href="#footnote-4-link"
+           href="#footnote-2-link"
            aria-label="Back to content">↩</a>
       </p>
     </div>
@@ -409,7 +391,7 @@
         </p>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">
-            Security maintenance for Ubuntu Universe and Main for up to 10 years<a id="footnote-5-link" href="#footnote-5" aria-describedby="footnote-5"><sup>5</sup></a>
+            Security maintenance for Ubuntu Universe and Main for up to 10 years<a id="footnote-3-link" href="#footnote-3" aria-describedby="footnote-3"><sup>3</sup></a>
           </li>
           <li class="p-list__item is-ticked">
             Ubuntu systems management with <a href="/landscape">Landscape</a>
@@ -430,10 +412,10 @@
         <div class="p-cta-block">
           <a href="/pro/devices">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
         </div>
-        <p id="footnote-5">
-          <sup>5</sup> Ubuntu Pro is a subscription that can be paid annually or as a one-time fee for up to 10 years. To access support for years 11-15, the Legacy add-on must be purchased. The Legacy add-on is available to both annual and one-time subscription customers.
+        <p id="footnote-3">
+          <sup>3</sup> Ubuntu Pro is a subscription that can be paid annually or as a one-time fee for up to 10 years. To access support for years 11-15, the Legacy add-on must be purchased. The Legacy add-on is available to both annual and one-time subscription customers.
           <a class="u-off-screen"
-             href="#footnote-5-link"
+             href="#footnote-3-link"
              aria-label="Back to content">↩</a>
         </p>
       </div>


### PR DESCRIPTION
## Done

- BAU copy update to https://ubuntu.com/pricing/devices
- Copydoc: https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit?tab=t.0#heading=h.53ksybmxkac6

## QA

- The demo is currently 404ing, if you want to try the link you can try it [here](https://ubuntu-com-16744.demos.haus/pricing/devices).
- Check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/devices
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-38742](https://warthogs.atlassian.net/browse/WD-38742?actionerId=557058%3Af58131cb-b67d-43c7-b30d-6b58d40bd077&sourceType=assign)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-38742]: https://warthogs.atlassian.net/browse/WD-38742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ