### PR TITLE
update Pro pricing link + drop numpy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ time-machine==2.9.0
 filelock==3.20.3
 bleach==6.4.0
 nh3==0.3.6
-numpy==1.26.0
 python-slugify==8.0.1
 djlint==1.44.2
 pycountry==24.6.1

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -274,7 +274,7 @@ pro:
     - title: CVE coverage
       path: /pro/linux-patch-management-with-pro
     - title: Pricing
-      path: /pricing/pro
+      path: /pricing/devices
     - title: Free trial
       path: /pro/free-trial
     - title: Docs

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -161,7 +161,7 @@ def descending_years(end_year):
 def split_list(array, parts):
     N = len(array)
     part_size = N // parts
-    remainder = N % parts # number of parts that have an additional element
+    remainder = N % parts  # number of parts that have an additional element
     result = []
     low = 0
     while low < N:

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -159,6 +159,16 @@ def descending_years(end_year):
 
 
 def split_list(array, parts):
+    """
+    Split the elements in `array` into `parts` sub-arrays.
+
+    Mirrors the behavior of numpy.split_array, as implemented in numpy v1.26:
+    https://numpy.org/doc/1.26/reference/generated/numpy.array_split.html
+    """
+
+    if parts <= 0:
+        raise ValueError("parts must be larger than 0")
+
     N = len(array)
     part_size = N // parts
     remainder = N % parts  # number of parts that have an additional element
@@ -169,6 +179,10 @@ def split_list(array, parts):
         result.append(array[low:high])
         low = high
         remainder -= 1
+
+    if len(result) < parts:
+        result += (parts - len(result)) * [[]]
+
     return result
 
 

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -4,7 +4,6 @@ import datetime
 import calendar
 import logging
 import json
-import numpy
 from urllib.parse import parse_qs, urlencode
 
 # Packages
@@ -160,7 +159,17 @@ def descending_years(end_year):
 
 
 def split_list(array, parts):
-    return numpy.array_split(array, parts)
+    N = len(array)
+    part_size = N // parts
+    remainder = N % parts # number of parts that have an additional element
+    result = []
+    low = 0
+    while low < N:
+        high = low + part_size + (remainder > 0)
+        result.append(array[low:high])
+        low = high
+        remainder -= 1
+    return result
 
 
 def format_to_id(string):

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -162,7 +162,7 @@ def split_list(array, parts):
     """
     Split the elements in `array` into `parts` sub-arrays.
 
-    Mirrors the behavior of numpy.split_array, as implemented in numpy v1.26:
+    Mirrors the behavior of numpy.array_split, as implemented in numpy v1.26:
     https://numpy.org/doc/1.26/reference/generated/numpy.array_split.html
     """
 
@@ -181,7 +181,7 @@ def split_list(array, parts):
         remainder -= 1
 
     if len(result) < parts:
-        result += (parts - len(result)) * [[]]
+        result.extend([[] for _ in range(parts - len(result))])
 
     return result
 


### PR DESCRIPTION
## Done
- changed Pro pricing link in subnav a requested in [WD-38767](https://warthogs.atlassian.net/browse/WD-38767)
- rewrote `split_list` to remove numpy as a dependency, we don't need such a big library to split a list
  - it mirrors the behavior of `numpy.split_array` as implemented in v1.26 ([docs](https://numpy.org/doc/1.26/reference/generated/numpy.array_split.html))

## QA

- Open the [DEMO](https://ubuntu-com-16755.demos.haus//pro/devices)
- click on the "Pricing" link in the subnav
- you should land on https://ubuntu-com-16755.demos.haus//pricing/devices


- to QA the `split_list` changes open the "Products" dropdown in the meganav and compare to the one in production

## Issue / Card

Fixes [WD-38767](https://warthogs.atlassian.net/browse/WD-38767)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-38767]: https://warthogs.atlassian.net/browse/WD-38767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-38767]: https://warthogs.atlassian.net/browse/WD-38767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
