### PR TITLE
fix: exclude inactive engage pages

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -479,6 +479,13 @@ def build_engage_index(engage_docs):
                 limit, offset, key="is_static", value=None
             )
 
+        # Don't render pages marked as active=false
+        metadata = [
+            page
+            for page in metadata
+            if str(page.get("active", "")).strip().lower() != "false"
+        ]
+
         # Fixed so that engage page authors don't create random resource types
         resource_types = [
             "Blog",
@@ -559,6 +566,8 @@ def build_engage_page(engage_pages):
             path = f"/engage/{page}"
         metadata = engage_pages.get_engage_page(path)
         if not metadata:
+            flask.abort(404)
+        elif str(metadata.get("active", "")).strip().lower() == "false":
             flask.abort(404)
         else:
             related_pages_metadata = []


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Open the [DEMO](__DEMO_URL__)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-38869](https://warthogs.atlassian.net/browse/WD-38869)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-38869]: https://warthogs.atlassian.net/browse/WD-38869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ