### PR TITLE
fix: correct 'Jion' to 'Join' in public clouds section

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -167,7 +167,7 @@
         <h3 class="p-heading--5">
           <a href="https://discourse.ubuntu.com/c/public-cloud/176">Community Discourse</a>
         </h3>
-        <p>Jion the Ubuntu on Public Clouds community and make your voice heard.</p>
+        <p>Join the Ubuntu on Public Clouds community and make your voice heard.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
Fixes a spelling typo on the Ubuntu on Public Clouds community page.

## Fix
- `templates/download/cloud/index.html` line 170: `Jion the Ubuntu` → `Join the Ubuntu`

## Verification
Fixes issue #16745.
