### PR TITLE
WD-38869: Hide inactive engage articles unless previewing

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -126,49 +126,51 @@
       <div {% if total_pages > 1 %}class="p-section--shallow"{% endif %}>
         <div class="grid-row">
           {% for item in metadata %}
-            {%- set item_link = item.path -%}
-            {%- if item.active == 'false' and preview != None -%}
-              {%- set item_link = item_link ~ '?preview' -%}
+            {%- if item.active != 'false' or preview != None -%}
+              {%- set item_link = item.path -%}
+              {%- if item.active == 'false' and preview != None -%}
+                {%- set item_link = item_link ~ '?preview' -%}
+              {%- endif -%}
+              {%- if 'whitepaper' in item.type %}
+                {%- set type_icon = "topic" -%}
+              {%- elif 'webinar' in item.type -%}
+                {%- set type_icon = "video-play" -%}
+              {%- elif 'case study' in item.type -%}
+                {%- set type_icon = "units" -%}
+              {%- else -%}
+                {%- set type_icon = "topic" -%}
+              {%- endif -%}
+              {% if loop.index <= 2 and both_have_images %}
+                {{ vf_card(columns="4",
+                              link=item_link,
+                              heading=item.topic_name,
+                              image={
+                              "src": item.image,
+                              "alt": item.topic_name
+                              } if item.image else None,
+                              footer={
+                              "resource_type": {
+                              "icon": type_icon,
+                              "text": item.type
+                              },
+                              "content_type": item.tags.split(',') | map('trim') | list if item.tags else []
+                } if item.type or item.tags else None,
+                description=item.subtitle,
+                stacked_image=true) }}
+              {% else %}
+                {{ vf_card(columns="4",
+                              link=item_link,
+                              heading=item.topic_name,
+                              footer={
+                              "resource_type": {
+                              "icon": type_icon,
+                              "text": item.type
+                              },
+                              "content_type": item.tags.split(',') | map('trim') | list if item.tags else []
+                } if item.type or item.tags else None,
+                description=item.subtitle) }}
+              {% endif %}
             {%- endif -%}
-            {%- if 'whitepaper' in item.type %}
-              {%- set type_icon = "topic" -%}
-            {%- elif 'webinar' in item.type -%}
-              {%- set type_icon = "video-play" -%}
-            {%- elif 'case study' in item.type -%}
-              {%- set type_icon = "units" -%}
-            {%- else -%}
-              {%- set type_icon = "topic" -%}
-            {%- endif -%}
-            {% if loop.index <= 2 and both_have_images %}
-              {{ vf_card(columns="4",
-                            link=item_link,
-                            heading=item.topic_name,
-                            image={
-                            "src": item.image,
-                            "alt": item.topic_name
-                            } if item.image else None,
-                            footer={
-                            "resource_type": {
-                            "icon": type_icon,
-                            "text": item.type
-                            },
-                            "content_type": item.tags.split(',') | map('trim') | list if item.tags else []
-              } if item.type or item.tags else None,
-              description=item.subtitle,
-              stacked_image=true) }}
-            {% else %}
-              {{ vf_card(columns="4",
-                            link=item_link,
-                            heading=item.topic_name,
-                            footer={
-                            "resource_type": {
-                            "icon": type_icon,
-                            "text": item.type
-                            },
-                            "content_type": item.tags.split(',') | map('trim') | list if item.tags else []
-              } if item.type or item.tags else None,
-              description=item.subtitle) }}
-            {% endif %}
           {% endfor %}
         </div>
       </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -479,6 +479,15 @@ def build_engage_index(engage_docs):
                 limit, offset, key="is_static", value=None
             )
 
+        # Only show active items, unless previewing
+        if preview is None:
+            metadata = [
+                item
+                for item in metadata
+                if str(item.get("active", "")).strip().lower() == "true"
+            ]
+            current_total = active_count
+
         # Fixed so that engage page authors don't create random resource types
         resource_types = [
             "Blog",


### PR DESCRIPTION
## Done

- Filter out non active engage articles from rendering on engage index unless previewing

## QA

- Open the [DEMO](https://ubuntu-com-16771.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `task start`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [this page](https://ubuntu-com-16771.demos.haus/engage?resource=roadshow&page=2) on the demo and chceck that the inactive articles are not rendered unlike on the [live site](https://ubuntu.com/engage?resource=roadshow&page=2)
- Also check [this page](https://ubuntu-com-16771.demos.haus/engage?resource=roadshow&page=2&preview) on the demo and verify that the inactive articles are rendered when previewing

## Issue / Card

Fixes [WD-38869](https://warthogs.atlassian.net/browse/WD-38869)

[WD-38869]: https://warthogs.atlassian.net/browse/WD-38869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
